### PR TITLE
Make LVM sleep time configurable

### DIFF
--- a/etc/mock/site-defaults.cfg
+++ b/etc/mock/site-defaults.cfg
@@ -220,6 +220,8 @@
 # config_opts['plugin_conf']['lvm_root_opts']['mkfs_args'] = []
 # Will be passed to -o option of mount when mounting the volume. String or None.
 # config_opts['plugin_conf']['lvm_root_opts']['mount_opts'] = None
+# How long to sleep when waiting for concurrent LVM initialization.
+# config_opts['plugin_conf']['lvm_root_opts']['sleep_time'] = 1
 
 ### pm_request plugin can install packages requested from within the buildroot
 # It is disabled by default, as it affects build reproducibility. It can be enabled


### PR DESCRIPTION
Let user configure mock to wait more patiently for LVM initialization.
`lvs' call can be quite expensive, especially when there are hundreds
of volumes and multiple parallel mocks waiting for common LVM
initialization to complete.

CC @msimacek