### PR TITLE
Don't try to use a spec we've already cleaned up

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -854,6 +854,8 @@ def run_command(options, args, config_opts, commands, buildroot, state):
                 args.append(srpm)
             if config_opts['scm']:
                 scmWorker.clean()
+                options.spec = None
+                options.sources = None
             else:
                 config_opts['clean'] = False
         do_rebuild(config_opts, commands, buildroot, options, args)


### PR DESCRIPTION
Since commit 3a9221c5d13, a rebuild with scm in the config options
would a) check out from SCM b) generate an SRPM from spec and sources
c) clean up the SCM checkout including the spec file
d) try to copy the spec into the chroot