### PR TITLE
Add initial openSUSE distribution targets

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
@@ -1,0 +1,45 @@
+config_opts['root'] = 'opensuse-leap-15.0-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'suse.lp150'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '15.0'
+config_opts['macros']['%dist'] = '.suse.lp150'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+excludepkgs=*.i586,*.i686
+
+# repos
+
+[opensuse-leap-oss]
+name=openSUSE Leap $releasever - x86_64 - OSS
+#baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+[updates-oss]
+name=openSUSE Leap $releasever - x86_64 - Updates - OSS
+#baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
+metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
@@ -1,0 +1,37 @@
+config_opts['root'] = 'opensuse-tumbleweed-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '0'
+config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+# repos
+
+[opensuse-tumbleweed-oss]
+name=openSUSE Tumbleweed - aarch64 - OSS
+#baseurl=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/
+metalink=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
@@ -1,0 +1,39 @@
+config_opts['root'] = 'opensuse-tumbleweed-i586'
+config_opts['target_arch'] = 'i586'
+config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '0'
+config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+excludepkgs=*.x86_64
+
+
+# repos
+
+[opensuse-tumbleweed-oss]
+name=openSUSE Tumbleweed - i586 - OSS
+#baseurl=http://download.opensuse.org/tumbleweed/repo/oss/
+metalink=http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
@@ -1,0 +1,38 @@
+config_opts['root'] = 'opensuse-tumbleweed-ppc64'
+config_opts['target_arch'] = 'ppc64'
+config_opts['legal_host_arches'] = ('ppc64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '0'
+config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+excludepkgs=*.ppc,*.ppc64le
+
+# repos
+
+[opensuse-tumbleweed-oss]
+name=openSUSE Tumbleweed - ppc64 - OSS
+#baseurl=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
+metalink=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
@@ -1,0 +1,38 @@
+config_opts['root'] = 'opensuse-tumbleweed-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '0'
+config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+excludepkgs=*.ppc,*.ppc64
+
+# repos
+
+[opensuse-tumbleweed-oss]
+name=openSUSE Tumbleweed - ppc64le - OSS
+#baseurl=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
+metalink=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
@@ -1,0 +1,38 @@
+config_opts['root'] = 'opensuse-tumbleweed-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '0'
+config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+excludepkgs=*.i586,*.i686
+
+# repos
+
+[opensuse-tumbleweed-oss]
+name=openSUSE Tumbleweed - x86_64 - OSS
+#baseurl=http://download.opensuse.org/tumbleweed/repo/oss/
+metalink=http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""


### PR DESCRIPTION
This PR adds initial targets for building for openSUSE Leap 15.0 and Tumbleweed.

This depends on https://github.com/xsuchy/distribution-gpg-keys/pull/13