### PR TITLE
Fix "init_install_output" error

### DIFF
--- a/py/mockbuild/buildroot.py
+++ b/py/mockbuild/buildroot.py
@@ -241,14 +241,14 @@ class Buildroot(object):
         if cmd:
             if isinstance(cmd, util.basestring):
                 cmd = cmd.split()
-            self.init_install_output = self.pkg_manager.execute(*cmd, returnOutput=1)
+            self.pkg_manager.init_install_output = self.pkg_manager.execute(*cmd, returnOutput=1)
 
         if 'chroot_additional_packages' in self.config and self.config['chroot_additional_packages']:
             cmd = self.config['chroot_additional_packages']
             if isinstance(cmd, util.basestring):
                 cmd = cmd.split()
             cmd = ['install'] + cmd
-            self.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
+            self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
 
         self.state.finish(update_state)
 


### PR DESCRIPTION
This error:

  AttributeError: 'Buildroot' object has no attribute 'init_install_output'

can occur because init_install_output is initialized in the pkg_manager object but not in the buildroot object.