### PR TITLE
mock-core-configs: add CentOS SCL repositories to EPEL 7 (aarch64 & p…

### DIFF
--- a/mock-core-configs/etc/mock/epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-aarch64.cfg
@@ -54,6 +54,14 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:
 gpgcheck=1
 skip_if_unavailable=False
 
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/altarch/7/sclo/aarch64/rh/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
 [testing]
 name=epel-testing
 enabled=0

--- a/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
@@ -54,6 +54,14 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:
 gpgcheck=1
 skip_if_unavailable=False
 
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/altarch/7/sclo/ppc64le/rh/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
 [testing]
 name=epel-testing
 enabled=0


### PR DESCRIPTION
…pc64le)

Support for x86_64 was added in 684bda7 ("mock-core-configs: add CentOS
SCL repositories to EPEL 6 & 7 (x86_64)", 2018-01-27).

There is currently no support in EPEL's koji for SCL/devtoolset on EL6.
Nor is there support for SCL/devtoolset on aarch64 or ppc64le.