### PR TITLE
overlayfs plugin: added explicit mount support

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -122,7 +122,7 @@ Current base snapshot is marked with an asterisk (\fB*\fR)
 .TP
 \fB\-\-mount\fP
 Mount all everything mounted in the chroot path including the root itself
-that might have been an LVM volume or TMPFS.
+that might have been an LVM volume, TMPFS or overlayfs.
 .TP
 \fB\-\-orphanskill\fP
 No\-op mode that simply checks that no stray processes are running in the chroot. Kills any processes that it finds using the specified root.
@@ -180,7 +180,7 @@ This feature is available only when the lvm_root or overlayfs plugin is installe
 .TP
 \fB\-\-umount\fP
 Umount all everything mounted in the chroot path including the root itself
-that might have been an LVM volume or TMPFS.
+that might have been an LVM volume, TMPFS or overalyfs.
 .TP
 \fB\-\-yum\-cmd\fP
 Execute following arguments with YUM with installroot set to the chroot path. Yum must be installed on the system.

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -192,10 +192,10 @@ def command_parse():
 
     parser.add_option("--umount", action="store_const", const="umount",
                       dest="mode", help="Umount the buildroot if it's "
-                      "mounted from separate device (LVM)")
+                      "mounted from separate device (LVM/overlayfs)")
     parser.add_option("--mount", action="store_const", const="mount",
                       dest="mode", help="Mount the buildroot if it's "
-                      "mounted from separate device (LVM)")
+                      "mounted from separate device (LVM/overlayfs)")
 
     # options
     parser.add_option("-r", "--root", action="store", type="string", dest="chroot",


### PR DESCRIPTION
This PR allows to explicitly mount buildroot, when using overlayfs plugin. So that mock --mount works. (Buildroot remains mounted, after --mount command finishes.) With this done, I also documented behaviour of plugin, with regard to concurrency/locking.

After considering several options, I decided to make explicit mount exclusive. That is, not to allow issue other mock commands, while buildroot is explicitly mounted by: mock --mount, until mock --umount is issued. ( Note: mount is considered explicit, if call to mount_root hook is not followed by postinit hook call. )

Expected usage of --mount command (when using overlayfs plugin) is as following:
`# mock commands... ( --init, --shell, --install, --snapshot etc. )`
`mock --mount`
`# only manual access to buildroot is expected here,`
`# mock commands (for the same mock config) are not allowed here`
`mock --umount`
`# mock commands  (for the same mock config) are allowed once again...`
