### PR TITLE
fix more_buildreq logic a bit

### DIFF
--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -279,7 +279,8 @@
 # config_opts['chroot_setup_cmd'] = 'install buildsys-build'
 # config_opts['chroot_additional_packages'] = ''
 # config_opts['log_config_file'] = 'logging.ini'
-# config_opts['more_buildreqs']['srpm_name-version-release'] = 'dependencies'
+# config_opts['more_buildreqs']['srpm_name-version-release'] = 'dependency'
+# config_opts['more_buildreqs']['srpm_name-version-release'] = ['dependency1', 'dependency2']
 # config_opts['macros']['%Add_your_macro_name_here'] = "add macro value here"
 # config_opts['files']['path/name/no/leading/slash'] = "put file contents here."
 # config_opts['chrootuid'] = os.getuid()

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -276,7 +276,7 @@ def getAddtlReqs(hdr, conf):
                       '-'.join([name])]:
         if this_srpm in conf:
             more_reqs = conf[this_srpm]
-            if isinstance(type(more_reqs), basestring):
+            if isinstance(more_reqs, basestring):
                 reqlist.append(more_reqs)
             else:
                 reqlist.extend(more_reqs)


### PR DESCRIPTION
Clarify docs-examples and fix logic in case of just one dependency.

`isinstance(type(more_reqs), basestring)` is always `False`
```python
>>> isinstance(type("test"), basestring)
False
```
So, if I have lines like `config_opts['more_buildreqs']['acl'] = 'ruby-devel'`, I will get
```bash
$ mock -r epel-7-x86_64 --resultdir RPMS/ acl-2.2.51-12.el7.src.rpm
...
Start: clean chroot
Finish: clean chroot
ERROR: Error: No packages found for:
  -
  b
  d
  e
  l
  r
  u
  v
  y
```
:D 

Also, it is not clear from site-defaults, how to use 2+ deps.