### PR TITLE
scm: define _sourcedir to checkout directory

### DIFF
--- a/py/mockbuild/scm.py
+++ b/py/mockbuild/scm.py
@@ -155,6 +155,8 @@ class scmWorker(object):
         # Dig out some basic information from the spec file
         self.sources = []
         ts = rpm.ts()
+        # Spec might %include its sources
+        rpm.addMacro("_sourcedir", self.src_dir)
         rpm_spec = ts.parseSpec(self.spec)
         self.name = rpm.expandMacro("%{name}")
         self.version = rpm.expandMacro("%{version}")


### PR DESCRIPTION
There are cases when people do %include %{SOURCE1}.

For example, grub2 package in Fedora has:
...
Source7:	grub.patches
...
%include %{SOURCE7}
...

In that case mock-scm fails with:
error: Unable to open /builddir/build/SOURCES/grub.patches: No such file or directory

Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>