### PR TITLE
fix defaults for yum_builddep_opts (it is list)

### DIFF
--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -299,8 +299,8 @@
 # config_opts['releasever'] = '20'
 # config_opts['yum_common_opts'] = []
 # config_opts['dnf_common_opts'] = ['--disableplugin=local', '--setopt=deltarpm=false']
-# config_opts['yum_builddep_opts'] = ''
-# config_opts['dnf_builddep_opts'] = ''
+# config_opts['yum_builddep_opts'] = []
+# config_opts['dnf_builddep_opts'] = []
 # config_opts['priorities.conf'] = 'put file contents here.'
 # config_opts['rhnplugin.conf'] = 'put file contents here.'
 # config_opts['subscription-manager.conf'] = 'put file contents here.'

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -880,7 +880,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['releasever'] = None
     config_opts['rpmbuild_arch'] = None  # <-- None means set automatically from target_arch
     config_opts['yum.conf'] = ''
-    config_opts['yum_builddep_opts'] = ''
+    config_opts['yum_builddep_opts'] = []
     config_opts['yum_common_opts'] = []
     config_opts['update_before_build'] = True
     config_opts['priorities.conf'] = '\n[main]\nenabled=0'


### PR DESCRIPTION
Since it is list, not string [everywhere](https://github.com/rpm-software-management/mock/blob/55ea53f5a1ebc84017f947a48326658b8df6ce3a/py/mockbuild/package_manager.py#L270).

I just added `config_opts['yum_builddep_opts'] = '--verbose'` and...
```
$ mock --resultdir acl -r epel-7-x86_64 acl-2.2.51-12.el7.src.rpm
...
Finish: creating root cache
Finish: chroot init
INFO: Installed packages:
Start: build phase for acl-2.2.51-12.el7.src.rpm
Start: build setup for acl-2.2.51-12.el7.src.rpm
warning: Could not canonicalize hostname: 3618f6f8c0bf49a9a47c250db521df79
Building target platforms: x86_64
Building for target x86_64
Wrote: /builddir/build/SRPMS/acl-2.2.51-12.el7.centos.src.rpm

Yum-utils package has been deprecated, use dnf instead.
See 'man yum2dnf' for more information.

No such package(s): b, e, -, o, s, r, v
ERROR: Exception(acl-2.2.51-12.el7.src.rpm) Config(epel-7-x86_64) 0 minutes 53 seconds
INFO: Results and/or logs in: acl
INFO: Cleaning up build root ('cleanup_on_failure=True')
Start: clean chroot
Finish: clean chroot
ERROR: Command failed:
 # /usr/bin/yum-builddep --installroot /var/lib/mock/epel-7-x86_64/root/ --releasever 7 - - v e r b o s e /var/lib/mock/epel-7-x86_64/root//builddir/build/SRP
MS/acl-2.2.51-12.el7.centos.src.rpm

Yum-utils package has been deprecated, use dnf instead.
See 'man yum2dnf' for more information.

No such package(s): b, e, -, o, s, r, v
```