### PR TITLE
core-configs: epel-7 profiles to use mirrorlists

### DIFF
--- a/mock-core-configs/etc/mock/epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-aarch64.cfg
@@ -25,7 +25,7 @@ protected_packages=
 # repos
 [base]
 name=BaseOS
-baseurl=http://mirror.centos.org/altarch/7/os/aarch64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=aarch64&repo=os
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7-aarch64
 gpgcheck=1
@@ -34,7 +34,7 @@ skip_if_unavailable=False
 [updates]
 name=updates
 enabled=1
-baseurl=http://mirror.centos.org/altarch/7/updates/aarch64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=aarch64&repo=updates
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7-aarch64
 gpgcheck=1
@@ -50,7 +50,7 @@ skip_if_unavailable=False
 
 [extras]
 name=extras
-baseurl=http://mirror.centos.org/altarch/7/extras/aarch64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=aarch64&repo=extras
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7-aarch64
 gpgcheck=1
@@ -58,7 +58,7 @@ skip_if_unavailable=False
 
 [sclo-rh]
 name=sclo-rh
-baseurl=http://mirror.centos.org/altarch/7/sclo/aarch64/rh/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=aarch64&repo=sclo-rh
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*

--- a/mock-core-configs/etc/mock/epel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64.cfg
@@ -24,7 +24,7 @@ protected_packages=
 # repos
 [base]
 name=BaseOS
-baseurl=http://mirror.centos.org/altarch/7/os/ppc64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=aarch64&repo=os
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos//RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64
 gpgcheck=1
@@ -33,7 +33,7 @@ skip_if_unavailable=False
 [updates]
 name=updates
 enabled=1
-baseurl=http://mirror.centos.org/altarch/7/updates/ppc64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=ppc64&repo=updates
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64
 gpgcheck=1
@@ -49,7 +49,7 @@ skip_if_unavailable=False
 
 [extras]
 name=extras
-baseurl=http://mirror.centos.org/altarch/7/extras/ppc64/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=ppc64&repo=extras
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64
 gpgcheck=1

--- a/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
@@ -25,7 +25,7 @@ protected_packages=
 # repos
 [base]
 name=BaseOS
-baseurl=http://mirror.centos.org/altarch/7/os/ppc64le/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=ppc64le&repo=os
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos//RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=1
@@ -34,7 +34,7 @@ skip_if_unavailable=False
 [updates]
 name=updates
 enabled=1
-baseurl=http://mirror.centos.org/altarch/7/updates/ppc64le/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=ppc64le&repo=updates
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=1
@@ -50,7 +50,7 @@ skip_if_unavailable=False
 
 [extras]
 name=extras
-baseurl=http://mirror.centos.org/altarch/7/extras/ppc64le/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=ppc64le&repo=extras
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7,file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le
 gpgcheck=1
@@ -58,7 +58,7 @@ skip_if_unavailable=False
 
 [sclo-rh]
 name=sclo-rh
-baseurl=http://mirror.centos.org/altarch/7/sclo/ppc64le/rh/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=ppc64le&repo=sclo-rh
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*

--- a/mock-core-configs/etc/mock/epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-x86_64.cfg
@@ -66,7 +66,7 @@ skip_if_unavailable=False
 
 [sclo-rh]
 name=sclo-rh
-baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=sclo-rh
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*


### PR DESCRIPTION
This caused problems on aarch64 copr builders recently -- the
default baseurl failed on http error 404.