### PR TITLE
Rename mageia pubkey to RPM-GPG-KEY-Mageia

### DIFF
--- a/etc/mock/mageia-6-armv5tl.cfg
+++ b/etc/mock/mageia-6-armv5tl.cfg
@@ -30,7 +30,7 @@ name=Mageia $releasever - armv5tl
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -40,7 +40,7 @@ name=Mageia $releasever - armv5tl - Updates
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=updates
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -50,7 +50,7 @@ name=Mageia $releasever - armv5tl - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 
@@ -60,7 +60,7 @@ name=Mageia $releasever - armv5tl - Updates - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=updates&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-6-armv7hl.cfg
+++ b/etc/mock/mageia-6-armv7hl.cfg
@@ -30,7 +30,7 @@ name=Mageia $releasever - armv7hl
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -40,7 +40,7 @@ name=Mageia $releasever - armv7hl - Updates
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -50,7 +50,7 @@ name=Mageia $releasever - armv7hl - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 
@@ -60,7 +60,7 @@ name=Mageia $releasever - armv7hl - Updates - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-6-i586.cfg
+++ b/etc/mock/mageia-6-i586.cfg
@@ -30,7 +30,7 @@ name=Mageia $releasever - i586
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -40,7 +40,7 @@ name=Mageia $releasever - i586 - Updates
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -50,7 +50,7 @@ name=Mageia $releasever - i586 - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 
@@ -60,7 +60,7 @@ name=Mageia $releasever - i586 - Updates - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-6-x86_64.cfg
+++ b/etc/mock/mageia-6-x86_64.cfg
@@ -31,7 +31,7 @@ name=Mageia $releasever - x86_64
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -41,7 +41,7 @@ name=Mageia $releasever - x86_64 - Updates
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -51,7 +51,7 @@ name=Mageia $releasever - x86_64 - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 
@@ -61,7 +61,7 @@ name=Mageia $releasever - x86_64 - Updates - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-cauldron-armv5tl.cfg
+++ b/etc/mock/mageia-cauldron-armv5tl.cfg
@@ -30,7 +30,7 @@ name=Mageia Cauldron - armv5tl
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv5tl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv5tl&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -40,7 +40,7 @@ name=Mageia Cauldron - armv5tl - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv5tl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv5tl&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-cauldron-armv7hl.cfg
+++ b/etc/mock/mageia-cauldron-armv7hl.cfg
@@ -30,7 +30,7 @@ name=Mageia Cauldron - armv7hl
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv7hl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv7hl&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -40,7 +40,7 @@ name=Mageia Cauldron - armv7hl - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv7hl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv7hl&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-cauldron-i586.cfg
+++ b/etc/mock/mageia-cauldron-i586.cfg
@@ -30,7 +30,7 @@ name=Mageia Cauldron - i586
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=i586@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=i586&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -40,7 +40,7 @@ name=Mageia Cauldron - i586 - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=i586@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=i586&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 

--- a/etc/mock/mageia-cauldron-x86_64.cfg
+++ b/etc/mock/mageia-cauldron-x86_64.cfg
@@ -31,7 +31,7 @@ name=Mageia Cauldron - x86_64
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=x86_64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=x86_64&section=core&repo=release
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=1
 
@@ -41,7 +41,7 @@ name=Mageia Cauldron - x86_64 - Debug
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=x86_64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=x86_64&section=core&repo=release&debug=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/mageia/pubkey
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 failovermethod=priority
 enabled=0
 


### PR DESCRIPTION
This is consistent with the file name in mageia-repos-keys package and the one previously used.

This PR depends on xsuchy/distribution-gpg-keys#1