### PR TITLE
Allow more loop devices

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -93,6 +93,9 @@
 # config_opts['dynamic_buildrequires'] = True
 # config_opts['dynamic_buildrequires_max_loops'] = 10
 
+# Default maximum number of dev loops in chroot is 12
+# config_opts['dev_loop_count'] = 12
+
 # You can configure Yum, DNF, rpm and rpmbuild executable paths if you need to
 # use different versions that the system-wide ones
 # config_opts['yum_command'] = '/usr/bin/yum'

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -471,14 +471,11 @@ class Buildroot(object):
                 (stat.S_IFCHR | 0o600, os.makedev(5, 1), "dev/console"),
                 (stat.S_IFCHR | 0o666, os.makedev(5, 2), "dev/ptmx"),
                 (stat.S_IFCHR | 0o666, os.makedev(10, 237), "dev/loop-control"),
-                (stat.S_IFBLK | 0o666, os.makedev(7, 0), "dev/loop0"),
-                (stat.S_IFBLK | 0o666, os.makedev(7, 1), "dev/loop1"),
-                (stat.S_IFBLK | 0o666, os.makedev(7, 2), "dev/loop2"),
-                (stat.S_IFBLK | 0o666, os.makedev(7, 3), "dev/loop3"),
-                (stat.S_IFBLK | 0o666, os.makedev(7, 4), "dev/loop4"),
                 (stat.S_IFCHR | 0o600, os.makedev(10, 57), "dev/prandom"),
                 (stat.S_IFCHR | 0o600, os.makedev(10, 183), "dev/hwrng"),
             ]
+            for i in range(self.config['dev_loop_count']):
+                devFiles.append((stat.S_IFBLK | 0o666, os.makedev(7, i), "dev/loop{loop_number}".format(loop_number=i)))
             kver = os.uname()[2]
             self.root_log.debug("kernel version == %s", kver)
             for i in devFiles:

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1098,6 +1098,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['dynamic_buildrequires'] = True
     config_opts['dynamic_buildrequires_max_loops'] = 10
 
+    config_opts['dev_loop_count'] = 12
+
     # configurable commands executables
     config_opts['yum_command'] = '/usr/bin/yum'
     config_opts['system_yum_command'] = '/usr/bin/yum'


### PR DESCRIPTION
Run as mock -r fedora-30-x86_64 shell --old-chroot and I can see the loop0-loop11 in /dev.
Doesn't work without --old-chroot