### PR TITLE
invoke chroot scan for 'initfailed' event

### DIFF
--- a/mock/py/mockbuild/plugins/chroot_scan.py
+++ b/mock/py/mockbuild/plugins/chroot_scan.py
@@ -34,6 +34,7 @@ class ChrootScan(object):
         self.scan_opts = conf
         self.resultdir = os.path.join(buildroot.resultdir, "chroot_scan")
         plugins.add_hook("postbuild", self._scanChroot)
+        plugins.add_hook("initfailed", self._scanChroot)
         getLog().info("chroot_scan: initialized")
 
     def _only_failed(self):


### PR DESCRIPTION
Calling this plugin for 'initfailed' event is useful e.g. when one wants to collect dnf logs in case repo sync failure when buildroot is being initialized.