### PR TITLE
Replace armv5tl with aarch64 for Mageia Cauldron

### DIFF
--- a/mock-core-configs/etc/mock/mageia-cauldron-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-aarch64.cfg
@@ -1,6 +1,6 @@
-config_opts['root'] = 'mageia-cauldron-armv5tl'
-config_opts['target_arch'] = 'armv5tl'
-config_opts['legal_host_arches'] = ('armv5tl', 'armv6l', 'armv7l', 'armv7hl')
+config_opts['root'] = 'mageia-cauldron-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
 config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
@@ -25,21 +25,22 @@ install_weak_deps=0
 metadata_expire=0
 best=1
 
+
 [mageia-cauldron]
-name=Mageia Cauldron - armv5tl
-#baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/armv5tl/media/core/release/
-#metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv5tl@&section=core&repo=release
-mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv5tl&section=core&repo=release
+name=Mageia Cauldron - aarch64
+#baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/aarch64/media/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=aarch64@&section=core&repo=release
+mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=aarch64&section=core&repo=release
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
 skip_if_unavailable=False
 
 [mageia-cauldron-debuginfo]
-name=Mageia Cauldron - armv5tl - Debug
-#baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/armv5tl/media/debug/core/release/
-#metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv5tl@&section=core&repo=release&debug=true
-mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv5tl&section=core&repo=release&debug=1
+name=Mageia Cauldron - aarch64 - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/aarch64/media/debug/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=aarch64@&section=core&repo=release&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=aarch64&section=core&repo=release&debug=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0


### PR DESCRIPTION
The armv5tl architecture has been replaced with aarch64 in Cauldron, as Mageia is bootstrapping an AArch64 variant for Mageia 7.