### PR TITLE
Delay mounting of user-defined mountpoints (rhbz#1386544)

### DIFF
--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -130,7 +130,7 @@ class Buildroot(object):
             self._setup_devices()
         self._setup_files()
         self._setup_nosync()
-        self.mounts.mountall()
+        self.mounts.mountall_managed()
 
         # write out config details
         self.root_log.debug('rootdir = %s', self.make_chroot_path())
@@ -167,6 +167,9 @@ class Buildroot(object):
 
         # done with init
         self.plugins.call_hooks('postinit')
+
+        self.mounts.mountall_user()
+
         self.state.finish("chroot init")
 
     def doChroot(self, command, shell=False, nosync=False, *args, **kargs):

--- a/py/mockbuild/plugins/bind_mount.py
+++ b/py/mockbuild/plugins/bind_mount.py
@@ -28,12 +28,17 @@ class BindMount(object):
         self.config = buildroot.config
         self.state = buildroot.state
         self.bind_opts = conf
-        plugins.add_hook("preinit", self._bindMountPreInitHook)
+        plugins.add_hook("postinit", self._bindMountCreateDirs)
         for srcdir, destdir in self.bind_opts['dirs']:
-            buildroot.mounts.add(BindMountPoint(srcpath=srcdir, bindpath=buildroot.make_chroot_path(destdir)))
+            buildroot.mounts.add_user_mount(
+                BindMountPoint(
+                    srcpath=srcdir,
+                    bindpath=buildroot.make_chroot_path(destdir)
+                )
+            )
 
     @traceLog()
-    def _bindMountPreInitHook(self):
+    def _bindMountCreateDirs(self):
         create_dirs = self.config['plugin_conf']['bind_mount_opts']['create_dirs']
         for srcdir, destdir in self.bind_opts['dirs']:
             if create_dirs:

--- a/py/mockbuild/plugins/mount.py
+++ b/py/mockbuild/plugins/mount.py
@@ -41,15 +41,15 @@ class Mount(object):
         self.config = buildroot.config
         self.state = buildroot.state
         self.opts = conf
-        plugins.add_hook("preinit", self._mountPreInitHook)
+        plugins.add_hook("postinit", self._mountCreateDirs)
         for device, dest_dir, vfstype, mount_opts in self.opts['dirs']:
-            buildroot.mounts.add(
+            buildroot.mounts.add_user_mount(
                 FileSystemMountPoint(buildroot.make_chroot_path(dest_dir),
                                      filetype=vfstype,
                                      device=device,
                                      options=mount_opts))
 
     @traceLog()
-    def _mountPreInitHook(self):
+    def _mountCreateDirs(self):
         for device, dest_dir, vfstype, mount_opts in self.opts['dirs']:
             mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path(dest_dir))


### PR DESCRIPTION
Splits mounts into two categories:
- mock managed mountpoints, which are treated the same as before
- user managed mountpoints, which are mounted as the last initialization step
  (even after hooks), to make sure that they won't be affected by cleanup
  routines

bind_mount plugin and mount plugin now use user mounts, everything else uses
managed mounts
