### PR TITLE
Strip trailing / from mountpath in ismounted()

### DIFF
--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -20,7 +20,7 @@ class MountPoint(object):
     @traceLog()
     def ismounted(self):
         with open('/proc/mounts') as f:
-            if self.mountpath in [x.split()[1] for x in f]:
+            if self.mountpath.rstrip('/') in [x.split()[1] for x in f]:
                 return True
         return False
 


### PR DESCRIPTION
Fixes an issue where a failed build can result in mountpoints left around causing subsequent builds to fail.

e.g. `/var/lib/mock/epel-7-x86_64/root/var/cache/yum`(`/`).
`ismounted()` currently returns `False` because the trailing slash does not appear in `/proc/mounts`

Removing the trailing slash from `config_opts['plugin_conf']['yum_cache_opts']['target_dir'] = "/var/cache/%(package_manager)s/"` also works around the issue.