### PR TITLE
Add support for DeskOS

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -676,7 +676,7 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None, c
         cmd = [cmd]
     nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-M', uuid.uuid4().hex, '-D', chrootPath]
     distro_label = distro.linux_distribution(full_distribution_name=False)[0]
-    if (distro_label != 'centos') and (distro_label != 'ol') and (distro_label != 'rhel'):
+    if (distro_label != 'centos') and (distro_label != 'ol') and (distro_label != 'rhel') and (distro_label != 'deskos'):
         # EL7 does not support it (yet). See BZ 1417387
         nspawn_argv += ['-a']
     nspawn_argv.extend(nspawn_args)


### PR DESCRIPTION
DeskOS (http://deskosproject.org) uses mock to build packages.
We need to add this check, unless there is a generic way to test for an EL fork.