### PR TITLE
new-chroot: set up new network namespace and add default route in it

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -56,11 +56,11 @@ class Commands(object):
         # do we allow interactive root shells?
         self.no_root_shells = config['no_root_shells']
 
+        self.private_network= not config['rpmbuild_networking']
+
     def _get_nspawn_args(self):
         nspawn_args = []
         if util.USE_NSPAWN:
-            if not self.config['rpmbuild_networking']:
-                nspawn_args.append('--private-network')
             nspawn_args.extend(self.config['nspawn_args'])
         return nspawn_args
 
@@ -313,6 +313,7 @@ class Commands(object):
             ret = util.doshell(chrootPath=self.buildroot.make_chroot_path(),
                                environ=self.buildroot.env, uid=uid, gid=gid,
                                nspawn_args=self._get_nspawn_args(),
+                               unshare_net=self.private_network,
                                cmd=cmd)
         finally:
             log.debug("shell: unmounting all filesystems")
@@ -340,10 +341,12 @@ class Commands(object):
                 self.buildroot.doChroot(args, shell=shell, printOutput=True,
                                         uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
                                         user=self.buildroot.chrootuser, cwd=options.cwd,
-                                        nspawn_args=self._get_nspawn_args())
+                                        nspawn_args=self._get_nspawn_args(),
+                                        unshare_net=self.private_network)
             else:
                 self.buildroot.doChroot(args, shell=shell, cwd=options.cwd,
                                         nspawn_args=self._get_nspawn_args(),
+                                        unshare_net=self.private_network,
                                         printOutput=True)
         finally:
             self.state.finish(chrootstate)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -38,6 +38,7 @@ import distro
 from . import exception
 from .trace_decorator import getLog, traceLog
 from .uid import getresuid, setresuid
+from pyroute2 import IPRoute
 
 encoding = locale.getpreferredencoding()
 
@@ -377,6 +378,24 @@ def condUnshareIPC(unshare_ipc=True):
             # fails, there had to be a warning already
             pass
 
+def condUnshareNet(unshare_net=True):
+    if USE_NSPAWN and unshare_net:
+        try:
+            unshare(CLONE_NEWNET)
+            # Set up loopback interface and add default route via loopback in the namespace.
+            # Missing default route may confuse some software, see
+            # https://github.com/rpm-software-management/mock/issues/113
+            ipr = IPRoute()
+            dev = ipr.link_lookup(ifname='lo')[0]
+
+            ipr.link('set', index=dev, state='up')
+            ipr.route("add", dst="default", gateway="127.0.0.1")
+        except exception.UnshareFailed:
+            # IPC and UTS ns are supported since the same kernel version. If this
+            # fails, there had to be a warning already
+            pass
+        except Exception as e:
+            getLog().warning("network namespace setup failed: %s", e)
 
 def process_input(line):
     out = []
@@ -516,7 +535,7 @@ def resize_pty(pty):
 # pylint: disable=unused-argument
 def do(command, shell=False, chrootPath=None, cwd=None, timeout=0, raiseExc=True,
        returnOutput=0, uid=None, gid=None, user=None, personality=None,
-       printOutput=False, env=None, pty=False, nspawn_args=None,
+       printOutput=False, env=None, pty=False, nspawn_args=None, unshare_net=False,
        *args, **kargs):
 
     logger = kargs.get("logger", getLog())
@@ -526,7 +545,7 @@ def do(command, shell=False, chrootPath=None, cwd=None, timeout=0, raiseExc=True
         master_pty, slave_pty = os.openpty()
         resize_pty(slave_pty)
         reader = os.fdopen(master_pty, 'rb')
-    preexec = ChildPreExec(personality, chrootPath, cwd, uid, gid, unshare_ipc=bool(chrootPath))
+    preexec = ChildPreExec(personality, chrootPath, cwd, uid, gid, unshare_ipc=bool(chrootPath), unshare_net=unshare_net)
     if env is None:
         env = clean_env()
     stdout = None
@@ -602,7 +621,7 @@ def do(command, shell=False, chrootPath=None, cwd=None, timeout=0, raiseExc=True
 
 class ChildPreExec(object):
     def __init__(self, personality, chrootPath, cwd, uid, gid, env=None,
-                 shell=False, unshare_ipc=False):
+                 shell=False, unshare_ipc=False, unshare_net=False):
         self.personality = personality
         self.chrootPath = chrootPath
         self.cwd = cwd
@@ -611,12 +630,14 @@ class ChildPreExec(object):
         self.env = env
         self.shell = shell
         self.unshare_ipc = unshare_ipc
+        self.unshare_net = unshare_net
         getLog().debug("child environment: %s", env)
 
     def __call__(self, *args, **kargs):
         if not self.shell:
             os.setsid()
         os.umask(0o02)
+        condUnshareNet(self.unshare_net)
         condPersonality(self.personality)
         condEnvironment(self.env)
         if not USE_NSPAWN:
@@ -675,7 +696,8 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None, c
 
 def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
             nspawn_args=None,
-            unshare_ipc=True):
+            unshare_ipc=True,
+            unshare_net=False):
     log = getLog()
     log.debug("doshell: chrootPath:%s, uid:%d, gid:%d", chrootPath, uid, gid)
     if environ is None:
@@ -698,7 +720,7 @@ def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
         cmd = _prepare_nspawn_command(chrootPath, uid, cmd, nspawn_args=nspawn_args, env=environ)
     preexec = ChildPreExec(personality=None, chrootPath=chrootPath, cwd=None,
                            uid=uid, gid=gid, env=environ, shell=True,
-                           unshare_ipc=unshare_ipc)
+                           unshare_ipc=unshare_ipc, unshare_net=unshare_net)
     log.debug("doshell: command: %s", cmd)
     return subprocess.call(cmd, preexec_fn=preexec, env=environ, shell=False)
 


### PR DESCRIPTION
Some software excepts (implicitly or otherwise) that system always has
default route properly configured. For example, you can't bind() UDP
socket to all IP addresses and then join multicast group, w/o having
default route. This is what ruby test-suite does and fails due to
missing default route when building ruby with --new-chroot while network
access is disallowed.

rpmbuild_networking option allows you to configure whether mock should
set up build environment in way that it is possible to access
network. This option affects only mock commands spawned with
--new-chroot. Previously we added --private-network to nspawn command
when rpmbuild_networking was set to False. This commit introduces a
change in this regard. We never add --private-network to nspawn
arguments, instead we setup network namespace ourselves and we also add
default route pointing to loopback interface (only interface in the new
namespace). This should fix build ruby's build failure and provide more
"pleasant" build environment even when network access is disallowed.

Note that this commit introduces new dependency which is pyroute2. We
need pyroute2 in order to setup environment in new network namespace.

Fixes #113