### PR TITLE
Enable chrootgroup as a config file option

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -52,7 +52,7 @@ class Buildroot(object):
         self.chrootuid = config['chrootuid']
         self.chrootuser = 'mockbuild'
         self.chrootgid = config['chrootgid']
-        self.chrootgroup = 'mock'
+        self.chrootgroup = config['chrootgroup']
         self.env = config['environment']
         self.env['HOME'] = self.homedir
         proxy_env = util.get_proxy_environment(config)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -781,6 +781,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     except KeyError:
         #  'mock' group doesn't exist, must set in config file
         pass
+    config_opts['chrootgroup'] = 'mock'
     config_opts['build_log_fmt_name'] = "unadorned"
     config_opts['root_log_fmt_name'] = "detailed"
     config_opts['state_log_fmt_name'] = "state"


### PR DESCRIPTION
Fix for #130

Change the previously hardcoded value for chrootgroup to be
a configuration file option which defaults to the previous
hardcoded value.

Signed-off-by: Mark D Horn <mark.d.horn@intel.com>