### PR TITLE
WIP: Added support for MicroDnf

### DIFF
--- a/mock/py/mockbuild/plugins/package_state.py
+++ b/mock/py/mockbuild/plugins/package_state.py
@@ -52,7 +52,7 @@ class PackageState(object):
                 self.state.start("Outputting list of available packages")
                 out_file = self.buildroot.resultdir + '/available_pkgs.log'
                 chrootpath = self.buildroot.make_chroot_path()
-                if self.buildroot.config['package_manager'] == 'dnf':
+                if self.buildroot.config['package_manager'] in ['dnf', 'microdnf']:
                     cmd = "/usr/bin/dnf --installroot={0} repoquery -c {0}/etc/dnf/dnf.conf {1} > {2}".format(
                         chrootpath, repoquery_avail_opts, out_file)
                 else:

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -991,11 +991,16 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['yum_command'] = '/usr/bin/yum'
     config_opts['system_yum_command'] = '/usr/bin/yum'
     config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
-
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
     config_opts['dnf_command'] = '/usr/bin/dnf'
     config_opts['system_dnf_command'] = '/usr/bin/dnf'
     config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
+    config_opts['microdnf_command'] = '/usr/bin/microdnf'
+    # "dnf-install" is special keyword which tells mock to use install but with DNF
+    config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core distribution-gpg-keys'
+    config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
+    config_opts['microdnf_builddep_opts'] = []
+    config_opts['microdnf_common_opts'] = []
     config_opts['rpm_command'] = '/bin/rpm'
     config_opts['rpmbuild_command'] = '/usr/bin/rpmbuild'
 


### PR DESCRIPTION
You have to add to config:

Determining path to MicroDnf:
config_opts['microdnf_command'] = '/usr/bin/microdnf'
Command on install with MicroDnf:
config_opts['microdnf_install_command'] = 'microdnf install'

MicroDnf cannot use source config at /etc/microdnf/. At this moment, MicroDnf uses source config of Dnf, but its structure is already prepared for moment, when it will be available. Also, MicroDnf can't use installroot and builddep params. You need to use Dnf for these options.
