### PR TITLE
mock/tests/functions: fixed runcmd function

### DIFF
--- a/mock/tests/functions
+++ b/mock/tests/functions
@@ -10,7 +10,8 @@ header() {
 
 runcmd() {
     echo $1
-    ret=time sh -c "$1"
+    time sh -c "$1"
+    ret=$?
     return $ret
 }
 


### PR DESCRIPTION
As I have been adding test (my other pull request), I have noticed, there is a bug in runcmd function in mock/tests/functions file [1]. It currently runs sh with 'ret' env. variable set to 'time'. Then variable 'ret' is  not set, when next line (with return) is executed.  Also time command is not ran and bug causes test to fail when using: set -u.

I have made a change to make it work in a way as was (probably) originaly intended.