### PR TITLE
expose print_main_output in configs

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -35,6 +35,11 @@
 # config_opts['root_log_fmt_name']  = "detailed"
 # config_opts['state_log_fmt_name'] = "state"
 #
+# By default, mock only prints the build log to stderr if it is a tty; you can
+# force it on here (for CI builds where there is no tty, for example) by
+# setting this to True, or force it off by setting it to False.
+# config_opts['print_main_output'] = None
+#
 # mock will normally set up a minimal chroot /dev.
 # If you want to use a pre-configured /dev, disable this and use the bind-mount
 # plugin to mount your special /dev

--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -35,9 +35,10 @@
 # config_opts['root_log_fmt_name']  = "detailed"
 # config_opts['state_log_fmt_name'] = "state"
 #
-# By default, mock only prints the build log to stderr if it is a tty; you can
+# By default, mock only prints the build log to stderr if it is a tty. You can
 # force it on here (for CI builds where there is no tty, for example) by
-# setting this to True, or force it off by setting it to False.
+# setting this to True, or force it off by setting it to False. Setting it to
+# None or leaving it undefined uses the default behavior.
 # config_opts['print_main_output'] = None
 #
 # mock will normally set up a minimal chroot /dev.

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1043,7 +1043,8 @@ def set_config_opts_per_cmdline(config_opts, options, args):
     config_opts.update(cli_opt_new)
 
     config_opts['verbose'] = options.verbose
-    config_opts['print_main_output'] = config_opts['verbose'] > 0 and sys.stderr.isatty()
+    if 'print_main_output' not in config_opts or config_opts['print_main_output'] is None:
+        config_opts['print_main_output'] = config_opts['verbose'] > 0 and sys.stderr.isatty()
 
     # do some other options and stuff
     if options.arch:


### PR DESCRIPTION
When building the kernel with mock on gitlab CI, I found that there was no way of having it print the output. Digging into the code, I found that `print_main_output` was the main thing controlling whether or not I saw the logs.

This PR simply exposes that configuration value in the actual configs. The default behaviour is preserved; it will detect whether stderr is a tty, and set it True or False based on that. However, it can now be overridden by the configuration.