### PR TITLE
bootstrap: independent network configuration

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -131,7 +131,10 @@ class _PackageManager(object):
             elif self.bootstrap_buildroot is None:
                 out = util.do(invocation, env=env, **kwargs)
             else:
-                out = util.do(invocation, env=env, chrootPath=self.bootstrap_buildroot.make_chroot_path(), **kwargs)
+                out = util.do(invocation, env=env,
+                              chrootPath=self.bootstrap_buildroot.make_chroot_path(),
+                              nspawn_args=self.bootstrap_buildroot.config['nspawn_args'],
+                              **kwargs)
         except Error as e:
             raise YumError(str(e))
         finally:


### PR DESCRIPTION
First, make sure that 'util.do' uses the pre-configured
Buildroot's "nspawn_args" config (when using nspawn is enabled).

Second, postpone setup_host_resolv() call after bootstrap chroot
initialization step, so the bootstrap chroot doesn't inherit
resolv.conf from the main chroot.  This is needed because the main
chroot might or might not have network disabled, while bootstrap
chroot has network always enabled.  IOW, even though both chroots
are using nspawn, the former resolv.conf might be intentionally
empty while the latter one should always be a copy of hosts's
/etc/resolv.conf.