### PR TITLE
grant anyone access to bind-mounted /etc/resolv.conf

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1424,6 +1424,9 @@ def setup_host_resolv(config_opts):
     resolv_path = (tempfile.mkstemp(prefix="mock-resolv."))[1]
     atexit.register(_nspawnTempResolvAtExit, resolv_path)
 
+    # make sure that anyone in container can read resolv.conf file
+    os.chmod(resolv_path, 0o644)
+
     if config_opts['use_host_resolv']:
         shutil.copyfile('/etc/resolv.conf', resolv_path)
 


### PR DESCRIPTION
The mkstemp() call creates file with 0600 permissions, and it is
not a natural setup for the /etc/resolv.conf file.

The 0600 permissions are especially problematic with
'systemd-nspawn --private-users=pick' (recommended settings by
systemd docs, and used e.g. by copr in some cases).  The option
doesn't imply that the file is re-mapped according to the picked
user namespace.

Fixes: #265