### PR TITLE
Fix debuginfo repo naming

### DIFF
--- a/etc/mock/epel-5-i386.cfg
+++ b/etc/mock/epel-5-i386.cfg
@@ -41,7 +41,7 @@ gpgcheck=1
 name=groups
 baseurl=http://buildsys.fedoraproject.org/buildgroups/rhel5/i386/
 
-[extras]
+[epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=i386
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-5
@@ -58,7 +58,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/i386/
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=i386
 failovermethod=priority

--- a/etc/mock/epel-5-ppc.cfg
+++ b/etc/mock/epel-5-ppc.cfg
@@ -41,7 +41,7 @@ gpgcheck=1
 name=groups
 baseurl=http://buildsys.fedoraproject.org/buildgroups/rhel5/ppc/
 
-[extras]
+[epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=ppc
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-5
@@ -58,7 +58,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/ppc/
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=ppc
 failovermethod=priority

--- a/etc/mock/epel-5-x86_64.cfg
+++ b/etc/mock/epel-5-x86_64.cfg
@@ -41,7 +41,7 @@ gpgcheck=1
 name=groups
 baseurl=http://buildsys.fedoraproject.org/buildgroups/rhel5/x86_64/
 
-[extras]
+[epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=x86_64
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-5
@@ -58,7 +58,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/dist-5E-epel-build/latest/x86_6
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=x86_64
 failovermethod=priority

--- a/etc/mock/epel-6-i386.cfg
+++ b/etc/mock/epel-6-i386.cfg
@@ -57,8 +57,8 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/i386/
 cost=2000
 enabled=0
 
-[epel-debug]
-name=fedora-debug
+[epel-debuginfo]
+name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=i386
 failovermethod=priority
 enabled=0

--- a/etc/mock/epel-6-ppc64.cfg
+++ b/etc/mock/epel-6-ppc64.cfg
@@ -53,6 +53,12 @@ name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/ppc64/
 cost=2000
 enabled=0
+
+[epel-debuginfo]
+name=epel-debug
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=ppc64
+failovermethod=priority
+enabled=0
 """
 
 

--- a/etc/mock/epel-6-x86_64.cfg
+++ b/etc/mock/epel-6-x86_64.cfg
@@ -57,7 +57,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/dist-6E-epel-build/latest/x86_6
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=x86_64
 failovermethod=priority

--- a/etc/mock/epel-7-aarch64.cfg
+++ b/etc/mock/epel-7-aarch64.cfg
@@ -63,7 +63,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/epel7-build/latest/aarch64/
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=aarch64
 failovermethod=priority

--- a/etc/mock/epel-7-ppc64le.cfg
+++ b/etc/mock/epel-7-ppc64le.cfg
@@ -63,7 +63,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/epel7-build/latest/ppc64le/
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=ppc64le
 failovermethod=priority

--- a/etc/mock/epel-7-x86_64.cfg
+++ b/etc/mock/epel-7-x86_64.cfg
@@ -63,7 +63,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/epel7-build/latest/x86_64/
 cost=2000
 enabled=0
 
-[epel-debug]
+[epel-debuginfo]
 name=epel-debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=x86_64
 failovermethod=priority

--- a/etc/mock/fedora-rawhide-aarch64.cfg
+++ b/etc/mock/fedora-rawhide-aarch64.cfg
@@ -36,7 +36,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/aarch64/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - aarch64 - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-armhfp.cfg
+++ b/etc/mock/fedora-rawhide-armhfp.cfg
@@ -36,7 +36,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/armhfp/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - arm - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-i386.cfg
+++ b/etc/mock/fedora-rawhide-i386.cfg
@@ -36,7 +36,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/i386
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - i386 - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-ppc64.cfg
+++ b/etc/mock/fedora-rawhide-ppc64.cfg
@@ -36,7 +36,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/ppc64/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - ppc64 - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-ppc64le.cfg
+++ b/etc/mock/fedora-rawhide-ppc64le.cfg
@@ -36,7 +36,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/ppc64le/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - ppc64le - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-s390.cfg
+++ b/etc/mock/fedora-rawhide-s390.cfg
@@ -36,7 +36,7 @@ baseurl=http://s390pkgs.fedoraproject.org/repos/rawhide/latest/s390/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - s390 - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-s390x.cfg
+++ b/etc/mock/fedora-rawhide-s390x.cfg
@@ -36,7 +36,7 @@ baseurl=http://s390pkgs.fedoraproject.org/repos/rawhide/latest/s390x/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - s390x - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch

--- a/etc/mock/fedora-rawhide-x86_64.cfg
+++ b/etc/mock/fedora-rawhide-x86_64.cfg
@@ -36,7 +36,7 @@ baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64/
 cost=2000
 enabled=0
 
-[debug]
+[fedora-debuginfo]
 name=Fedora Rawhide - x86_64 - Debug
 failovermethod=priority
 metalink=https://mirrors.fedoraproject.org/metalink?repo=rawhide-debug&arch=$basearch


### PR DESCRIPTION
dnf debuginfo-install needs the debug repo to be named
${repo}-debuginfo, where ${repo} is the name of the main repo.
Otherwise, it doesn't find it.