### PR TITLE
Fix --enable-network documentation in man page

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -239,7 +239,7 @@ It can be specified multiple times.
 .TP
 \fB\-\-enable\-network\fR
 Enable networking. If you want to have reproducible builds then your builds should run without a network.
-This option overrides config_opts['rpmbuild_network'] and config_opts['use_host_resolv'], setting both True.
+This option overrides config_opts['rpmbuild_networking'] and config_opts['use_host_resolv'], setting both True.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Show usage information and exit.


### PR DESCRIPTION
The config file option is rpmbuild_networking not rpmbuild_network