### PR TITLE
backend.py: quote check_opt

### DIFF
--- a/py/mockbuild/backend.py
+++ b/py/mockbuild/backend.py
@@ -459,10 +459,7 @@ class Commands(object):
         if not check:
             # this is because EL5/6 does not know --nocheck
             # when EL5/6 targets are not supported, replace it with --nocheck
-            if util.USE_NSPAWN:
-                check_opt += ["--define", "__spec_check_template exit 0; "]
-            else:
-                check_opt += ["--define", "'__spec_check_template exit 0; '"]
+            check_opt += ["--define", "'__spec_check_template exit 0; '"]
 
         mode = ['-bb']
         sc = self.config.get('short_circuit')


### PR DESCRIPTION
Now that we always use `bash --login` (after 826c9d6), we have to always
quote the macro. Fixes the regression noted in
https://bugzilla.redhat.com/show_bug.cgi?id=1450516#c12.

---

Untested; though seems right by inspection.