### PR TITLE
mock-core-configs: add CentOS SCL repositories to EPEL 6 & 7 (x86_64)

### DIFF
--- a/mock-core-configs/etc/mock/epel-6-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-x86_64.cfg
@@ -49,6 +49,22 @@ gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-6
 gpgcheck=1
 skip_if_unavailable=False
 
+[sclo]
+name=sclo
+baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/sclo/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/centos/6/sclo/x86_64/rh/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
 [testing]
 name=epel-testing
 enabled=0

--- a/mock-core-configs/etc/mock/epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-x86_64.cfg
@@ -54,6 +54,22 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
 gpgcheck=1
 skip_if_unavailable=False
 
+[sclo]
+name=sclo
+baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/sclo/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
 [testing]
 name=epel-testing
 enabled=0


### PR DESCRIPTION
EPEL now allows packages to use 'devtoolset*' packages from the SCLo and
SCLo-rh repositories as BuildRequires.  Restrict the package list from
the SCLo repositories to 'devtoolset*' with the includepkgs option.

These repositories are currently only available for x86_64.  aarch64 and
ppc64le are in testing now in CentOS¹.

¹ https://bugs.centos.org/view.php?id=14078