### PR TITLE
Add procenv plugin for more detailed buildtime information

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -205,6 +205,9 @@
 # config_opts['plugin_conf']['hw_info_enable'] = True
 # config_opts['plugin_conf']['hw_info_opts'] = {}
 #
+# config_opts['plugin_conf']['procenv_enable'] = False
+# config_opts['plugin_conf']['procenv_opts'] = {}
+#
 # bind mount plugin is enabled by default but has no configured directories to
 # mount
 # config_opts['plugin_conf']['bind_mount_enable'] = True

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -78,6 +78,7 @@ Requires: dnf-plugins-core
 Recommends: btrfs-progs
 Recommends: dnf-utils
 Suggests: qemu-user-static
+Suggests: procenv
 %else
 %if 0%{?rhel} == 7
 Requires: btrfs-progs

--- a/mock/py/mockbuild/plugins/compress_logs.py
+++ b/mock/py/mockbuild/plugins/compress_logs.py
@@ -26,7 +26,7 @@ class CompressLogsPlugin(object):
     @traceLog()
     def _compress_logs(self):
         logger = getLog()
-        for f_name in ('root.log', 'build.log', 'state.log', 'available_pkgs.log', 'installed_pkgs.log', 'hw_info.log'):
+        for f_name in ('root.log', 'build.log', 'state.log', 'available_pkgs.log', 'installed_pkgs.log', 'hw_info.log', 'procenv.log'):
             f_path = os.path.join(self.buildroot.resultdir, f_name)
             if os.path.exists(f_path):
                 command = "{0} {1}".format(self.command, f_path)

--- a/mock/py/mockbuild/plugins/procenv.py
+++ b/mock/py/mockbuild/plugins/procenv.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+
+# python library imports
+import codecs
+
+# our imports
+from mockbuild.trace_decorator import getLog, traceLog
+import mockbuild.util
+
+requires_api_version = "1.1"
+
+
+# plugin entry point
+@traceLog()
+def init(plugins, conf, buildroot):
+    ProcEnv(plugins, conf, buildroot)
+
+
+class ProcEnv(object):
+    # pylint: disable=too-few-public-methods
+    """Get the runtime process environment"""
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.procenv_opts = conf
+        self.config = buildroot.config
+
+        # ensure procenv is installed into the buildroot
+        buildroot.preexisting_deps.append('procenv')
+
+        # actually run our plugin at this step
+        plugins.add_hook("prebuild", self._PreBuildHook)
+
+    # =============
+    # 'Private' API
+    # =============
+    @traceLog()
+    def _PreBuildHook(self):
+        getLog().info("enabled ProcEnv plugin")
+
+        out_file = self.buildroot.resultdir + '/procenv.log'
+        with codecs.open(out_file, 'w', 'utf-8', 'replace') as out:
+
+            cmd = ["/usr/bin/procenv"]
+            output = mockbuild.util.do(cmd, shell=False, returnOutput=True, raiseExc=False)
+            out.write(output)
+
+        self.buildroot.uid_manager.changeOwner(out_file, gid=self.config['chrootgid'])

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -100,7 +100,7 @@ personality_defs = {
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
-               'hw_info']
+               'hw_info', 'procenv']
 
 USE_NSPAWN = False
 
@@ -1029,6 +1029,9 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         },
         'hw_info_enable': True,
         'hw_info_opts': {
+        },
+        'procenv_enable': False,
+        'procenv_opts': {
         },
     }
 


### PR DESCRIPTION
This adds a plugin similar to hw_info.  Where hw_info produces detailed output on the hardware, this dumps a significant amount of information about the build time environment, any capabilities, and much more.