### PR TITLE
Delete rootdir as well when calling clean

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -607,6 +607,8 @@ class Buildroot(object):
             subv = util.find_btrfs_in_chroot(self.mockdir, p)
             if subv:
                 util.do(["btrfs", "subv", "delete", "/" + subv])
+            if not self.rootdir.startswith(self.basedir):
+              util.rmtree(self.rootdir, selinux=self.selinux)
             util.rmtree(self.basedir, selinux=self.selinux)
         self.chroot_was_initialized = False
         self.plugins.call_hooks('postclean')


### PR DESCRIPTION
In case one overrides the rootdir option and the rootdir is located
outside of basedir, it was not cleaned up when calling --clean.

Fix this case by checking if the rootdir is outside basedir. If that
is the case, run an extra rmtree() on it.

Fixes #90