### PR TITLE
Detect if essential mounts are already mounted

### DIFF
--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -121,7 +121,6 @@ class Mounts(object):
     @traceLog()
     def __init__(self, rootObj):
         self.rootObj = rootObj
-        self.essential_mounted = False
         self.essential_mounts = [] # /proc, /sys ... normally managed by systemd
         self.managed_mounts = []  # mounts owned by mock
         self.user_mounts = []  # mounts injected by user
@@ -152,6 +151,7 @@ class Mounts(object):
                         options=opts
                     )
                 )
+        self.essential_mounted = all(m.ismounted() for m in self.essential_mounts)
 
     @traceLog()
     def add(self, mount):


### PR DESCRIPTION
Previously, mock assumed that essential mounts are never mounted when
mock starts up. That's not true, as multiple non-destructive mock
processes are allowed (`--shell`, `--install`, etc.) to run
concurrently. So when you use `mock --shell` and do a `mock --install`
in parallel, it breaks your shell, because it unmounts its proc.
This improves the situation by first asking whether the mounts aren't
there already.