### PR TITLE
RFC: do not populate /etc/resolv.conf when networking is disabled (RHBZ#15…

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -691,9 +691,10 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None, c
         cmd = [cmd]
     nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-M', uuid.uuid4().hex, '-D', chrootPath]
     distro_label = distro.linux_distribution(full_distribution_name=False)[0]
-    if (distro_label != 'centos') and (distro_label != 'ol') and \
-       (distro_label != 'rhel') and (distro_label != 'deskos'):
-        # EL7 does not support it (yet). See BZ 1417387
+    distro_version = float(distro.version() or 0)
+    epel = ('centos', 'deskos', 'ol', 'rhel')
+    if distro_label not in epel or distro_version >= 7.5:
+        # EL < 7.5 does not support the nspawn -a option. See BZ 1417387
         nspawn_argv += ['-a']
     nspawn_argv.extend(nspawn_args)
     if cwd:


### PR DESCRIPTION
…14028)

systemd-nspawn overrides the 'use_host_resolv' config and copies the
host /etc/resolv.conf to the chroot even when networking is disabled.

In most common cases, this causes any networking calls in the chroot to
timeout rather than fail quickly, resulting in significant delays.  For
example:

    <mock-chroot> sh-4.4# time curl http://example.com/
    curl: (6) Could not resolve host: example.com

    real	0m20.541s
    user	0m0.009s
    sys	0m0.008s

With an empty /etc/resolv.conf in the chroot, this is much quicker:

    <mock-chroot> sh-4.4# time curl http://example.com/
    curl: (6) Could not resolve host: example.com

    real	0m0.016s
    user	0m0.005s
    sys	0m0.008s