### PR TITLE
site-defaults: fix quoting in sign_opts example [RHBZ#1537797]

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -244,7 +244,7 @@ config_opts['bootstrap_module_install'] = []
 # config_opts['plugin_conf']['sign_opts']['cmd'] = 'rpmsign'
 # The options to pass to the signing command. %(rpms)s will be expanded to
 # the rpms in the results folder.
-# config_opts['plugin_conf']['sign_opts']['opts'] = '--addsign %(rpms)s -D "%%_gpg_name your_name" -D "%%_gpg_path /home/your_name/.gnupg'
+# config_opts['plugin_conf']['sign_opts']['opts'] = '--addsign %(rpms)s -D "%%_gpg_name your_name" -D "%%_gpg_path /home/your_name/.gnupg"'
 
 #############################################################################
 #


### PR DESCRIPTION
The example added for config_opts['plugin_conf']['sign_opts']['opts'] in
3c2de6a ("Add a plugin that calls command (from the host) on the
produced rpms.", 2015-04-17) was missing a trailing quote in the
_gpg_path definition.  Users who failed to notice this when uncommenting
the option receive an error when building packages:

    Unexpected EOF missing '"'

Reported-by: Phil Wyett <philwyett@kathenas.org>
Signed-off-by: Todd Zullinger <tmz@pobox.com>

https://bugzilla.redhat.com/show_bug.cgi?id=1537797