### PR TITLE
Add 'fastestmirror=1' to Mageia mock configs

### DIFF
--- a/mock-core-configs/etc/mock/mageia-6-armv5tl.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-armv5tl.cfg
@@ -31,6 +31,7 @@ name=Mageia $releasever - armv5tl
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv5tl/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia $releasever - armv5tl - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv5tl/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -51,6 +53,7 @@ name=Mageia $releasever - armv5tl - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv5tl/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -61,6 +64,7 @@ name=Mageia $releasever - armv5tl - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv5tl/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv5tl@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv5tl&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-6-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-armv7hl.cfg
@@ -31,6 +31,7 @@ name=Mageia $releasever - armv7hl
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia $releasever - armv7hl - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -51,6 +53,7 @@ name=Mageia $releasever - armv7hl - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -61,6 +64,7 @@ name=Mageia $releasever - armv7hl - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-6-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-i586.cfg
@@ -31,6 +31,7 @@ name=Mageia $releasever - i586
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia $releasever - i586 - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -51,6 +53,7 @@ name=Mageia $releasever - i586 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -61,6 +64,7 @@ name=Mageia $releasever - i586 - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-6-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-x86_64.cfg
@@ -32,6 +32,7 @@ name=Mageia $releasever - x86_64
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -42,6 +43,7 @@ name=Mageia $releasever - x86_64 - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -52,6 +54,7 @@ name=Mageia $releasever - x86_64 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -62,6 +65,7 @@ name=Mageia $releasever - x86_64 - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-aarch64.cfg
@@ -32,6 +32,7 @@ name=Mageia $releasever - aarch64
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -42,6 +43,7 @@ name=Mageia $releasever - aarch64 - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -52,6 +54,7 @@ name=Mageia $releasever - aarch64 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -62,6 +65,7 @@ name=Mageia $releasever - aarch64 - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/aarch64/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=aarch64@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=aarch64&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
@@ -31,6 +31,7 @@ name=Mageia $releasever - armv7hl
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia $releasever - armv7hl - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -51,6 +53,7 @@ name=Mageia $releasever - armv7hl - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -61,6 +64,7 @@ name=Mageia $releasever - armv7hl - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/armv7hl/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=armv7hl@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=armv7hl&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-7-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-i586.cfg
@@ -31,6 +31,7 @@ name=Mageia $releasever - i586
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia $releasever - i586 - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -51,6 +53,7 @@ name=Mageia $releasever - i586 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -61,6 +64,7 @@ name=Mageia $releasever - i586 - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/i586/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=i586@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=i586&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-x86_64.cfg
@@ -32,6 +32,7 @@ name=Mageia $releasever - x86_64
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -42,6 +43,7 @@ name=Mageia $releasever - x86_64 - Updates
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -52,6 +54,7 @@ name=Mageia $releasever - x86_64 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0
@@ -62,6 +65,7 @@ name=Mageia $releasever - x86_64 - Updates - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/$releasever/x86_64/media/debug/core/updates/
 #metalink=https://mirrors.mageia.org/metalink?distrib=mageia-$releasever&arch=x86_64@&section=core&repo=updates&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=$releasever&arch=x86_64&section=core&repo=updates&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-cauldron-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-aarch64.cfg
@@ -31,6 +31,7 @@ name=Mageia Cauldron - aarch64
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/aarch64/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=aarch64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=aarch64&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia Cauldron - aarch64 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/aarch64/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=aarch64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=aarch64&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-cauldron-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-armv7hl.cfg
@@ -31,6 +31,7 @@ name=Mageia Cauldron - armv7hl
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/armv7hl/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv7hl@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv7hl&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia Cauldron - armv7hl - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/armv7hl/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=armv7hl@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=armv7hl&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-cauldron-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-i586.cfg
@@ -31,6 +31,7 @@ name=Mageia Cauldron - i586
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/i586/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=i586@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=i586&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -41,6 +42,7 @@ name=Mageia Cauldron - i586 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/i586/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=i586@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=i586&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0

--- a/mock-core-configs/etc/mock/mageia-cauldron-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-x86_64.cfg
@@ -32,6 +32,7 @@ name=Mageia Cauldron - x86_64
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/x86_64/media/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=x86_64@&section=core&repo=release
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=x86_64&section=core&repo=release
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=1
@@ -42,6 +43,7 @@ name=Mageia Cauldron - x86_64 - Debug
 #baseurl=http://mirrors.kernel.org/mageia/distrib/cauldron/x86_64/media/debug/core/release/
 #metalink=https://mirrors.mageia.org/metalink?distrib=cauldron&arch=x86_64@&section=core&repo=release&debug=true
 mirrorlist=https://www.mageia.org/mirrorlist/?release=cauldron&arch=x86_64&section=core&repo=release&debug=1
+fastestmirror=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/mageia/RPM-GPG-KEY-Mageia
 enabled=0


### PR DESCRIPTION
Mageia still uses yum-style mirrorlists, and the mirrorlists are
returned in random order in each request. To make the best use of
this, we'll use fastestmirror so that somewhat fast mirrors are
selected more often.