### PR TITLE
ccache: use different bind mount directory

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -160,7 +160,7 @@
 # config_opts['plugin_conf']['root_cache_opts']['compress_program'] = "pigz"
 # config_opts['plugin_conf']['root_cache_opts']['extension'] = ".gz"
 # config_opts['plugin_conf']['root_cache_opts']['exclude_dirs'] = ["./proc", "./sys", "./dev",
-#                                                                  "./tmp/ccache", "./var/cache/yum" ]
+#                                                                  "./var/tmp/ccache", "./var/cache/yum" ]
 # config_opts['plugin_conf']['hw_info_enable'] = True
 # config_opts['plugin_conf']['hw_info_opts'] = {}
 #

--- a/mock/py/mockbuild/plugins/ccache.py
+++ b/mock/py/mockbuild/plugins/ccache.py
@@ -36,7 +36,7 @@ class CCache(object):
         plugins.add_hook("prebuild", self._ccacheBuildHook)
         plugins.add_hook("preinit", self._ccachePreInitHook)
         buildroot.mounts.add(
-            BindMountPoint(srcpath=self.ccachePath, bindpath=buildroot.make_chroot_path("/tmp/ccache")))
+            BindMountPoint(srcpath=self.ccachePath, bindpath=buildroot.make_chroot_path("/var/tmp/ccache")))
 
     # =============
     # 'Private' API
@@ -53,11 +53,11 @@ class CCache(object):
     @traceLog()
     def _ccachePreInitHook(self):
         getLog().info("enabled ccache")
-        envupd = {"CCACHE_DIR": "/tmp/ccache", "CCACHE_UMASK": "002"}
+        envupd = {"CCACHE_DIR": "/var/tmp/ccache", "CCACHE_UMASK": "002"}
         if self.ccache_opts.get('compress') is not None:
             envupd["CCACHE_COMPRESS"] = str(self.ccache_opts['compress'])
         self.buildroot.env.update(envupd)
 
-        mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path('/tmp/ccache'))
+        mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path('/var/tmp/ccache'))
         mockbuild.util.mkdirIfAbsent(self.ccachePath)
         self.buildroot.uid_manager.changeOwner(self.ccachePath, recursive=True)


### PR DESCRIPTION
When using nspawn /tmp gets over-mounted with tmpfs. Let's use different
directory for our ccache bind mount.