### PR TITLE
systemd-nspawn: run as PID2

### DIFF
--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -631,7 +631,7 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=[], env=None, cwd
             raise exception.Error('Internal Error: command must be list or shell=True.')
     elif not cmd_is_list:
         cmd = [cmd]
-    nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-M', uuid.uuid4().hex, '-D', chrootPath]
+    nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-a', '-M', uuid.uuid4().hex, '-D', chrootPath]
     nspawn_argv.extend(nspawn_args)
     if cwd:
         nspawn_argv.append('--chdir={0}'.format(cwd))


### PR DESCRIPTION
Since we don't run systemd or any process which implements sysvinit
compatible signal handling (specifically: it needs to reboot on SIGINT,
reexecute on SIGTERM, reload configuration on SIGHUP, and so on) we
should use -a/--as-pid2 to run STUBINIT as PID1 and our process as PID2.

rpmbuild doesn't implement sysvinit compatible signal handling (e.g.
it doesn't kill child processes, so builds can stuck because of this).

Reported-by: Vít Ondruch <vondruch@redhat.com>
References: https://bugzilla.redhat.com/show_bug.cgi?id=1372234
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>