### PR TITLE
add binding in config file for file

### DIFF
--- a/mock/py/mockbuild/plugins/bind_mount.py
+++ b/mock/py/mockbuild/plugins/bind_mount.py
@@ -7,7 +7,8 @@
 # python library imports
 
 # our imports
-import os
+
+import os.path
 from mockbuild.mounts import BindMountPoint
 from mockbuild.trace_decorator import traceLog
 import mockbuild.util
@@ -49,4 +50,4 @@ class BindMount(object):
                 mockbuild.util.mkdirIfAbsent(srcdir)
                 mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path(destdir))
             else:
-                mockbuild.util.do(['/usr/bin/touch', self.buildroot.make_chroot_path(destdir)])
+                mockbuild.util.touch(self.buildroot.make_chroot_path(destdir))

--- a/mock/py/mockbuild/plugins/bind_mount.py
+++ b/mock/py/mockbuild/plugins/bind_mount.py
@@ -7,6 +7,7 @@
 # python library imports
 
 # our imports
+import os
 from mockbuild.mounts import BindMountPoint
 from mockbuild.trace_decorator import traceLog
 import mockbuild.util
@@ -43,8 +44,9 @@ class BindMount(object):
 
     @traceLog()
     def _bindMountCreateDirs(self):
-        create_dirs = self.config['plugin_conf']['bind_mount_opts']['create_dirs']
         for srcdir, destdir in self.bind_opts['dirs']:
-            if create_dirs:
+            if os.path.isdir(srcdir):
                 mockbuild.util.mkdirIfAbsent(srcdir)
-            mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path(destdir))
+                mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path(destdir))
+            else:
+                mockbuild.util.do(['/usr/bin/touch', self.buildroot.make_chroot_path(destdir)])


### PR DESCRIPTION
If you did wanted to create file in your mount it crashed. This creates empty file where will be copied that file.