### PR TITLE
Add new Mageia and openSUSE configs

### DIFF
--- a/mock-core-configs/etc/mock/mageia-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-aarch64.cfg
@@ -1,0 +1,69 @@
+config_opts['root'] = 'mageia-7-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
+config_opts['dist'] = 'mga7'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '7'
+config_opts['macros']['%distro_section'] = 'core'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+# repos
+
+[mageia]
+name=Mageia $releasever - aarch64
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=release
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=release
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[updates]
+name=Mageia $releasever - aarch64 - Updates
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=updates
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=updates
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[mageia-debuginfo]
+name=Mageia $releasever - aarch64 - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/debug/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=release&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=release&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Mageia $releasever - aarch64 - Updates - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/debug/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=updates&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=updates&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
@@ -1,0 +1,68 @@
+config_opts['root'] = 'mageia-7-armv7hl'
+config_opts['target_arch'] = 'armv7hl'
+config_opts['legal_host_arches'] = ('armv7l', 'armv7hl')
+config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
+config_opts['dist'] = 'mga7'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '7'
+config_opts['macros']['%distro_section'] = 'core'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+
+[mageia]
+name=Mageia $releasever - armv7hl
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[updates]
+name=Mageia $releasever - armv7hl - Updates
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[mageia-debuginfo]
+name=Mageia $releasever - armv7hl - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/debug/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Mageia $releasever - armv7hl - Updates - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/debug/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/mageia-7-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-i586.cfg
@@ -1,0 +1,68 @@
+config_opts['root'] = 'mageia-7-i586'
+config_opts['target_arch'] = 'i586'
+config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
+config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
+config_opts['dist'] = 'mga7'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '7'
+config_opts['macros']['%distro_section'] = 'core'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+
+[mageia]
+name=Mageia $releasever - i586
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[updates]
+name=Mageia $releasever - i586 - Updates
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[mageia-debuginfo]
+name=Mageia $releasever - i586 - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/debug/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Mageia $releasever - i586 - Updates - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/debug/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/mageia-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-x86_64.cfg
@@ -1,0 +1,69 @@
+config_opts['root'] = 'mageia-7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
+config_opts['dist'] = 'mga7'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '7'
+config_opts['macros']['%distro_section'] = 'core'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+# repos
+
+[mageia]
+name=Mageia $releasever - x86_64
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[updates]
+name=Mageia $releasever - x86_64 - Updates
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=1
+skip_if_unavailable=False
+
+[mageia-debuginfo]
+name=Mageia $releasever - x86_64 - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/debug/core/release/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+
+[updates-debuginfo]
+name=Mageia $releasever - x86_64 - Updates - Debug
+#baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/debug/core/updates/
+#metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates&debug=true
+mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates&debug=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
+enabled=0
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/mageia-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-8-aarch64.cfg
@@ -1,0 +1,1 @@
+mageia-cauldron-aarch64.cfg

--- a/mock-core-configs/etc/mock/mageia-8-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-8-armv7hl.cfg
@@ -1,0 +1,1 @@
+mageia-cauldron-armv7hl.cfg

--- a/mock-core-configs/etc/mock/mageia-8-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-8-i586.cfg
@@ -1,0 +1,1 @@
+mageia-cauldron-i586.cfg

--- a/mock-core-configs/etc/mock/mageia-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-8-x86_64.cfg
@@ -1,0 +1,1 @@
+mageia-cauldron-x86_64.cfg

--- a/mock-core-configs/etc/mock/mageia-cauldron-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-aarch64.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '7'
+config_opts['releasever'] = '8'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/mock-core-configs/etc/mock/mageia-cauldron-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-armv7hl.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '7'
+config_opts['releasever'] = '8'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/mock-core-configs/etc/mock/mageia-cauldron-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-i586.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '7'
+config_opts['releasever'] = '8'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/mock-core-configs/etc/mock/mageia-cauldron-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-x86_64.cfg
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mage
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
-config_opts['releasever'] = '7'
+config_opts['releasever'] = '8'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 

--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
@@ -1,0 +1,44 @@
+config_opts['root'] = 'opensuse-leap-15.0-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'suse.lp150'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '15.0'
+config_opts['macros']['%dist'] = '.suse.lp150'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+# repos
+
+[opensuse-leap-oss]
+name=openSUSE Leap $releasever - aarch64 - OSS
+#baseurl=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/
+metalink=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+[updates-oss]
+name=openSUSE Leap $releasever - aarch64 - Updates - OSS
+#baseurl=http://download.opensuse.org/ports/aarch64/update/leap/$releasever/oss/
+metalink=http://download.opensuse.org/ports/aarch64/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -1,0 +1,44 @@
+config_opts['root'] = 'opensuse-leap-15.1-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'suse.lp151'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '15.1'
+config_opts['macros']['%dist'] = '.suse.lp151'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+# repos
+
+[opensuse-leap-oss]
+name=openSUSE Leap $releasever - aarch64 - OSS
+#baseurl=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/
+metalink=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+[updates-oss]
+name=openSUSE Leap $releasever - aarch64 - Updates - OSS
+#baseurl=http://download.opensuse.org/ports/aarch64/update/leap/$releasever/oss/
+metalink=http://download.opensuse.org/ports/aarch64/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -1,0 +1,45 @@
+config_opts['root'] = 'opensuse-leap-15.1-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'suse.lp151'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
+config_opts['releasever'] = '15.1'
+config_opts['macros']['%dist'] = '.suse.lp151'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+excludepkgs=*.i586,*.i686
+
+# repos
+
+[opensuse-leap-oss]
+name=openSUSE Leap $releasever - x86_64 - OSS
+#baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+[updates-oss]
+name=openSUSE Leap $releasever - x86_64 - Updates - OSS
+#baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
+metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+"""


### PR DESCRIPTION
This PR adds new Mageia 7 and openSUSE Leap 15.1 configs, as well as adding in openSUSE Leap AArch64 configs for targeting that platform.