### PR TITLE
Adjust buildroot creation to work inside a user namespace.

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -369,6 +369,21 @@ class Buildroot(object):
                     fo.write(chroot_file_contents[key])
 
     @traceLog()
+    def ensure_rpm_config_home(self):
+        """Create a fake home directory with an appropriate .rpmmacros"""
+
+        rpm_config_home = os.path.join(self.basedir, 'rpmconfig')
+        util.mkdirIfAbsent(rpm_config_home)
+
+        # Since /proc and /sys are mounted special filesystems when RPM is running
+        # to install the buildroot, it doesn't make sense for RPM to try and
+        # set the permissions on them - and that might fail with permission errors.
+        with open(os.path.join(rpm_config_home, ".rpmmacros"), "w") as f:
+            f.write("%_netsharedpath /proc:/sys\n")
+
+        return rpm_config_home
+
+    @traceLog()
     def nuke_rpm_db(self):
         """remove rpm DB lock files from the chroot"""
 

--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -183,6 +183,13 @@ class Mounts(object):
         self.managed_mounts.append(mount)
 
     @traceLog()
+    def add_device_bindmount(self, path):
+        mount = BindMountPoint(path,
+                               self.rootObj.make_chroot_path(path),
+                               options="noexec,nosuid,readonly")
+        self.essential_mounts.append(mount)
+
+    @traceLog()
     def add_user_mount(self, mount):
         self.user_mounts.append(mount)
 

--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -143,15 +143,16 @@ class Mounts(object):
         self.managed_mounts = []  # mounts owned by mock
         self.user_mounts = []  # mounts injected by user
         self.essential_mounts = [
-            FileSystemMountPoint(filetype='proc',
-                                 device='mock_chroot_proc',
-                                 path=rootObj.make_chroot_path('/proc')),
-            # Instead of mounting a fresh sysfs, we bind mount /sys.
-            # This avoids problems with kernel restrictions if running within a
-            # user namespace, and is pretty much identical otherwise. The
-            # bind mount additionally needs to be recursive, because the
-            # kernel forbids mounts that might reveal parts of /sys that
-            # a container runtime overmounted to hide from the container.
+            # Instead of mounting a fresh procfs and sysfs, we bind mount /proc
+            # and /sys. This avoids problems with kernel restrictions if running
+            # within a user namespace, and is pretty much identical otherwise.
+            # The bind mount additionally needs to be recursive, because the
+            # kernel forbids mounts that might reveal parts of the filesystem
+            # that a container runtime overmounted to hide from the container.
+            BindMountPoint(srcpath='/proc',
+                           bindpath=rootObj.make_chroot_path('/proc'),
+                           recursive=True,
+                           options="nodev,noexec,nosuid,readonly"),
             BindMountPoint(srcpath='/sys',
                            bindpath=rootObj.make_chroot_path('/sys'),
                            recursive=True,

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -114,6 +114,8 @@ class _PackageManager(object):
         # intentionally we do not call bootstrap hook here - it does not have sense
         env = self.config['environment'].copy()
         env.update(util.get_proxy_environment(self.config))
+        # use a special home directory with only our desired RPM configuration
+        env['HOME'] = self.buildroot.ensure_rpm_config_home()
         env['LC_MESSAGES'] = 'C.UTF-8'
         if self.buildroot.nosync_path:
             env['LD_PRELOAD'] = self.buildroot.nosync_path

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -425,6 +425,13 @@ def unshare(flags):
     except AttributeError:
         pass
 
+    if flags & CLONE_NEWNS:
+        # Unsharing the mount namespace isn't immediately effective if the
+        # source mount propagation status is 'shared' - changes to the mounts
+        # will still propagate back to the parent namespace. Do the same
+        # thing as unshare(1) and make all mounts private.
+        do(['mount', '--make-rprivate', '/'])
+
 
 def sethostname(hostname):
     getLog().info("Setting hostname: %s", hostname)


### PR DESCRIPTION
This set of patches is sufficient for me to get mock running in a rootless container. I was testing with https://github.com/debarshiray/fedora-toolbox - but something like `podman run --privileged fedora:29` should work as well. 

(I developed and tested this against 1.4.13, then rebased to devel - I don't think anything should have broken with the rebase, but it's possible.)

The three changes are:
 * Use bind mounts for device files
 * Use a bind mount for /sys
 * Use the %_netsharedpath RPM macro to avoid RPM trying and failing to chown /proc and /sys