### PR TITLE
Keep the proxy by default

### DIFF
--- a/mock/etc/consolehelper/mock
+++ b/mock/etc/consolehelper/mock
@@ -2,4 +2,4 @@ USER=root
 PROGRAM=/usr/libexec/mock/mock
 SESSION=false
 FALLBACK=false
-KEEP_ENV_VARS=COLUMNS,SSH_AUTH_SOCK
+KEEP_ENV_VARS=COLUMNS,SSH_AUTH_SOCK,http_proxy,https_proxy,no_proxy


### PR DESCRIPTION
Keep the proxy configuration by default.
It allows to use    config_opts['http_proxy'] = os.getenv("http_proxy")
and a configured proxy could just work