### PR TITLE
fix @VERSION@ processing in man pages

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -141,7 +141,7 @@ for i in py/mock.py py/mockchain.py; do
     perl -p -i -e 's|^PKGPYTHONDIR\s*=.*|PKGPYTHONDIR="%{python_sitelib}/mockbuild"|' $i
 done
 for i in docs/mockchain.1 docs/mock.1; do
-    perl -p -i -e 's|@VERSION@|%{version}"|' $i
+    perl -p -i -e 's|\@VERSION\@|%{version}"|' $i
 done
 
 %install


### PR DESCRIPTION
Prior to this change, the rpm build process would replace all single `@` characters in the man pages with the version number.

The problem is that Perl treats `@VERSION` as an (undefined) array, so the regex matcher is simply `@`.

Escape the two `@` characters so we match the literal string `@VERSION@`
in the man page nroff sources.