### PR TITLE
Allow AArch64 systems to build 32-bit ARM packages

### DIFF
--- a/mock-core-configs/etc/mock/fedora-28-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-28-armhfp.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'fedora-28-armhfp'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l')
+config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'fc28'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]

--- a/mock-core-configs/etc/mock/fedora-29-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-armhfp.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'fedora-29-armhfp'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l')
+config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')
 # config_opts['module_enable'] = ['list', 'of', 'modules']
 # config_opts['module_install'] = ['module1/profile', 'module2/profile']
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'

--- a/mock-core-configs/etc/mock/fedora-30-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-armhfp.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'fedora-30-armhfp'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l')
+config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')
 # config_opts['module_enable'] = ['list', 'of', 'modules']
 # config_opts['module_install'] = ['module1/profile', 'module2/profile']
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'

--- a/mock-core-configs/etc/mock/fedora-rawhide-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-armhfp.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'fedora-rawhide-armhfp'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l')
+config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')
 # config_opts['module_enable'] = ['list', 'of', 'modules']
 # config_opts['module_install'] = ['module1/profile', 'module2/profile']
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'

--- a/mock-core-configs/etc/mock/mageia-6-armv5tl.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-armv5tl.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'mageia-6-armv5tl'
 config_opts['target_arch'] = 'armv5tl'
-config_opts['legal_host_arches'] = ('armv5tl', 'armv6l', 'armv7l', 'armv7hl')
+config_opts['legal_host_arches'] = ('armv5tl', 'armv6l', 'armv7l', 'armv7hl', 'armv8l', 'armv8hl', 'aarch64')
 config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
 config_opts['dist'] = 'mga6'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]

--- a/mock-core-configs/etc/mock/mageia-6-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-armv7hl.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'mageia-6-armv7hl'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l', 'armv7hl')
+config_opts['legal_host_arches'] = ('armv7l', 'armv7hl', 'armv8l', 'armv8hl', 'aarch64')
 config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
 config_opts['dist'] = 'mga6'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]

--- a/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'mageia-7-armv7hl'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l', 'armv7hl')
+config_opts['legal_host_arches'] = ('armv7l', 'armv7hl', 'armv8l', 'armv8hl', 'aarch64')
 config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
 config_opts['dist'] = 'mga7'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]

--- a/mock-core-configs/etc/mock/mageia-cauldron-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-armv7hl.cfg
@@ -1,6 +1,6 @@
 config_opts['root'] = 'mageia-cauldron-armv7hl'
 config_opts['target_arch'] = 'armv7hl'
-config_opts['legal_host_arches'] = ('armv7l', 'armv7hl')
+config_opts['legal_host_arches'] = ('armv7l', 'armv7hl', 'armv8l', 'armv8hl', 'aarch64')
 config_opts['chroot_setup_cmd'] = 'install basesystem-minimal rpm-build rpm-mageia-setup rpm-mageia-setup-build'
 config_opts['dist'] = 'cauldron'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]


### PR DESCRIPTION
There are a number of AArch64 systems that natively support
building and running code for 32-bit ARM ISAs.

In particular, some of the new ARM cloud servers are capable of it,
like the new ARM cloud servers from Packet.com.

RPM already has enhancements for supporting this as well.

So, let's go ahead and allow it.