### PR TITLE
Disable use_host_resolv by default

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -239,6 +239,7 @@ It can be specified multiple times.
 .TP
 \fB\-\-enable\-network\fR
 Enable networking. If you want to have reproducible builds then your builds should run without a network.
+This option overrides config_opts['rpmbuild_network'] and config_opts['use_host_resolv'], setting both True.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Show usage information and exit.

--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -27,7 +27,8 @@
 #  Note: the path pointed to by basedir and cache_topdir must be owned
 #        by group 'mock' and must have mode: g+rws
 # config_opts['rpmbuild_timeout'] = 0
-# config_opts['use_host_resolv'] = True
+# Using --enable-network sets use_host_resolv True, overriding the value set here.
+# config_opts['use_host_resolv'] = False
 
 # You can configure log format to pull from logging.ini formats of these names:
 # config_opts['build_log_fmt_name'] = "unadorned"

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -956,7 +956,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     # dependent on guest OS
     config_opts['useradd'] = \
         '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s -n %(user)s'
-    config_opts['use_host_resolv'] = True
+    config_opts['use_host_resolv'] = False
     config_opts['chroot_setup_cmd'] = ('groupinstall', 'buildsys-build')
     config_opts['target_arch'] = 'i386'
     config_opts['releasever'] = None
@@ -1140,6 +1140,7 @@ def set_config_opts_per_cmdline(config_opts, options, args):
 
     if options.enable_network:
         config_opts['rpmbuild_networking'] = True
+        config_opts['use_host_resolv'] = True
 
     if options.mode in ("rebuild",) and len(args) > 1 and not options.resultdir:
         raise exception.BadCmdline(


### PR DESCRIPTION
Mock has disabled networking by default since be4b13a ("Add
"rpmbuild_networking" key (False by default) for nspawn backend",
2015-07-27).  When using a systemd-nspawn chroot (the default), the host
resolv.conf is copied to the container by nspawn when 'use_host_resolv'
is True, which causes spurious network timeouts as noted in
RHBZ#1514028.

When the variable is unset, mock avoids populating it since 3f93978 ("do
not populate /etc/resolv.conf when networking is disabled
(RHBZ#1514028)", 2018-05-30).

Disabling 'use_host_resolv' by default provides a better out-of-the-box
experience.  The variable will be enabled when '--enable-network' option
is used, similar to the 'rpmbuild_networking' variable.

This is a follow-up to #190.