### PR TITLE
Add bash completion for .cfg files outside /etc/mock

### DIFF
--- a/etc/bash_completion.d/mock
+++ b/etc/bash_completion.d/mock
@@ -4,6 +4,7 @@ _mock_root()
 {
     COMPREPLY+=( $( compgen -W "$( command ls ${1:-/etc/mock} 2>/dev/null | \
         sed -ne 's/\.cfg$//p' )" -X site-defaults -- "$cur" ) )
+    COMPREPLY+=( $( compgen -f -o plusdirs -X '!*.cfg' -- "$cur" ) )
 }
 
 _mock()


### PR DESCRIPTION
The -r option accepts pathnames of files with .cfg extensions,
so make the bash completion also expand suitable files and
directories.