### PR TITLE
Fix openSUSE Tumbleweed DistTag definition

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
@@ -6,7 +6,7 @@ config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
 config_opts['releasever'] = '0'
-config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
 
 config_opts['yum.conf'] = """

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
@@ -6,7 +6,7 @@ config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
 config_opts['releasever'] = '0'
-config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
 
 config_opts['yum.conf'] = """

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
@@ -6,7 +6,7 @@ config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
 config_opts['releasever'] = '0'
-config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
 
 config_opts['yum.conf'] = """

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
@@ -6,7 +6,7 @@ config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
 config_opts['releasever'] = '0'
-config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
 
 config_opts['yum.conf'] = """

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
@@ -6,7 +6,7 @@ config_opts['dist'] = 'tumbleweed'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(home)s %(user)s'
 config_opts['releasever'] = '0'
-config_opts['macros']['%dist'] = '.suse.tw%(. /etc/os-release; echo $VERSION_ID)'
+config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
 
 config_opts['yum.conf'] = """


### PR DESCRIPTION
The DistTag macro definition for openSUSE Tumbleweed was slightly
incorrect, and did not correctly retrieve the `VERSION_ID` from the
`os-release(5)` file due to how shell expansion works.

This should be fixed now.