### PR TITLE
Honor the "cwd" flag when nspawn is being used and "chrootPath" is not

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -648,7 +648,9 @@ class ChildPreExec(object):
         condUnshareNet(self.unshare_net)
         condPersonality(self.personality)
         condEnvironment(self.env)
-        if not USE_NSPAWN:
+        # Even if nspawn is allowed to be used, it won't be used unless there
+        # is a chrootPath set
+        if not USE_NSPAWN or not self.chrootPath:
             condChroot(self.chrootPath)
             condDropPrivs(self.uid, self.gid)
             condChdir(self.cwd)


### PR DESCRIPTION
After commit https://github.com/rpm-software-management/mock/commit/a40567a635ad3a76f480198a499931eab6aabbdd mock-scm would clone the sources in the current directory instead of in the temp directory it was expecting. This is because nspawn is not used when `chrootPath` evaluates to false (even when `USE_NSPAWN` is true) and `ChildPreExec.__call__` only checks to see if `USE_NSPAWN` is set before running `condChdir(self.cwd)`.

This PR addresses this issue.