### PR TITLE
Not install additional packages and modules into bootstrap buildroot

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -701,6 +701,12 @@ def main():
         bootstrap_buildroot_config['yum_command'] = bootstrap_buildroot_config['system_yum_command']
         bootstrap_buildroot_config['dnf_command'] = bootstrap_buildroot_config['system_dnf_command']
 
+        # we don't need to install additional packages into the bootstrap buildroot
+        # since we care only about package manager in there
+        bootstrap_buildroot_config['chroot_additional_packages'] = []
+        bootstrap_buildroot_config['module_enable'] = []
+        bootstrap_buildroot_config['module_install'] = []
+
         bootstrap_buildroot = Buildroot(bootstrap_buildroot_config,
                                         uidManager, bootstrap_buildroot_state, bootstrap_plugins,
                                         is_bootstrap=True)


### PR DESCRIPTION
Currently, when the `use_bootstrap_container` option is set to `True`,
there are installed `chroot_additional_packages` also into the bootstrap buildroot.

Is there any use case, why anyone would need this? As I understand this, bootstrap container only serves for installing a package manager in there, so it can be used to installing packages in the final buildroot. For such case, I can't see any reason why any additional packages would need to be installed. Of course, it is _no problem_ when they are installed, but they don't have to.

There is a problem regarding modularity though. Let's have following use case.

1. Enable bootstrap container in the config
2. Allow modularity repositories
3. Allow repository for DNF with modularity features - [mhatina/DNF-Modules](https://copr.fedorainfracloud.org/coprs/mhatina/DNF-Modules)
4. Install this ^^ DNF into the bootstrap container
5. Install modules into the final buildroot with it

Is there any philosophical issue with this use case? I think, that it should be possible to do it. Problem is, that when you specify modules to install, mock attempts to install them also in the bootstrap container - and uses host's DNF for it.

    mock -r case1.cfg <package> 
    ...
    Warning: Group 'base-runtime:f26/buildroot' does not exist.
    Error: Nothing to do.
    ERROR: Exception(ed-1.14.1-4.fc26.src.rpm) Config(2766475-custom-1-x86_64) 5 minutes 26 seconds
    INFO: Results and/or logs in: /var/lib/mock/2766475-custom-1-x86_64/result
    ERROR: Command failed: 
     # /usr/bin/dnf --installroot /var/lib/mock/2766475-custom-1-x86_64-bootstrap/root/ --disableplugin=local --setopt=deltarpm=False install @base-runtime:f26/buildroot
    Last metadata expiration check: 0:00:00 ago on Tue 24 Oct 2017 01:28:15 AM CEST.
    Warning: Group 'base-runtime:f26/buildroot' does not exist.
    Error: Nothing to do.

and 

    mock -r case2.cfg <package>
    ...
    ERROR: Command failed: 
     # /usr/bin/dnf --installroot /var/lib/mock/2766476-custom-1-x86_64-bootstrap/root/ -y --disableplugin=local --setopt=deltarpm=False module enable base-runtime:f26
    Unable to detect release version (use '--releasever' to specify release version)
    No such command: module. Please use /usr/bin/dnf --help
    It could be a DNF plugin command, try: "dnf install 'dnf-command(module)'"

So I am proposing this PR which fixes the issue by not installing any additional stuff (packages or modules) into the bootstrap buildroot. Another way to fix it would be installing additional stuff into the bootstrap container by not using the host DNF, but the installed one. I just honestly don't know how would I do it, so I tried the easier approach first.

I am also attaching the config examples, so you can reproduce it. Github doesn't support .cfg file extensions, so I had to append .txt after it. Sorry for that.

[case1.cfg.txt](https://github.com/rpm-software-management/mock/files/1409094/case1.cfg.txt)
[case2.cfg.txt](https://github.com/rpm-software-management/mock/files/1409093/case2.cfg.txt)
