### PR TITLE
Mention user configuration file in a man page

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -65,6 +65,9 @@ be used to specify site\-wide options. The shipped version of this file has no
 active options, but does have a list of all of the configuration options
 examples of how to set them, and their default values.
 .LP
+To change configuration only for the current user please use ~/.config/mock.cfg
+configuration file.
+.LP
 For backward compatibility, old\-style commands, ("rebuild", "init", "clean",
 etc.) without leading '\-\-' are still accepted, but are deprecated. See
 COMMANDS section, below, for the detailed listing of all commands.


### PR DESCRIPTION
I'm missing this part in a man page.