### PR TITLE
Don't setup mounts in the bootstrap buildroot

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -685,15 +685,15 @@ def main():
     log.info("mock.py version %s starting (python version = %s)...",
              __VERSION__, py_version)
     state = State()
-    bootstrap_buildroot_state = State(bootstrap=True)
     plugins = Plugins(config_opts, state)
-    bootstrap_plugins = Plugins(config_opts, bootstrap_buildroot_state)
 
     # outer buildroot to bootstrap the installation - based on main config with some differences
     bootstrap_buildroot = None
     if config_opts['use_bootstrap_container']:
         # first take a copy of the config so we can make some modifications
         bootstrap_buildroot_config = config_opts.copy()
+        # copy plugins configuration so we get a separate deep copy
+        bootstrap_buildroot_config['plugin_conf'] = config_opts['plugin_conf'].copy()
         # add '-bootstrap' to the end of the root name
         bootstrap_buildroot_config['root'] = bootstrap_buildroot_config['root'] + '-bootstrap'
         # share a yum cache to save downloading everything twice
@@ -706,6 +706,8 @@ def main():
         bootstrap_buildroot_config['yum_command'] = bootstrap_buildroot_config['system_yum_command']
         bootstrap_buildroot_config['dnf_command'] = bootstrap_buildroot_config['system_dnf_command']
 
+        bootstrap_buildroot_state = State(bootstrap=True)
+        bootstrap_plugins = Plugins(bootstrap_buildroot_config, bootstrap_buildroot_state)
         bootstrap_buildroot = Buildroot(bootstrap_buildroot_config,
                                         uidManager, bootstrap_buildroot_state, bootstrap_plugins,
                                         is_bootstrap=True)

--- a/mock/py/mockbuild/plugins/bind_mount.py
+++ b/mock/py/mockbuild/plugins/bind_mount.py
@@ -29,6 +29,9 @@ class BindMount(object):
         self.config = buildroot.config
         self.state = buildroot.state
         self.bind_opts = conf
+        # Skip mounting user-specified mounts if we're in the boostrap chroot
+        if buildroot.is_bootstrap:
+            return
         plugins.add_hook("postinit", self._bindMountCreateDirs)
         for srcdir, destdir in self.bind_opts['dirs']:
             buildroot.mounts.add_user_mount(

--- a/mock/py/mockbuild/plugins/mount.py
+++ b/mock/py/mockbuild/plugins/mount.py
@@ -42,6 +42,9 @@ class Mount(object):
         self.config = buildroot.config
         self.state = buildroot.state
         self.opts = conf
+        # Skip mounting user-specified mounts if we're in the boostrap chroot
+        if buildroot.is_bootstrap:
+            return
         plugins.add_hook("postinit", self._mountCreateDirs)
         for device, dest_dir, vfstype, mount_opts in self.opts['dirs']:
             buildroot.mounts.add_user_mount(


### PR DESCRIPTION
Its supposed to be a minimal buildroot just for running the package
manager, so don't try to mount things into it.