### PR TITLE
Activate use_bootstrap_container for dnf enabled config files on RHEL < 8

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -49,7 +49,15 @@ Config files which allow you to create chroots for:
 
 
 %build
-# nothing to do here
+
+%if 0%{?rhel} > 0 && 0%{?rhel} < 8
+# Required for dnf enabled ocnfigs on yum based hosts
+# config_opts['use_bootstrap_container'] = True
+grep -rl "config_opts\['package_manager'\] = 'dnf'" etc/mock | \
+    while read name; do
+    sed -i.bak "s/config_opts\['package_manager'\] = 'dnf'/config_opts\['package_manager'\] = 'dnf'\n# Enable bootstrap on dnf host for %%rhel %{rhel}\nconfig_opts\[\'use_bootstrap_container\'\] = True\n\n/g" $name
+done
+%endif # rhel && rhel < 8
 
 
 %install


### PR DESCRIPTION
Issue 39 about bootstrap_container settings, addressed as needed in /etc/mock/ configs.