### PR TITLE
Fix local repo URLs in configs

### DIFF
--- a/etc/mock/epel-5-i386.cfg
+++ b/etc/mock/epel-5-i386.cfg
@@ -54,7 +54,7 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel5&arch=i
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/i386/
+baseurl=https://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/i386/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-5-ppc.cfg
+++ b/etc/mock/epel-5-ppc.cfg
@@ -54,7 +54,7 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel5&arch=p
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/ppc/
+baseurl=https://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/ppc/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-5-x86_64.cfg
+++ b/etc/mock/epel-5-x86_64.cfg
@@ -54,7 +54,7 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel5&arch=x
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/x86_64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/x86_64/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-6-i386.cfg
+++ b/etc/mock/epel-6-i386.cfg
@@ -53,7 +53,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/i386/
+baseurl=https://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/i386/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-6-ppc64.cfg
+++ b/etc/mock/epel-6-ppc64.cfg
@@ -50,7 +50,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/ppc64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/ppc64/
 cost=2000
 enabled=0
 """

--- a/etc/mock/epel-6-x86_64.cfg
+++ b/etc/mock/epel-6-x86_64.cfg
@@ -53,7 +53,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/x86_64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/x86_64/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-7-aarch64.cfg
+++ b/etc/mock/epel-7-aarch64.cfg
@@ -59,7 +59,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/epel7-build/latest/aarch64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel7-build/latest/aarch64/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-7-ppc64le.cfg
+++ b/etc/mock/epel-7-ppc64le.cfg
@@ -59,7 +59,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/epel7-build/latest/ppc64le/
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel7-build/latest/ppc64le/
 cost=2000
 enabled=0
 

--- a/etc/mock/epel-7-x86_64.cfg
+++ b/etc/mock/epel-7-x86_64.cfg
@@ -59,7 +59,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/epel7-build/latest/x86_64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel7-build/latest/x86_64/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-24-armhfp.cfg
+++ b/etc/mock/fedora-24-armhfp.cfg
@@ -48,7 +48,7 @@ enabled=0
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/f24-build/latest/armhfp/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f24-build/latest/armhfp/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-24-i386.cfg
+++ b/etc/mock/fedora-24-i386.cfg
@@ -48,7 +48,7 @@ enabled=0
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/f24-build/latest/i386/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f24-build/latest/i386/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-24-x86_64.cfg
+++ b/etc/mock/fedora-24-x86_64.cfg
@@ -48,7 +48,7 @@ enabled=0
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/f24-build/latest/x86_64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f24-build/latest/x86_64/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-25-armhfp.cfg
+++ b/etc/mock/fedora-25-armhfp.cfg
@@ -48,7 +48,7 @@ enabled=0
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/f25-build/latest/armhfp/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f25-build/latest/armhfp/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-25-i386.cfg
+++ b/etc/mock/fedora-25-i386.cfg
@@ -48,7 +48,7 @@ enabled=0
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/f25-build/latest/i386/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f25-build/latest/i386/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-25-x86_64.cfg
+++ b/etc/mock/fedora-25-x86_64.cfg
@@ -48,7 +48,7 @@ enabled=0
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/f25-build/latest/x86_64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f25-build/latest/x86_64/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-rawhide-aarch64.cfg
+++ b/etc/mock/fedora-rawhide-aarch64.cfg
@@ -32,7 +32,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://armpkgs.fedoraproject.org/repos/f26-build/latest/aarch64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/aarch64/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-rawhide-armhfp.cfg
+++ b/etc/mock/fedora-rawhide-armhfp.cfg
@@ -32,7 +32,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/rawhide/latest/armhfp/
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/armhfp/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-rawhide-i386.cfg
+++ b/etc/mock/fedora-rawhide-i386.cfg
@@ -32,7 +32,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/rawhide/latest/i386
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/i386
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-rawhide-ppc64.cfg
+++ b/etc/mock/fedora-rawhide-ppc64.cfg
@@ -32,7 +32,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://ppcpkgs.fedoraproject.org/repos/rawhide/latest/ppc64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/ppc64/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-rawhide-ppc64le.cfg
+++ b/etc/mock/fedora-rawhide-ppc64le.cfg
@@ -32,7 +32,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://ppcpkgs.fedoraproject.org/repos/rawhide/latest/ppc64le/
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/ppc64le/
 cost=2000
 enabled=0
 

--- a/etc/mock/fedora-rawhide-x86_64.cfg
+++ b/etc/mock/fedora-rawhide-x86_64.cfg
@@ -32,7 +32,7 @@ failovermethod=priority
 
 [local]
 name=local
-baseurl=http://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64/
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64/
 cost=2000
 enabled=0
 


### PR DESCRIPTION
- Update local repo URLs for rawhide - since Fedora 26, secondary architectures were merged into primary Koji.
- Switch kojipkgs URLs to https - since 12 Dec 2016 kojipkgs.fedoraproject.org has a valid TLS certificate, so there is no longer any reason not to use https.