### PR TITLE
Add detection of OL (Oracle Linux) distribution

### DIFF
--- a/py/mockbuild/util.py
+++ b/py/mockbuild/util.py
@@ -646,7 +646,7 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None, c
         cmd = [cmd]
     nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-M', uuid.uuid4().hex, '-D', chrootPath]
     distro_label = distro.linux_distribution(full_distribution_name=False)[0]
-    if (distro_label != 'centos') and (distro_label != 'rhel'):
+    if (distro_label != 'centos') and (distro_label != 'ol') and (distro_label != 'rhel'):
         # EL7 does not support it (yet). See BZ 1417387
         nspawn_argv += ['-a']
     nspawn_argv.extend(nspawn_args)


### PR DESCRIPTION
On Oracle Linux EL7 platform, systemd-nspawn execution was was failing due to unsupported '-a' parameter being passed. This change adds detection for the 'ol' platform to implement the '-a' workaround for systemd-nspawn on Oracle Linux systems.