### PR TITLE
enable package_state plugin by default (again) [RHBZ#1277187]

### DIFF
--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -813,7 +813,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
             'keep_mounted': False},
         'selinux_enable': True,
         'selinux_opts': {},
-        'package_state_enable': False,
+        'package_state_enable': True,
         'package_state_opts': {
             'available_pkgs': False,
             'installed_pkgs': True,


### PR DESCRIPTION
since it wasn't fully enabled in 264597b8a17826362a839715fd7502cbee1ea9a0