### PR TITLE
allow bind-mounts in bootstrap for local repos

### DIFF
--- a/mock/py/mockbuild/plugins/bind_mount.py
+++ b/mock/py/mockbuild/plugins/bind_mount.py
@@ -32,7 +32,8 @@ class BindMount(object):
         self.state = buildroot.state
         self.bind_opts = conf
         # Skip mounting user-specified mounts if we're in the boostrap chroot
-        if buildroot.is_bootstrap:
+        skip_bootstrap = self.config['plugin_conf']['bind_mount_opts']['skip_bootstrap']
+        if skip_bootstrap and buildroot.is_bootstrap:
             return
         plugins.add_hook("postinit", self._bindMountCreateDirs)
         for srcdir, destdir in self.bind_opts['dirs']:

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -852,7 +852,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
                 # ('/host/path', '/bind/mount/path/in/chroot/' ),
                 # ('/another/host/path', '/another/bind/mount/path/in/chroot/'),
             ],
-            'create_dirs': False},
+            'create_dirs': False,
+            'skip_bootstrap': True},
         'mount_enable': True,
         'mount_opts': {'dirs': [
             # specify like this:


### PR DESCRIPTION
Don't know if there is a more elegant way to allow local repos ('file://') with container-builds.
Other way to address this would be a new plugin that automatically takes care of everything addressed via 'file://' but people can probably be quite inventive opening up a lot of corner-cases. So this probably covers the generic case for the first while giving people all possibilities.