### PR TITLE
Allow root

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -359,6 +359,8 @@ config_opts['bootstrap_module_install'] = []
 # name in this line of the mock PAM config:
 #   auth  sufficient pam_succeed_if.so user ingroup mock use_uid quiet
 # config_opts['chrootgid'] = grp.getgrnam("mock")[2]
+# name of user that is used when executing commands inside the chroot
+# config_opts['chrootuser'] = 'mockbuild'
 # name of the group inside of chroot
 # config_opts['chrootgroup'] = 'mock'
 

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -50,7 +50,7 @@ class Buildroot(object):
                         and util.selinuxEnabled())
 
         self.chrootuid = config['chrootuid']
-        self.chrootuser = 'mockbuild'
+        self.chrootuser = config['chrootuser'] 
         self.chrootgid = config['chrootgid']
         self.chrootgroup = config['chrootgroup']
         self.env = config['environment']

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -50,7 +50,7 @@ class Buildroot(object):
                         and util.selinuxEnabled())
 
         self.chrootuid = config['chrootuid']
-        self.chrootuser = config['chrootuser'] 
+        self.chrootuser = config['chrootuser']
         self.chrootgid = config['chrootgid']
         self.chrootgroup = config['chrootgroup']
         self.env = config['environment']

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -298,8 +298,9 @@ class Buildroot(object):
         self.doChroot(['/usr/sbin/groupdel', dets['group']],
                       shell=False, raiseExc=False, nosync=True)
 
-        self.doChroot(['/usr/sbin/groupadd', '-g', dets['gid'], dets['group']],
-                      shell=False, nosync=True)
+        if self.chrootgid != 0:
+            self.doChroot(['/usr/sbin/groupadd', '-g', dets['gid'], dets['group']],
+                          shell=False, nosync=True)
         self.doChroot(shlex.split(self.config['useradd'] % dets), shell=False, nosync=True)
         if not self.config['clean']:
             self.uid_manager.changeOwner(self.make_chroot_path(self.homedir))

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -795,6 +795,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         #  'mock' group doesn't exist, must set in config file
         pass
     config_opts['chrootgroup'] = 'mock'
+    config_opts['chrootuser'] = 'mockbuild'
     config_opts['build_log_fmt_name'] = "unadorned"
     config_opts['root_log_fmt_name'] = "detailed"
     config_opts['state_log_fmt_name'] = "state"


### PR DESCRIPTION
I have a project (https://github.com/nhorman/freight) which requires that some commands be run as the root user.  unfortunately, mock is not currently able to run commands as uid/gid 0 / user name root.  This set of patches enhances mock such that the uid/gid/username can be set in the config at build time.  Teste successfully by myself building freight container rpms

Signed-off-by: Neil Horman <nhorman@tuxdriver.com>