### PR TITLE
call 'gtar' binary, instead of 'tar'

### DIFF
--- a/mock/py/mockbuild/plugins/root_cache.py
+++ b/mock/py/mockbuild/plugins/root_cache.py
@@ -124,7 +124,7 @@ class RootCache(object):
                     os.chdir(mockbuild.util.find_non_nfs_dir())
                 mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path())
                 mockbuild.util.do(
-                    ["tar"] + self.compressArgs + ["-xf", self.rootCacheFile, "-C", self.buildroot.make_chroot_path()],
+                    ["gtar"] + self.compressArgs + ["-xf", self.rootCacheFile, "-C", self.buildroot.make_chroot_path()],
                     shell=False, printOutput=True
                 )
                 for item in self.exclude_dirs:
@@ -184,7 +184,7 @@ class RootCache(object):
                 self.state.start("creating root cache")
                 try:
                     mockbuild.util.do(
-                        ["tar", "--one-file-system", "--exclude-caches", "--exclude-caches-under"] +
+                        ["gtar", "--one-file-system", "--exclude-caches", "--exclude-caches-under"] +
                         self.compressArgs +
                         ["-cf", self.rootCacheFile,
                          "-C", self.buildroot.make_chroot_path()] +

--- a/mock/py/mockbuild/scm.py
+++ b/mock/py/mockbuild/scm.py
@@ -192,7 +192,7 @@ class scmWorker(object):
             cwd_dir = os.getcwd()
             os.chdir(self.wrk_dir)
             os.rename(self.name, tardir)
-            cmd = "tar caf " + tarball + " " + taropts + " " + tardir
+            cmd = "gtar caf " + tarball + " " + taropts + " " + tardir
             util.do(shlex.split(cmd), shell=False, cwd=self.wrk_dir, env=os.environ)
             os.rename(tarball, tardir + "/" + tarball)
             os.rename(tardir, self.name)


### PR DESCRIPTION
This helps OpenMandriva where /bin/tar is equivalent for
/bin/bsdtar .  That setup is somewhat unexpected on GNU/Linux
distro, but anyway, it doesn't hurt Fedora/RHEL/CentOS where we
symlink gtar to tar.

As original issue suggests, we could implement everything using
the POSIX tar options (+ helper scripting); but that would be just
too much work which is not worth spending ATM, at least as long as
it is safe to expect that 'gtar' is in PATH and that it really is
GNU tar.

Resolves: #169