### PR TITLE
fix permissions in chroot_scan's result dir, so user can delete it

### DIFF
--- a/py/mockbuild/plugins/chroot_scan.py
+++ b/py/mockbuild/plugins/chroot_scan.py
@@ -68,3 +68,6 @@ class ChrootScan(object):
             logger.info("chroot_scan: %d files copied to %s", count, self.resultdir)
             logger.info("\n".join(copied))
             self.buildroot.uid_manager.changeOwner(self.resultdir, recursive=True)
+            # some packages installs 555 perms on dirs,
+            # so user can't delete/move chroot_scan's results
+            subprocess.call(['chmod', '-R', 'u+w', self.resultdir])


### PR DESCRIPTION
Some packages (filesystem) set 555 perms on /,
also, some dirs with needed data may be 555 only.
In such cases unprivUser can't delete/move resutls.

From #45