### PR TITLE
Red Hat subscription-manager support

### DIFF
--- a/mock-core-configs/etc/mock/rhel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-aarch64.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-7.tpl')
+
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rhel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-ppc64.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-7.tpl')
+
+config_opts['target_arch'] = 'ppc64'
+config_opts['legal_host_arches'] = ('ppc64',)

--- a/mock-core-configs/etc/mock/rhel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-ppc64le.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-7.tpl')
+
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rhel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-x86_64.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-7.tpl')
+
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rhel-7.tpl
+++ b/mock-core-configs/etc/mock/rhel-7.tpl
@@ -1,0 +1,59 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '7Server'
+
+config_opts['dnf_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el7/noarch/distribution-gpg-keys-1.34-1.el7.noarch.rpm'
+config_opts['yum_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el7/noarch/distribution-gpg-keys-1.34-1.el7.noarch.rpm'
+
+config_opts['root'] = 'rhel-7-{{ target_arch }}'
+
+config_opts['redhat_subscription_required'] = True
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=1
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+best=1
+protected_packages=
+
+# repos
+
+[rhel]
+name = Red Hat Enterprise Linux
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
+skip_if_unavailable=False
+
+[rhel-optional]
+name = Red Hat Enterprise Linux - Optional
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
+skip_if_unavailable=False
+
+[rhel-extras]
+name = Red Hat Enterprise Linux - Extras
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/os
+enabled=0
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/rhel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-aarch64.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-8.tpl')
+
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rhel-8-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-ppc64.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-8.tpl')
+
+config_opts['target_arch'] = 'ppc64'
+config_opts['legal_host_arches'] = ('ppc64',)

--- a/mock-core-configs/etc/mock/rhel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-ppc64le.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-8.tpl')
+
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rhel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-x86_64.cfg
@@ -1,0 +1,4 @@
+include('/etc/mock/rhel-8.tpl')
+
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/rhel-8.tpl
@@ -1,0 +1,62 @@
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['releasever'] = '8'
+config_opts['package_manager'] = 'dnf'
+
+config_opts['dnf_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el8/noarch/distribution-gpg-keys-1.34-1.el8.noarch.rpm'
+config_opts['yum_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el8/noarch/distribution-gpg-keys-1.34-1.el8.noarch.rpm'
+
+config_opts['root'] = 'rhel-8-{{ target_arch }}'
+
+config_opts['redhat_subscription_required'] = True
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=1
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+module_platform_id=platform:el8
+protected_packages=
+
+# repos
+[rhel-baseos]
+name = Red Hat Enterprise Linux - BaseOS
+baseurl = https://cdn.redhat.com/content/dist/rhel8/$releasever/$basearch/baseos/os
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat8-release
+skip_if_unavailable=False
+
+[rhel-appstream]
+name = Red Hat Enterprise Linux - AppStream
+baseurl = https://cdn.redhat.com/content/dist/rhel8/$releasever/$basearch/appstream/os
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat8-release
+skip_if_unavailable=False
+
+[codeready-builder]
+name = Red Hat Enterprise Linux - CodeReady Linux Builder
+baseurl = https://cdn.redhat.com/content/dist/rhel8/$releasever/$basearch/codeready-builder/os
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat8-release
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/rhelepel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-aarch64.cfg
@@ -1,0 +1,2 @@
+include('/etc/mock/rhel-8-aarch64.cfg')
+include('/etc/mock/rhelepel-8.tpl')

--- a/mock-core-configs/etc/mock/rhelepel-8-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-ppc64.cfg
@@ -1,0 +1,2 @@
+include('/etc/mock/rhel-8-ppc64.cfg')
+include('/etc/mock/rhelepel-8.tpl')

--- a/mock-core-configs/etc/mock/rhelepel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-ppc64le.cfg
@@ -1,0 +1,2 @@
+include('/etc/mock/rhel-8-ppc64le.cfg')
+include('/etc/mock/rhelepel-8.tpl')

--- a/mock-core-configs/etc/mock/rhelepel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-x86_64.cfg
@@ -1,0 +1,2 @@
+include('/etc/mock/rhel-8-x86_64.cfg')
+include('/etc/mock/rhelepel-8.tpl')

--- a/mock-core-configs/etc/mock/rhelepel-8.tpl
+++ b/mock-core-configs/etc/mock/rhelepel-8.tpl
@@ -1,0 +1,12 @@
+config_opts['root'] = "rhelepel-8-{{ target_arch }}"
+
+config_opts['yum.conf'] += """
+
+[epel]
+name="EPEL 8"
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=$basearch
+failovermethod=priority
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgcheck=1
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -60,11 +60,12 @@ cp -a mock.conf %{buildroot}%{_sysusersdir}
 
 mkdir -p %{buildroot}%{_sysconfdir}/mock/eol
 cp -a etc/mock/*.cfg %{buildroot}%{_sysconfdir}/mock
+cp -a etc/mock/*.tpl %{buildroot}%{_sysconfdir}/mock
 cp -a etc/mock/eol/*cfg %{buildroot}%{_sysconfdir}/mock/eol
 
 # generate files section with config - there is many of them
 echo "%defattr(0644, root, mock)" > %{name}.cfgs
-find %{buildroot}%{_sysconfdir}/mock -name "*.cfg" \
+find %{buildroot}%{_sysconfdir}/mock -name "*.cfg" -o -name '*.tpl' \
     | sed -e "s|^%{buildroot}|%%config(noreplace) |" >> %{name}.cfgs
 # just for %%ghosting purposes
 ln -s fedora-rawhide-x86_64.cfg %{buildroot}%{_sysconfdir}/mock/default.cfg

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -614,6 +614,10 @@ def main():
     # cmdline options override config options
     util.set_config_opts_per_cmdline(config_opts, options, args)
 
+    # Now when all options are correctly loaded from config files and program
+    # options, turn the jinja templating ON.
+    config_opts['__jinja_expand'] = True
+
     # allow a different mock group to be specified
     if config_opts['chrootgid'] != mockgid:
         uidManager.restorePrivs()

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -125,7 +125,9 @@ class TemplatedDictionary(MutableMapping):
     def __setitem__(self, key, value):
         self.__dict__[key] = value
     def __getitem__(self, key):
-        return self.__render_value(self.__dict__[key])
+        if '__jinja_expand' in self.__dict__:
+            return self.__render_value(self.__dict__[key])
+        return self.__dict__[key]
     def __delitem__(self, key):
         del self.__dict__[key]
     def __iter__(self):

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -956,6 +956,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['backup_on_clean'] = False
     config_opts['backup_base_dir'] = os.path.join(config_opts['basedir'], "backup")
 
+    config_opts['redhat_subscription_required'] = False
+
     # (global) plugins and plugin configs.
     # ordering constraings: tmpfs must be first.
     #    root_cache next.
@@ -1609,3 +1611,35 @@ best=1
 """.format(repoid=repoid, baseurl=baseurl)
 
     config_opts['yum.conf'] += localyumrepo
+
+
+def subscription_redhat_init(opts):
+    if not opts['redhat_subscription_required']:
+        return
+
+    if 'redhat_subscription_key_id' in opts:
+        return
+
+    if not os.path.isdir('/etc/pki/entitlement'):
+        raise exception.ConfigError("/etc/pki/entitlment is not a directory, "
+                                    "is subscription-manager installed?")
+
+    keys = glob("/etc/pki/entitlement/*-key.pem")
+    if not keys:
+        raise exception.ConfigError(
+            "No key found in /etc/pki/entitlement directory.  It means "
+            "this machine is not subscribed.  Please use \n"
+            "  1. subscription-manager register\n"
+            "  2. subscription-manager list --all --available "
+            "(available pool IDs)\n"
+            "  3. subscription-manager attach --pool <POOL_ID>\n"
+            "If you don't have Red Hat subscription yet, consider "
+            "getting subscription:\n"
+            "  https://access.redhat.com/solutions/253273\n"
+            "You can have a free developer subscription:\n"
+            "  https://developers.redhat.com/faq/"
+        )
+
+    # Use the first available key.
+    key_file_name = os.path.basename(keys[0])
+    opts['redhat_subscription_key_id'] = key_file_name.split('-')[0]


### PR DESCRIPTION
Try e.g. on Fedora:

Register:
```
$ subscription-manager register (--serverurl subscription.rhsm.stage.redhat.com) \
 --username username \
 --password password
```

Check available pools:
```
$ subscription-manager list --all --available
...
Pool ID:  <THE_POOL_ID>
...
```

Obtain the keypair:
```
# subscription-manager attach --pool <THE_POOL_ID>
...

$ ls /etc/pki/entitlement
<KEY_ID>-key.pem  <KEY_ID>.pem
```

And try mock:
```
$ mock -r rhel-8-x86_64 --shell
...
```


