### PR TITLE
add config option `build_as_root`

### DIFF
--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -338,3 +338,7 @@
 # This is just a list of strings representing chroot paths such as:
 #  [ '/run/lock', ]
 # config_opts['extra_chroot_dirs'] = []
+#
+# Some legacy packages expect to be built as root
+# Setting this one to True will help here
+# config_opts['build_as_root'] = False

--- a/py/mockbuild/backend.py
+++ b/py/mockbuild/backend.py
@@ -474,10 +474,18 @@ class Commands(object):
             if not self.config['rpmbuild_networking']:
                 nspawn_args.append('--private-network')
             nspawn_args.extend(self.config['nspawn_args'])
+        if self.config['build_as_root']:
+            uid = 0
+            gid = 0
+            user = None
+        else:
+            uid = self.buildroot.chrootuid
+            gid = self.buildroot.chrootgid
+            user = self.buildroot.chrootuser
         self.buildroot.doChroot(command,
                                 shell=False, logger=self.buildroot.build_log, timeout=timeout,
-                                uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
-                                user=self.buildroot.chrootuser,
+                                uid=uid, gid=gid,
+                                user=user,
                                 nspawn_args=nspawn_args,
                                 printOutput=self.config['print_main_output'])
         bd_out = self.make_chroot_path(self.buildroot.builddir)

--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -186,17 +186,17 @@ class Buildroot(object):
         env = dict(self.env)
         if nosync and self.nosync_path:
             env['LD_PRELOAD'] = self.nosync_path
-        if util.USE_NSPAWN:
+        if util.USE_NSPAWN or kargs.get('uid', -1) == 0:
             if 'uid' not in kargs:
                 kargs['uid'] = uid.getresuid()[1]
             if 'gid' not in kargs:
                 kargs['gid'] = uid.getresgid()[1]
             if 'user' not in kargs:
-                kargs['gid'] = pwd.getpwuid(kargs['uid'])[0]
+                kargs['user'] = pwd.getpwuid(kargs['uid'])[0]
             self.uid_manager.becomeUser(0, 0)
         result = util.do(command, chrootPath=self.make_chroot_path(),
                          env=env, shell=shell, *args, **kargs)
-        if util.USE_NSPAWN:
+        if util.USE_NSPAWN or kargs.get('uid', -1) == 0:
             self.uid_manager.restorePrivs()
         return result
 

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -613,7 +613,8 @@ class ChildPreExec(object):
         condEnvironment(self.env)
         if not USE_NSPAWN:
             condChroot(self.chrootPath)
-            condDropPrivs(self.uid, self.gid)
+            if self.uid != 0:
+                condDropPrivs(self.uid, self.gid)
         condChdir(self.cwd)
         condUnshareIPC(self.unshare_ipc)
         reset_sigpipe()
@@ -919,6 +920,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     # security config
     config_opts['no_root_shells'] = False
     config_opts['extra_chroot_dirs'] = []
+    config_opts['build_as_root'] = False
 
     config_opts['package_manager'] = 'yum'
 


### PR DESCRIPTION
new config option that does not drop to unprivileged user at build time
helps to build some legacy packages that expect to run build tests as root
