### PR TITLE
Splitting stdout and stderr in build.log

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -478,7 +478,7 @@ def logOutput(fdout, fderr, logger, returnOutput=1, start=0, timeout=0, printOut
                         if line != '':
                             line = ansi_escape.sub('', line)
                             if fderr is s and not line.startswith('+ '):
-                                logger.debug("BUILDSTDERR: " + line)
+                                logger.debug("BUILDSTDERR: %s", line)
                             else:
                                 logger.debug(line)
                     for h in logger.handlers:


### PR DESCRIPTION
This is for #8. All stderr output lines are prefixed by 'BUILDSTDERR:'. Also, all lines started with '+' are skipped (rpm debug output)