### PR TITLE
Fix mock for non-ascii paths on python2

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -159,7 +159,36 @@ class TemplatedDictionary(MutableMapping):
             return value
     def __render_string(self, value):
         template = jinja2.Template(value)
-        return template.render(self.__dict__)
+        return _to_native(template.render(self.__dict__))
+
+
+def _to_bytes(obj, encoding='utf-8', errors='strict', nonstring='strict'):
+    if isinstance(obj, six.binary_type):
+        return obj
+    elif isinstance(obj, six.text_type):
+        return obj.encode(encoding, errors)
+    else:
+        if nonstring == 'strict':
+            raise TypeError('First argument must be a string')
+        raise ValueError('nonstring must be one of: ["strict",]')
+
+
+def _to_text(obj, encoding='utf-8', errors='strict', nonstring='strict'):
+    if isinstance(obj, six.text_type):
+        return obj
+    elif isinstance(obj, six.binary_type):
+        return obj.decode(encoding, errors)
+    else:
+        if nonstring == 'strict':
+            raise TypeError('First argument must be a string')
+        raise ValueError('nonstring must be one of: ["strict",]')
+
+
+if six.PY2:
+    _to_native = _to_bytes
+else:
+    _to_native = _to_text
+
 
 @traceLog()
 def get_proxy_environment(config):


### PR DESCRIPTION
Many paths in mock are a combination of a directory sepcified in
configuration with a subdirectory read in from the filesystem (or
specified on the commandline or from some other system service).  The
configuration paths were made into text strings by the Jinja2 templated
configs feature.  On python2 (el6 and el7) the strings from the
filesystem are byte strings.  When the two string types are combined, a
UnicodeError is thrown.

Rather than find all the places where mock is loading byte strings and
would need to transform them back into text strings, this patch merely
changes the text strings returned from Jinja2 into native strings (ie:
text strings on python3 and byte strings on python2).  This should
restore the behaviour of the pre-Jinja2 configuration.

To reproduce the error that this is fixing, run the following commands with mock under python2 (for instance, on an el7 or el6 box or by changing the shebang line in ```/usr/libexec/mock/mock``` to ```/usr/bin/python2```):

```
mock -r fedora-29-x86_64 --init
mock -r fedora-29-x86_64 --copyin /etc/motd /var/tmp/café
```

Without this PR, that will produce a traceback like this:
```
[pts/15@peru /srv/git/mock]$ mock -r fedora-29-x86_64 --copyin /etc/motd /var/tmp/café          *[epel7]  (15:50:05)
INFO: mock.py version 1.4.14 starting (python version = 2.7.15)...
Start: init plugins
INFO: selinux disabled
Finish: init plugins
Start: run
Start: chroot init
INFO: calling preinit hooks
INFO: enabled root cache
INFO: enabled dnf cache
Start: cleaning dnf metadata
Finish: cleaning dnf metadata
INFO: enabled HW Info plugin
Mock Version: 1.4.14
INFO: Mock Version: 1.4.14
Finish: chroot init
ERROR: 'ascii' codec can't decode byte 0xc3 in position 12: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/libexec/mock/mock", line 977, in <module>
    main()
  File "/usr/lib/python3.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 766, in main
    run_command(options, args, config_opts, commands, buildroot, state)
  File "/usr/lib/python3.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 877, in run_command
    dest = buildroot.make_chroot_path(args[-1])
  File "/usr/lib/python3.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.7/site-packages/mockbuild/buildroot.py", line 81, in make_chroot_path
    new_path = os.path.join(new_path, path)
  File "/usr/lib64/python2.7/posixpath.py", line 73, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 12: ordinal not in range(128)
```