### PR TITLE
Add bash completion for --copyin with files (not just dirs)

### DIFF
--- a/mock/etc/bash_completion.d/mock
+++ b/mock/etc/bash_completion.d/mock
@@ -46,9 +46,14 @@ _mock()
             _mock_root $cfgdir
             return 0
             ;;
-        --configdir|--resultdir|--copyin|--sources)
+        --configdir|--resultdir|--sources)
             local IFS=$'\n'
             COMPREPLY=( $( compgen -d -- "$cur" ) )
+            return 0
+            ;;
+        --copyin)
+            local IFS=$'\n'
+            COMPREPLY=( $( compgen -f -o plusdirs -- "$cur" ) )
             return 0
             ;;
         --spec)


### PR DESCRIPTION
Fixed behaviour to match documentation. Useful for copying files.

https://github.com/rpm-software-management/mock/blob/devel/mock/docs/mock.1#L92