### PR TITLE
Automatically disable systemd-nspawn in some circumstances

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -634,6 +634,9 @@ def main():
     # configure logging
     setup_logging(config_path, config_opts, options)
 
+    # see if we need to force old-chroot because systemd-nspawn can't work
+    util.check_for_nspawn_support()
+
     # verify that we're not trying to build an arch that we can't
     check_arch_combination(config_opts['rpmbuild_arch'], config_opts)
 

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -899,6 +899,29 @@ def find_non_nfs_dir():
     raise exception.Error('Cannot find non-NFS directory in: %s' % dirs)
 
 
+def nspawn_supported():
+    """Detect some situations where the systemd-nspawn chroot code won't work"""
+    with open("/proc/1/cmdline", "rb") as f:
+        # if PID 1 has a non-0 UID, then we're running in a user namespace
+        # without a PID namespace. systemd-nspawn won't work
+        if os.fstat(f.fileno()).st_uid != 0:
+            return False
+
+        argv0 = f.read().split(b'\0')[0]
+
+        # If PID 1 is not systemd, then we're in a PID namespace, or systemd
+        # isn't running on the system: systemd-nspawn won't work.
+        return os.path.basename(argv0) == b'systemd'
+
+
+def check_for_nspawn_support():
+    global USE_NSPAWN
+
+    if USE_NSPAWN and not nspawn_supported():
+        getLog().info("systemd-nspawn not supported, disabling")
+        USE_NSPAWN = False
+
+
 @traceLog()
 def setup_default_config_opts(unprivUid, version, pkgpythondir):
     "sets up default configuration."


### PR DESCRIPTION
This is a patch that automatically forces --old-chroot if it detects a circumstance where systemd-nspawn isn't going to work. I've gone back and forth about doing this, but my argument for doing it is that "systemd-nspawn not working" is a question about *how* a container is run (using user namespaces or not, using with systemd as the init or not, etc), and not about the contents of the container. So saying that the creator of a container should adjust `/etc/mock/site-defaults.cfg` doesn't really make sense.

In terms of the particular checks here, I'm sure that current systemd-nspawn, as used by mock, will not work in these cases. It's hard to prove that some future version of systemd-nspawn couldn't be adapted to work in these cases - this is one reason that I have a message printed out here - so that if it's *unexpected* that systemd-nspawn is disabled, someone will have the chance to go in and figure out what is going on.

The check occurs a little later in mock setup than you might expect - it doesn't happen during option processing. This is because it needs to happen after logging is set up to get an INFO level message to work.

<hr>

If PID 1 isn't systemd, or PID 1 is running in a different user
namespace, then systemd-nspawn will not work currently, and is
unlikely to work in the future. Fall back to the --old-chroot code
with a message.

cc: @debarshiray