### PR TITLE
config['decompress_program'] default

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -875,6 +875,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
             'dir': "%(cache_topdir)s/%(root)s/root_cache/",
             'tar': "gnutar",
             'compress_program': 'pigz',
+            'decompress_program': None,
             'exclude_dirs': ["./proc", "./sys", "./dev", "./tmp/ccache", "./var/cache/yum", "./var/cache/dnf"],
             'extension': '.gz'},
         'bind_mount_enable': True,


### PR DESCRIPTION
Fixes traceback:
File "/usr/lib/python3.7/site-packages/mockbuild/plugins/root_cache.py", line 42, in __init__
    self.decompressProgram = self.root_cache_opts['decompress_program'] or self.compressProgram
KeyError: 'decompress_program'

Complements: 2b4d3809821de8590689e3a5315ee465711c44dd