### PR TITLE
Fix crash on non-ascii dnf log messages

### DIFF
--- a/mock/py/mockbuild/plugins/root_cache.py
+++ b/mock/py/mockbuild/plugins/root_cache.py
@@ -216,7 +216,7 @@ class RootCache(object):
                     raise
                 # now create the cache log file
                 with open(os.path.join(self.rootSharedCachePath, "cache.log"), "wb") as cache_log:
-                    cache_log.write(self.buildroot.pkg_manager.init_install_output.encode())
+                    cache_log.write(self.buildroot.pkg_manager.init_install_output.encode(mockbuild.util.encoding))
                 self.state.finish("creating root cache")
         finally:
             self._rootCacheUnlock()


### PR DESCRIPTION
When in Python 2 (el7) mock would crash while writing `cache.log` if
yum/dnf would output any non-ascii characters.

Following is an example exception message from such a crash:

```
Start: creating root cache
ERROR: 'ascii' codec can't encode character u'\u2192' in position 88551: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/libexec/mock/mock", line 977, in <module>
    main()
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 766, in main
    run_command(options, args, config_opts, commands, buildroot, state)
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 793, in run_command
    commands.init()
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.7/site-packages/mockbuild/backend.py", line 165, in init
    self.buildroot.initialize(**kwargs)
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.7/site-packages/mockbuild/buildroot.py", line 93, in initialize
    self._init(prebuild=prebuild, do_log=do_log)
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.7/site-packages/mockbuild/buildroot.py", line 183, in _init
    self.plugins.call_hooks('postinit')
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.7/site-packages/mockbuild/plugin.py", line 78, in call_hooks
    hook(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.7/site-packages/mockbuild/plugins/root_cache.py", line 178, in _rootCachePostInitHook
    self._rebuild_root_cache()
  File "/usr/lib/python2.7/site-packages/mockbuild/trace_decorator.py", line 96, in trace
    result = func(*args, **kw)
  File "/usr/lib/python2.7/site-packages/mockbuild/plugins/root_cache.py", line 219, in _rebuild_root_cache
    cache_log.write(self.buildroot.pkg_manager.init_install_output.encode())
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2192' in position 88551: ordinal not in range(128)
```