### PR TITLE
Enable dynamic BuildRequires for Fedora Rawhide

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -90,7 +90,7 @@
 # dnf-plugins-core installed
 
 # Dynamic BuildRequires, available since RPM 4.15
-# config_opts['dynamic_buildrequires'] = False
+# config_opts['dynamic_buildrequires'] = True
 
 # You can configure Yum, DNF, rpm and rpmbuild executable paths if you need to
 # use different versions that the system-wide ones

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1095,7 +1095,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
 
     config_opts['package_manager'] = 'yum'
 
-    config_opts['dynamic_buildrequires'] = False
+    config_opts['dynamic_buildrequires'] = True
 
     # configurable commands executables
     config_opts['yum_command'] = '/usr/bin/yum'


### PR DESCRIPTION
RPM 4.15 is there, so let's turn it on!

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>