### PR TITLE
bootstrap-chroot: install shadow-utils by dnf as well

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -122,7 +122,7 @@
 # when 'use_bootstrap_container' is True, these commands are used to build
 # the minimal chroot for the respective package manager
 # config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
-# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
+# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
 # config_opts['system_yum_command'] = '/usr/bin/yum'
 # config_opts['system_dnf_command'] = '/usr/bin/dnf'
 
@@ -381,7 +381,7 @@
 # config_opts['dnf_builddep_opts'] = []
 # config_opts['microdnf_command'] = '/usr/bin/microdnf'
 ## "dnf-install" is special keyword which tells mock to use install but with DNF
-# config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core distribution-gpg-keys'
+# config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
 # config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
 # config_opts['microdnf_builddep_opts'] = []
 # config_opts['microdnf_common_opts'] = []

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1123,10 +1123,11 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
     config_opts['dnf_command'] = '/usr/bin/dnf'
     config_opts['system_dnf_command'] = '/usr/bin/dnf'
-    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
+    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
     config_opts['microdnf_command'] = '/usr/bin/microdnf'
     # "dnf-install" is special keyword which tells mock to use install but with DNF
-    config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core distribution-gpg-keys'
+    config_opts['microdnf_install_command'] = \
+        'dnf-install microdnf dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
     config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
     config_opts['microdnf_builddep_opts'] = []
     config_opts['microdnf_common_opts'] = []


### PR DESCRIPTION
    bootstrap-chroot: always explicitly install shadow-utils
    
    Previously we only did this explicitly for yum_install_command,
    apparently because yum itself (even transitively) never depended on
    shadow-utils.
    
    The 'dnf' package OTOH (mentioned in dnf_install_command and
    microdnf_install_command) used %systemd_requires before.  It means that
    also systemd package was installed as a dependency, and transitively
    /sbin/groupadd binary (shadow-utils).  So we didn't need to mention
    'shadow-utils' explicitly before.  This has changed recently in dnf [1],
    so we need to explicitly install shadow-utils for both
    {micro,}dnf_install_command.
    
    Per error:
    Finish(bootstrap): dnf install
    ERROR: Could not find useradd in chroot, maybe the install failed?
    
    [1] https://src.fedoraproject.org/rpms/dnf/c/faa199f16041940b85012fb8456b2fca349b6f9e?branch=master
    
    Fixes: rhbz#1743843
