### PR TITLE
Require dnf-utils

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -74,7 +74,7 @@ Requires: dnf
 Suggests: yum
 Requires: dnf-plugins-core
 Recommends: btrfs-progs
-Suggests: dnf-utils
+Recommends: dnf-utils
 Suggests: qemu-user-static
 %endif
 %if 0%{?rhel} == 7


### PR DESCRIPTION
Fedora 29 does not ship with by yum default, so require dnf-utils to allow non-bootstrapped epel-7 builds on Fedora without needing to manually install yum/dnf-utils.