### PR TITLE
add config option `hostname` to set hostname

### DIFF
--- a/py/mock.py
+++ b/py/mock.py
@@ -655,6 +655,9 @@ def main():
     # New namespace starting from here
     unshare_namespace()
 
+    if config_opts['hostname']:
+        util.sethostname(config_opts['hostname'])
+
     # set personality (ie. setarch)
     if config_opts['internal_setarch']:
         util.condPersonality(config_opts['target_arch'])

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -47,6 +47,8 @@ _libc.personality.argtypes = [ctypes.c_ulong]
 _libc.personality.restype = ctypes.c_int
 _libc.unshare.argtypes = [ctypes.c_int]
 _libc.unshare.restype = ctypes.c_int
+_libc.sethostname.argtypes = [ctypes.c_char_p, ctypes.c_int]
+_libc.sethostname.restype = ctypes.c_int
 
 # See linux/include/sched.h
 CLONE_NEWNS = 0x00020000
@@ -291,6 +293,13 @@ def unshare(flags):
             raise exception.UnshareFailed(os.strerror(ctypes.get_errno()))
     except AttributeError:
         pass
+
+
+def sethostname(hostname):
+    getLog().info("Setting hostname: %s", hostname)
+    hostname = hostname.encode('utf-8')
+    if _libc.sethostname(hostname, len(hostname)) != 0:
+        raise OSError('Failed to sethostname %s' % hostname)
 
 
 # these are called in child process, so no logging
@@ -871,6 +880,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         '%_topdir': '%s/build' % config_opts['chroothome'],
         '%_rpmfilename': '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm',
     }
+    config_opts['hostname'] = None
+
     # security config
     config_opts['no_root_shells'] = False
     config_opts['extra_chroot_dirs'] = []


### PR DESCRIPTION
adds ability to set a hostname for a build
hostname is a part of the resulting rpm in most of the cases
makes builds more reproducible
