### PR TITLE
[mockbuild] create custom error message for dnf-utils not being installed

### DIFF
--- a/mock/py/mockbuild/exception.py
+++ b/mock/py/mockbuild/exception.py
@@ -41,6 +41,7 @@ class Error(Exception):
 # 70 = result dir could not be created
 # 80 = unshare of namespace failed
 # 110 = unbalanced call to state functions
+# 120 = weak dependent package not installed
 
 class BuildError(Error):
     "rpmbuild failed."

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -5,6 +5,7 @@ import copy
 import glob
 import os.path
 import shutil
+import sys
 from textwrap import dedent
 
 import distro
@@ -156,7 +157,22 @@ class _PackageManager(object):
     # pylint: disable=unused-argument
     @traceLog()
     def builddep(self, *args, **kwargs):
-        return self.execute('builddep', returnOutput=1, *args)
+        try:
+            result = self.execute('builddep', returnOutput=1, *args)
+        except (FileNotFoundError) as error:
+            er = str(error)
+            if "builddep" in er:
+                print(error)
+                print("""
+Error:      dnf-utils is not installed. Dnf-utils is needed to complete this action.
+            To install dnf-utils use one of the commands below:
+            $ dnf install dnf-utils
+            or
+            $ yum install dnf-utils""")
+                sys.exit(120)
+            else:
+                raise
+        return result
 
     @traceLog()
     def copy_gpg_keys(self):

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -164,11 +164,11 @@ class _PackageManager(object):
             if "builddep" in er:
                 print(error)
                 print("""
-Error:      dnf-utils is not installed. Dnf-utils is needed to complete this action.
-            To install dnf-utils use one of the commands below:
+Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-utils are needed to complete this action.
+            To install dnf-utils use:
             $ dnf install dnf-utils
-            or
-            $ yum install dnf-utils""")
+            or yum-utils:
+            $ yum install yum-utils""")
                 sys.exit(120)
             else:
                 raise


### PR DESCRIPTION
Created a new exception for absent weak dependent package.
Added custom message for error caused by dnf-utils not being installed.

bugzilla url:
https://bugzilla.redhat.com/show_bug.cgi?id=1626879

I am an intern working under Mirek Suchý.