### PR TITLE
macros: don't let host's %_install_langs affect guest chroots

### DIFF
--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -879,6 +879,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['macros'] = {
         '%_topdir': '%s/build' % config_opts['chroothome'],
         '%_rpmfilename': '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm',
+        '%_install_langs': 'all',
     }
     # security config
     config_opts['no_root_shells'] = False


### PR DESCRIPTION
Background story:  Fedora Cloud (and Docker) kickstarts put
basically only en_US.utf8 into %_install_langs, which then affects
mock's chroots -> the configuration is inherited from host's
config.

This affected Internal Copr builders which are built on top of
official Fedora Cloud images, but I believe this should be fixed
for everybody.