### PR TITLE
bootstrap: enforce elfutils-libelf installation in epel-*

### DIFF
--- a/mock-core-configs/etc/mock/epel-6-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-x86_64.cfg
@@ -6,6 +6,7 @@ config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware RHEL uses 6Server or 6Client
 config_opts['releasever'] = '6'
 config_opts['use_nspawn'] = False
+config_opts['yum_install_command'] += ' --disablerepo sclo*'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-aarch64.cfg
@@ -4,6 +4,7 @@ config_opts['legal_host_arches'] = ('aarch64',)
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['yum_install_command'] += ' --disablerepo sclo*'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
@@ -4,6 +4,7 @@ config_opts['legal_host_arches'] = ('ppc64le',)
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['yum_install_command'] += ' --disablerepo sclo*'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-x86_64.cfg
@@ -4,6 +4,7 @@ config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['yum_install_command'] += ' --disablerepo sclo*'
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
There are several devtoolset-*-elfutils-libelf packages which
provide 'libelf.so.1()(64bit)' soname (bug), and since rpm-libs
depend on that soname those could be installed instead.

This actually happens if the bootstrap --installroot is done with
dnf (dnf-yum) package, where /usr/bin/yum calculates the
transaction a little bit differently than /usr/bin/yum-deprecated.

It's (probably?) not OK to just '--disablerepo sclo*' for
bootstrap --installroot, since those repositories are now by
default allowed even in Koji [1] and some package in that
transaction might (at least in theory) depend on some DTS package.

https://lists.fedorahosted.org/archives/list/\
epel-devel@lists.fedoraproject.org/thread/6EJIQ72JXWAAOQPFLRFYE5A7CUKC756D/