### PR TITLE
mageia-cauldron: Change releasever to 7

### DIFF
--- a/etc/mock/mageia-cauldron-armv5tl.cfg
+++ b/etc/mock/mageia-cauldron-armv5tl.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '6'
+config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/etc/mock/mageia-cauldron-armv7hl.cfg
+++ b/etc/mock/mageia-cauldron-armv7hl.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '6'
+config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/etc/mock/mageia-cauldron-i586.cfg
+++ b/etc/mock/mageia-cauldron-i586.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '6'
+config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/etc/mock/mageia-cauldron-x86_64.cfg
+++ b/etc/mock/mageia-cauldron-x86_64.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '6'
+config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 


### PR DESCRIPTION
Mageia 6 is released and branched from Cauldron now.