### PR TITLE
Forcing armv7hl arch when it is the target arch enables transparent n…

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1124,6 +1124,11 @@ def set_config_opts_per_cmdline(config_opts, options, args):
     if options.forcearch:
         config_opts['forcearch'] = options.forcearch
 
+    # if armv7hl is forced when being the target it enables it to build from aarch64 hosts
+    if config_opts['target_arch'] == 'armv7hl':
+        config_opts['forcearch'] = 'armv7hl'
+        options.arch = 'armv7hl'
+
     if not options.clean:
         config_opts['clean'] = options.clean
 


### PR DESCRIPTION
Forcing armv7hl arch when it is the target arch enables transparent native build on aarch64 hosts with EL0 CONFIG_COMPAT support