### PR TITLE
add dist-git support into mock-scm

### DIFF
--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -254,6 +254,8 @@
 # config_opts['scm_opts']['cvs_get'] = 'cvs -d /srv/cvs co SCM_BRN SCM_PKG'
 # config_opts['scm_opts']['git_get'] = 'git clone SCM_BRN git://localhost/SCM_PKG.git SCM_PKG'
 # config_opts['scm_opts']['svn_get'] = 'svn co file:///srv/svn/SCM_PKG/SCM_BRN SCM_PKG'
+# config_opts['scm_opts']['distgit_get'] = 'rpkg clone -a --branch SCM_BRN SCM_PKG SCM_PKG'
+# config_opts['scm_opts']['distgit_src_get'] = 'rpkg sources
 # config_opts['scm_opts']['spec'] = 'SCM_PKG.spec'
 # config_opts['scm_opts']['ext_src_dir'] = '/dev/null'
 # config_opts['scm_opts']['write_tar'] = True

--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -255,7 +255,7 @@
 # config_opts['scm_opts']['git_get'] = 'git clone SCM_BRN git://localhost/SCM_PKG.git SCM_PKG'
 # config_opts['scm_opts']['svn_get'] = 'svn co file:///srv/svn/SCM_PKG/SCM_BRN SCM_PKG'
 # config_opts['scm_opts']['distgit_get'] = 'rpkg clone -a --branch SCM_BRN SCM_PKG SCM_PKG'
-# config_opts['scm_opts']['distgit_src_get'] = 'rpkg sources
+# config_opts['scm_opts']['distgit_src_get'] = 'rpkg sources'
 # config_opts['scm_opts']['spec'] = 'SCM_PKG.spec'
 # config_opts['scm_opts']['ext_src_dir'] = '/dev/null'
 # config_opts['scm_opts']['write_tar'] = True

--- a/py/mockbuild/scm.py
+++ b/py/mockbuild/scm.py
@@ -90,9 +90,21 @@ class scmWorker(object):
         self.wrk_dir = tempfile.mkdtemp(".mock-scm." + os.path.basename(self.pkg))
         self.src_dir = self.wrk_dir + "/" + os.path.basename(self.pkg)
         self.log.debug("SCM checkout directory: %s", self.wrk_dir)
-        util.do(shlex.split(self.get), shell=False, cwd=self.wrk_dir, env=os.environ)
+        try:
+            util.do(shlex.split(self.get), shell=False, cwd=self.wrk_dir, env=os.environ)
+        except PermissionError as e:
+            self.log.error("{} does not exist or cannot be executed due permissions."
+                           .format(shlex.split(self.get)[0]));
+            sys.exit(5)
+
         for command in self.postget:
-            util.do(shlex.split(command), shell=False, cwd=self.src_dir, env=os.environ)
+            try:
+                util.do(shlex.split(command), shell=False, cwd=self.src_dir, env=os.environ)
+            except PermissionError as e:
+                self.log.error("{} does not exist or cannot be executed due permissions."
+                               .format(shlex.split(command)[0]));
+                sys.exit(5)
+
         self.log.debug("Fetched sources from SCM")
 
     @traceLog()

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -869,7 +869,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         'cvs_get': 'cvs -d /srv/cvs co SCM_BRN SCM_PKG',
         'git_get': 'git clone SCM_BRN git://localhost/SCM_PKG.git SCM_PKG',
         'svn_get': 'svn co file:///srv/svn/SCM_PKG/SCM_BRN SCM_PKG',
-        'distgit_get': 'rpkg clone --branch SCM_BRN SCM_PKG SCM_PKG',
+        'distgit_get': 'rpkg clone -a --branch SCM_BRN SCM_PKG SCM_PKG',
         'distgit_src_get': 'rpkg sources',
         'spec': 'SCM_PKG.spec',
         'ext_src_dir': os.devnull,

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -869,6 +869,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         'cvs_get': 'cvs -d /srv/cvs co SCM_BRN SCM_PKG',
         'git_get': 'git clone SCM_BRN git://localhost/SCM_PKG.git SCM_PKG',
         'svn_get': 'svn co file:///srv/svn/SCM_PKG/SCM_BRN SCM_PKG',
+        'distgit_get': 'rpkg clone --branch SCM_BRN SCM_PKG SCM_PKG',
+        'distgit_src_get': 'rpkg sources',
         'spec': 'SCM_PKG.spec',
         'ext_src_dir': os.devnull,
         'write_tar': False,


### PR DESCRIPTION
This pull request implements support for building from a dist-git repo into the mock-scm plugin.

Example usage:

    mock -r fedora-25-x86_64 --scm-enable --scm-option method=distgit --scm-option package=prunerepo --scm-option distgit_get='rpkg clone prunerepo' --scm-option distgit_src_get='rpkg sources'

Example config:

    config_opts['scm'] = True
    config_opts['scm_opts']['method'] = 'distgit'
    config_opts['scm_opts']['distgit_get'] = 'rpkg clone prunerepo'
    config_opts['scm_opts']['distgit_src_get'] = 'rpkg sources'
    config_opts['scm_opts']['package'] = 'prunerepo'
    config_opts['scm_opts']['branch'] = 'master'