### PR TITLE
Bootstrap package manager using outer chroot

### DIFF
--- a/docs/mock.1
+++ b/docs/mock.1
@@ -331,6 +331,13 @@ Disable configure OPTION for build.  This option may be used multiple times.  Fo
 \fB\-\-yum\fR
 Use yum as the current package manager. This is the default.
 
+.TP
+\fB\-\-bootstrap-chroot\fR
+build in two stages, using chroot rpm for creating the build chroot
+.TP
+\fB\-\-no-bootstrap-chroot\fR
+build in a single stage, using system rpm for creating the build chroot
+
 .SH "FILES"
 .LP
 \fI/etc/mock/\fP \- default configuration directory

--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -103,6 +103,8 @@
 # the minimal chroot for the respective package manager
 # config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
 # config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
+# config_opts['system_yum_command'] = '/usr/bin/yum'
+# config_opts['system_dnf_command'] = '/usr/bin/dnf'
 
 # if you want mock to automatically run createrepo on the rpms in your
 # resultdir.

--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -92,6 +92,18 @@
 # By default a Yum/DNF update is performed before each rebuild
 # config_opts['update_before_build'] = True
 
+# If you want mock to bootstrap a chroot with
+# the target yum/dnf version in, before using
+# that chroot to make the actual build chroot, set this to True.
+# This is useful when the target may require newer RPM features
+# than are available on the host.
+# config_opts['use_bootstrap_container'] = True
+
+# when 'use_bootstrap_container' is True, these commands are used to build
+# the minimal chroot for the respective package manager
+# config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
+# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
+
 # if you want mock to automatically run createrepo on the rpms in your
 # resultdir.
 # config_opts['createrepo_on_rpms'] = False

--- a/py/mock.py
+++ b/py/mock.py
@@ -333,6 +333,11 @@ def command_parse():
                       dest="pkg_manager", action="store_const", const="yum")
     parser.add_option("--dnf", help="use dnf as package manager",
                       dest="pkg_manager", action="store_const", const="dnf")
+    
+    parser.add_option('--bootstrap-chroot', dest='bootstrapchroot', action='store_true',
+                        help="build in two stages, using chroot rpm for creating the build chroot")
+    parser.add_option('--no-bootstrap-chroot', dest='bootstrapchroot', action='store_false',
+                        help="build in a single stage, using system rpm for creating the build chroot")
 
     (options, args) = parser.parse_args()
 

--- a/py/mock.py
+++ b/py/mock.py
@@ -333,11 +333,11 @@ def command_parse():
                       dest="pkg_manager", action="store_const", const="yum")
     parser.add_option("--dnf", help="use dnf as package manager",
                       dest="pkg_manager", action="store_const", const="dnf")
-    
+
     parser.add_option('--bootstrap-chroot', dest='bootstrapchroot', action='store_true',
-                        help="build in two stages, using chroot rpm for creating the build chroot")
+                      help="build in two stages, using chroot rpm for creating the build chroot")
     parser.add_option('--no-bootstrap-chroot', dest='bootstrapchroot', action='store_false',
-                        help="build in a single stage, using system rpm for creating the build chroot")
+                      help="build in a single stage, using system rpm for creating the build chroot")
 
     (options, args) = parser.parse_args()
 
@@ -683,8 +683,13 @@ def main():
         # add '-minimal' to the end of the root name
         outer_buildroot_config['root'] = outer_buildroot_config['root'] + '-minimal'
         # share a yum cache to save downloading everything twice
-        outer_buildroot_config['plugin_conf']['yum_cache_opts']['dir'] = "%(cache_topdir)s/"+config_opts['root']+"/%(package_manager)s_cache/"
-        outer_buildroot = Buildroot(outer_buildroot_config, uidManager, outer_buildroot_state, outer_plugins)
+        outer_buildroot_config['plugin_conf']['yum_cache_opts']['dir'] = \
+            "%(cache_topdir)s/"+config_opts['root']+"/%(package_manager)s_cache/"
+        # allow outer buildroot to access the network for getting packages
+        outer_buildroot_config['rpmbuild_networking'] = True
+        outer_buildroot_config['use_host_resolv'] = True
+        outer_buildroot = Buildroot(outer_buildroot_config,
+                                    uidManager, outer_buildroot_state, outer_plugins)
         # this bit of config is needed after we have created the outer buildroot since we need to
         # query pkg_manager to know which manager is in use
         outer_buildroot_config['chroot_setup_cmd'] = outer_buildroot.pkg_manager.install_command

--- a/py/mockbuild/backend.py
+++ b/py/mockbuild/backend.py
@@ -10,10 +10,11 @@ import glob
 import os
 import shutil
 
+from mockbuild.mounts import BindMountPoint
+
 from . import util
 from .exception import PkgError
 from .trace_decorator import getLog, traceLog
-from mockbuild.mounts import BindMountPoint
 
 
 class Commands(object):
@@ -111,19 +112,23 @@ class Commands(object):
                         self.buildroot.root_log.info("scrubbing c-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'ccache'), selinux=self.buildroot.selinux)
                         if self.outer_buildroot is not None:
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'ccache'), selinux=self.outer_buildroot.selinux)
+                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'ccache'),
+                                        selinux=self.outer_buildroot.selinux)
                     elif scrub == 'root-cache':
                         self.buildroot.root_log.info("scrubbing root-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'root_cache'), selinux=self.buildroot.selinux)
                         if self.outer_buildroot is not None:
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'root_cache'), selinux=self.outer_buildroot.selinux)
+                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'root_cache'),
+                                        selinux=self.outer_buildroot.selinux)
                     elif scrub == 'yum-cache' or scrub == 'dnf-cache':
                         self.buildroot.root_log.info("scrubbing yum-cache and dnf-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'yum_cache'), selinux=self.buildroot.selinux)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'dnf_cache'), selinux=self.buildroot.selinux)
                         if self.outer_buildroot is not None:
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'yum_cache'), selinux=self.outer_buildroot.selinux)
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'dnf_cache'), selinux=self.outer_buildroot.selinux)
+                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'yum_cache'),
+                                        selinux=self.outer_buildroot.selinux)
+                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'dnf_cache'),
+                                        selinux=self.outer_buildroot.selinux)
             except IOError as e:
                 getLog().warning("parts of chroot do not exist: %s", e)
                 raise
@@ -145,7 +150,8 @@ class Commands(object):
                 inner_mount = self.outer_buildroot.make_chroot_path(self.buildroot.make_chroot_path())
                 util.mkdirIfAbsent(inner_mount)
                 util.mkdirIfAbsent(self.buildroot.make_chroot_path())
-                self.outer_buildroot.mounts.managed_mounts.append(BindMountPoint(self.buildroot.make_chroot_path(), inner_mount))
+                self.outer_buildroot.mounts.managed_mounts.append(
+                    BindMountPoint(self.buildroot.make_chroot_path(), inner_mount))
                 self.outer_buildroot.initialize(**kwargs)
             self.buildroot.initialize(**kwargs)
             if not self.buildroot.chroot_was_initialized:

--- a/py/mockbuild/backend.py
+++ b/py/mockbuild/backend.py
@@ -20,10 +20,10 @@ from .trace_decorator import getLog, traceLog
 class Commands(object):
     """Executes mock commands in the buildroot"""
     @traceLog()
-    def __init__(self, config, uid_manager, plugins, state, buildroot, outer_buildroot):
+    def __init__(self, config, uid_manager, plugins, state, buildroot, bootstrap_buildroot):
         self.uid_manager = uid_manager
         self.buildroot = buildroot
-        self.outer_buildroot = outer_buildroot
+        self.bootstrap_buildroot = bootstrap_buildroot
         self.state = state
         self.plugins = plugins
         self.config = config
@@ -76,8 +76,8 @@ class Commands(object):
             self.backup_results()
         self.state.start("clean chroot")
         self.buildroot.delete()
-        if self.outer_buildroot is not None:
-            self.outer_buildroot.delete()
+        if self.bootstrap_buildroot is not None:
+            self.bootstrap_buildroot.delete()
         self.state.finish("clean chroot")
 
     @traceLog()
@@ -95,40 +95,40 @@ class Commands(object):
                         self.buildroot.root_log.info("scrubbing everything for %s", self.config_name)
                         self.buildroot.delete()
                         util.rmtree(self.buildroot.cachedir, selinux=self.buildroot.selinux)
-                        if self.outer_buildroot is not None:
-                            self.outer_buildroot.delete()
-                            util.rmtree(self.outer_buildroot.cachedir, selinux=self.outer_buildroot.selinux)
+                        if self.bootstrap_buildroot is not None:
+                            self.bootstrap_buildroot.delete()
+                            util.rmtree(self.bootstrap_buildroot.cachedir, selinux=self.bootstrap_buildroot.selinux)
                     elif scrub == 'chroot':
                         self.buildroot.root_log.info("scrubbing chroot for %s", self.config_name)
                         self.buildroot.delete()
-                        if self.outer_buildroot is not None:
-                            self.outer_buildroot.delete()
+                        if self.bootstrap_buildroot is not None:
+                            self.bootstrap_buildroot.delete()
                     elif scrub == 'cache':
                         self.buildroot.root_log.info("scrubbing cache for %s", self.config_name)
                         util.rmtree(self.buildroot.cachedir, selinux=self.buildroot.selinux)
-                        if self.outer_buildroot is not None:
-                            util.rmtree(self.outer_buildroot.cachedir, selinux=self.outer_buildroot.selinux)
+                        if self.bootstrap_buildroot is not None:
+                            util.rmtree(self.bootstrap_buildroot.cachedir, selinux=self.bootstrap_buildroot.selinux)
                     elif scrub == 'c-cache':
                         self.buildroot.root_log.info("scrubbing c-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'ccache'), selinux=self.buildroot.selinux)
-                        if self.outer_buildroot is not None:
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'ccache'),
-                                        selinux=self.outer_buildroot.selinux)
+                        if self.bootstrap_buildroot is not None:
+                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'ccache'),
+                                        selinux=self.bootstrap_buildroot.selinux)
                     elif scrub == 'root-cache':
                         self.buildroot.root_log.info("scrubbing root-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'root_cache'), selinux=self.buildroot.selinux)
-                        if self.outer_buildroot is not None:
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'root_cache'),
-                                        selinux=self.outer_buildroot.selinux)
+                        if self.bootstrap_buildroot is not None:
+                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'root_cache'),
+                                        selinux=self.bootstrap_buildroot.selinux)
                     elif scrub == 'yum-cache' or scrub == 'dnf-cache':
                         self.buildroot.root_log.info("scrubbing yum-cache and dnf-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'yum_cache'), selinux=self.buildroot.selinux)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'dnf_cache'), selinux=self.buildroot.selinux)
-                        if self.outer_buildroot is not None:
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'yum_cache'),
-                                        selinux=self.outer_buildroot.selinux)
-                            util.rmtree(os.path.join(self.outer_buildroot.cachedir, 'dnf_cache'),
-                                        selinux=self.outer_buildroot.selinux)
+                        if self.bootstrap_buildroot is not None:
+                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'yum_cache'),
+                                        selinux=self.bootstrap_buildroot.selinux)
+                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'dnf_cache'),
+                                        selinux=self.bootstrap_buildroot.selinux)
             except IOError as e:
                 getLog().warning("parts of chroot do not exist: %s", e)
                 raise
@@ -145,14 +145,14 @@ class Commands(object):
     @traceLog()
     def init(self, **kwargs):
         try:
-            if self.outer_buildroot is not None:
+            if self.bootstrap_buildroot is not None:
                 # add the extra bind mount to the outer chroot
-                inner_mount = self.outer_buildroot.make_chroot_path(self.buildroot.make_chroot_path())
+                inner_mount = self.bootstrap_buildroot.make_chroot_path(self.buildroot.make_chroot_path())
                 util.mkdirIfAbsent(inner_mount)
                 util.mkdirIfAbsent(self.buildroot.make_chroot_path())
-                self.outer_buildroot.mounts.managed_mounts.append(
+                self.bootstrap_buildroot.mounts.managed_mounts.append(
                     BindMountPoint(self.buildroot.make_chroot_path(), inner_mount))
-                self.outer_buildroot.initialize(**kwargs)
+                self.bootstrap_buildroot.initialize(**kwargs)
             self.buildroot.initialize(**kwargs)
             if not self.buildroot.chroot_was_initialized:
                 self._show_installed_packages()

--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -23,12 +23,12 @@ from .trace_decorator import getLog, traceLog
 
 class Buildroot(object):
     @traceLog()
-    def __init__(self, config, uid_manager, state, plugins, outer_buildroot=None):
+    def __init__(self, config, uid_manager, state, plugins, bootstrap_buildroot=None):
         self.config = config
         self.uid_manager = uid_manager
         self.state = state
         self.plugins = plugins
-        self.outer_buildroot = outer_buildroot
+        self.bootstrap_buildroot = bootstrap_buildroot
         self.shared_root_name = config['root']
         if 'unique-ext' in config:
             config['root'] = "%s-%s" % (config['root'], config['unique-ext'])
@@ -58,7 +58,7 @@ class Buildroot(object):
         self.env.update(proxy_env)
         os.environ.update(proxy_env)
 
-        self.pkg_manager = package_manager(config, self, plugins, outer_buildroot)
+        self.pkg_manager = package_manager(config, self, plugins, bootstrap_buildroot)
         self.mounts = mounts.Mounts(self)
 
         self.root_log = getLog("mockbuild")

--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -23,11 +23,12 @@ from .trace_decorator import getLog, traceLog
 
 class Buildroot(object):
     @traceLog()
-    def __init__(self, config, uid_manager, state, plugins):
+    def __init__(self, config, uid_manager, state, plugins, outer_buildroot = None):
         self.config = config
         self.uid_manager = uid_manager
         self.state = state
         self.plugins = plugins
+        self.outer_buildroot = outer_buildroot
         self.shared_root_name = config['root']
         if 'unique-ext' in config:
             config['root'] = "%s-%s" % (config['root'], config['unique-ext'])
@@ -57,7 +58,7 @@ class Buildroot(object):
         self.env.update(proxy_env)
         os.environ.update(proxy_env)
 
-        self.pkg_manager = package_manager(config, self, plugins)
+        self.pkg_manager = package_manager(config, self, plugins, outer_buildroot)
         self.mounts = mounts.Mounts(self)
 
         self.root_log = getLog("mockbuild")

--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -23,7 +23,7 @@ from .trace_decorator import getLog, traceLog
 
 class Buildroot(object):
     @traceLog()
-    def __init__(self, config, uid_manager, state, plugins, outer_buildroot = None):
+    def __init__(self, config, uid_manager, state, plugins, outer_buildroot=None):
         self.config = config
         self.uid_manager = uid_manager
         self.state = state

--- a/py/mockbuild/package_manager.py
+++ b/py/mockbuild/package_manager.py
@@ -36,11 +36,11 @@ You can suppress this warning when you put
   config_opts['dnf_warning'] = False
 in Mock config.""")
                     input("Press Enter to continue.")
-                return Yum(config_opts, chroot, plugins)
+                return Yum(config_opts, chroot, plugins, outer_buildroot)
         # something else then EL, and no dnf_command exist
         # This will likely mean some error later.
         # Either user is smart or let him shot in his foot.
-        return Dnf(config_opts, chroot, plugins)
+        return Dnf(config_opts, chroot, plugins, outer_buildroot)
     else:
         # TODO specific exception type
         raise Exception('Unrecognized package manager')

--- a/py/mockbuild/plugin.py
+++ b/py/mockbuild/plugin.py
@@ -15,8 +15,8 @@ class Plugins(object):
         self.config = config
         self._hooks = {}
         self.state = state
-        
-        self.initted = False
+
+        self.already_initialized = False
 
         self.plugins = config['plugins']
         self.plugin_conf = config['plugin_conf']
@@ -24,9 +24,9 @@ class Plugins(object):
 
     @traceLog()
     def init_plugins(self, buildroot):
-        if self.initted:
+        if self.already_initialized:
             return
-        self.initted = True
+        self.already_initialized = True
         for key in list(self.plugin_conf.keys()):
             if key.endswith('_opts'):
                 self.plugin_conf[key]['basedir'] = buildroot.basedir

--- a/py/mockbuild/plugin.py
+++ b/py/mockbuild/plugin.py
@@ -15,6 +15,8 @@ class Plugins(object):
         self.config = config
         self._hooks = {}
         self.state = state
+        
+        self.initted = False
 
         self.plugins = config['plugins']
         self.plugin_conf = config['plugin_conf']
@@ -22,6 +24,9 @@ class Plugins(object):
 
     @traceLog()
     def init_plugins(self, buildroot):
+        if self.initted:
+            return
+        self.initted = True
         for key in list(self.plugin_conf.keys()):
             if key.endswith('_opts'):
                 self.plugin_conf[key]['basedir'] = buildroot.basedir

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -748,6 +748,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['rpmbuild_networking'] = False
     config_opts['nspawn_args'] = []
     config_opts['use_container_host_hostname'] = True
+    config_opts['use_bootstrap_container'] = True
 
     config_opts['internal_dev_setup'] = True
     config_opts['internal_setarch'] = True
@@ -913,11 +914,11 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
 
     # configurable commands executables
     config_opts['yum_command'] = '/usr/bin/yum'
-    if os.path.isfile('/usr/bin/yum-deprecated'):
-        config_opts['yum_command'] = '/usr/bin/yum-deprecated'
+    config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
 
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
     config_opts['dnf_command'] = '/usr/bin/dnf'
+    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
     config_opts['rpm_command'] = '/bin/rpm'
     config_opts['rpmbuild_command'] = '/usr/bin/rpmbuild'
 

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -983,6 +983,8 @@ def set_config_opts_per_cmdline(config_opts, options, args):
         config_opts['unique-ext'] = options.uniqueext
     if options.rpmbuild_timeout is not None:
         config_opts['rpmbuild_timeout'] = options.rpmbuild_timeout
+    if options.bootstrapchroot is not None:
+        config_opts['use_bootstrap_container'] = options.bootstrapchroot
 
     for i in options.disabled_plugins:
         if i not in config_opts['plugins']:

--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -914,10 +914,12 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
 
     # configurable commands executables
     config_opts['yum_command'] = '/usr/bin/yum'
+    config_opts['system_yum_command'] = '/usr/bin/yum'
     config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
 
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
     config_opts['dnf_command'] = '/usr/bin/dnf'
+    config_opts['system_dnf_command'] = '/usr/bin/dnf'
     config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
     config_opts['rpm_command'] = '/bin/rpm'
     config_opts['rpmbuild_command'] = '/usr/bin/rpmbuild'


### PR DESCRIPTION
This commit changes Mock so that it first builds
an outer chroot, then uses that chroot to build the main
chroot. This means the chroot is built with the version of
dnf or yum it contains, allowing the package being built to
use newer RPM/dnf features. This means the only packages
that need to be installable by the old rpm/yum/dnf are those
required in this minimal environment.

This is intended as an implementation of [RHBZ#1118719] - at least for the SIG-Rust case