### PR TITLE
use primary key for F-27+ on s390x

### DIFF
--- a/mock-core-configs/etc/mock/fedora-27-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-27-s390x.cfg
@@ -30,14 +30,14 @@ best=1
 name=fedora
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
 failovermethod=priority
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-27-secondary
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-27-primary
 gpgcheck=1
 
 [updates]
 name=updates
 metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
 failovermethod=priority
-gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-27-secondary
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-27-primary
 gpgcheck=1
 
 [updates-testing]


### PR DESCRIPTION
Starting with F-27 the s390x architecture is built in the primary koji instance
and thus using the primary signing key.