### PR TITLE
add qemu_user_static plugin

### DIFF
--- a/mock/py/mockbuild/plugins/qemu_user_static.py
+++ b/mock/py/mockbuild/plugins/qemu_user_static.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+# Written by Klaus Wenninger
+# Copyright (C) 2018 Klaus Wenninger <kwenning@redhat.com>
+
+# python library imports
+
+# our imports
+
+import os
+import os.path
+import shutil
+from mockbuild.trace_decorator import traceLog
+import mockbuild.util
+
+requires_api_version = "1.1"
+
+
+# plugin entry point
+@traceLog()
+def init(plugins, conf, buildroot):
+    QemuUserStatic(plugins, conf, buildroot)
+
+
+class QemuUserStatic(object):
+    """copies user-space-qemu into buildroot"""
+    # pylint: disable=too-few-public-methods
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.config = buildroot.config
+        self.state = buildroot.state
+        self.qemu_user_static = conf['binary_path']
+        # Skip for boostrap chroot as this is anyway host-arch
+        if buildroot.is_bootstrap or (self.qemu_user_static == None):
+            return
+        plugins.add_hook("preinit", self._copyQemuUserStatic)
+
+    @traceLog()
+    def _copyQemuUserStatic(self):
+        destpath = self.buildroot.make_chroot_path(self.qemu_user_static)
+        directory = os.path.dirname(destpath)
+
+        try:
+            os.stat(directory)
+        except:
+            os.makedirs(directory)
+
+        try:
+            os.stat(destpath)
+        except:
+            shutil.copy2(self.qemu_user_static, destpath)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -83,7 +83,7 @@ personality_defs = {
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
-               'hw_info']
+               'hw_info', 'qemu_user_static']
 
 USE_NSPAWN = False
 
@@ -911,6 +911,10 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         },
         'hw_info_enable': True,
         'hw_info_opts': {
+        },
+        'qemu_user_static_enable': False,
+        'qemu_user_static_opts': {
+            'binary_path': None,
         },
     }
 


### PR DESCRIPTION
building against foreign architectures seemed not to work for me in a systemd container.
not sure if the approach is desirable but at least it showcases that building
foreign architectures with bootstrap-containers is working if one simply copies
the qemu-binary into to destination-buildroot. 
copyin & bind-mount don't work as the qemu-binary has to be available during
installation as a lot of scriptlets can't be executed properly without.
of course it would be possible to detect automatically which and if the qemu-binary
should be copied. A bindmount done before the packages are installed should of
course work as well I guess.
Excuse my ignorance if I've overseen a mechanism that is already implemented.

Example from my config:

config_opts['plugin_conf']['qemu_user_static_enable'] = True
config_opts['plugin_conf']['qemu_user_static_opts']['binary_path'] = '/usr/bin/qemu-aarch64-static'