### PR TITLE
fix logic to remove all tmpdirs on mock exit

### DIFF
--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -494,7 +494,7 @@ class Buildroot(object):
     @traceLog()
     def _setup_nosync(self):
         multilib = ('x86_64', 's390x')
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = tempfile.mkdtemp(prefix="tmp.mock.")
         os.chmod(self.tmpdir, 0o777)
         tmp_libdir = os.path.join(self.tmpdir, '$LIB')
         mock_libdir = self.make_chroot_path(tmp_libdir)
@@ -532,7 +532,7 @@ class Buildroot(object):
         """
         Do the cleanup if this is the last process working with the buildroot.
         """
-        if os.path.exists(self.make_chroot_path()):
+        if not os.path.exists(self.make_chroot_path()):
             try:
                 if self.tmpdir:
                     for d in self.tmpdir, self.make_chroot_path(self.tmpdir):


### PR DESCRIPTION
Currently there appears extra one mock's dir in /tmp after every build.
```bash
$ ls -l /tmp
drwxrwxr-x. 3 builder builder 4096 nov 28 17:13 tito
drwx------. 2 root    root      20 nov 28 14:25 tmux-0

$ mock -r epel-7-x86_64 --resultdir RPMS/ acl-2.2.51-12.el7.src.rpm
...
Start: clean chroot
Finish: clean chroot
Finish: run

$ ls -l /tmp
drwxrwxr-x. 3 builder builder 4096 nov 28 17:13 tito
drwx------. 2 root    root      20 nov 28 14:25 tmux-0
drwxrwxrwx. 2 root    root    4096 nov 19 11:07 tmpzZkwvm
```

and it is because [this line](https://github.com/rpm-software-management/mock/blob/devel/py/mockbuild/buildroot.py#L535) is always false at the end (dir already removed). And it is also miss-sync with comments in code.