### PR TITLE
Use podman to pull and export an image as a bootstrap chroot.

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -126,6 +126,11 @@
 # config_opts['system_yum_command'] = '/usr/bin/yum'
 # config_opts['system_dnf_command'] = '/usr/bin/dnf'
 
+# The bootstrap chroot is installed using a package manager by default,
+# but in some cases you may want it populated from a container image instead.
+# config_opts['use_bootstrap_image'] = False
+# config_opts['bootstrap_image'] = 'fedora:latest'
+
 # anything you specify with 'bootstrap_*' will be copied to bootstrap config
 # e.g. config_opts['bootstrap_system_yum_command'] = '/usr/bin/yum-deprecated' will become
 # config_opts['system_yum_command'] = '/usr/bin/yum-deprecated' for bootstrap config

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -79,6 +79,7 @@ Recommends: btrfs-progs
 Recommends: dnf-utils
 Suggests: qemu-user-static
 Suggests: procenv
+Suggests: podman
 %else
 %if 0%{?rhel} == 7
 Requires: btrfs-progs

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -675,6 +675,9 @@ def main():
         bootstrap_buildroot_config['yum_command'] = bootstrap_buildroot_config['system_yum_command']
         bootstrap_buildroot_config['dnf_command'] = bootstrap_buildroot_config['system_dnf_command']
 
+        # disable updating bootstrap chroot
+        bootstrap_buildroot_config['update_before_build'] = False
+
         bootstrap_buildroot_state = State(bootstrap=True)
         bootstrap_plugins = Plugins(bootstrap_buildroot_config, bootstrap_buildroot_state)
         bootstrap_buildroot = Buildroot(bootstrap_buildroot_config,

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -60,6 +60,9 @@ class Buildroot(object):
         self.env.update(proxy_env)
         os.environ.update(proxy_env)
 
+        self.use_bootstrap_image = self.config['use_bootstrap_image']
+        self.bootstrap_image = self.config['bootstrap_image']
+
         self.pkg_manager = package_manager(config, self, plugins, bootstrap_buildroot)
         self.mounts = mounts.Mounts(self)
 
@@ -250,6 +253,9 @@ class Buildroot(object):
 
     @traceLog()
     def _init_pkg_management(self):
+        if self.is_bootstrap and self.use_bootstrap_image:
+            getLog().debug("Skipping package management init in the bootstrap chroot due to using bootstrap image")
+            return
         update_state = '{0} install'.format(self.pkg_manager.name)
         self.state.start(update_state)
         if 'module_enable' in self.config and self.config['module_enable']:

--- a/mock/py/mockbuild/plugins/root_cache.py
+++ b/mock/py/mockbuild/plugins/root_cache.py
@@ -7,6 +7,7 @@
 # python library imports
 import fcntl
 import os
+import subprocess
 import time
 
 # our imports
@@ -127,6 +128,35 @@ class RootCache(object):
         if self.rootCacheLock is None:
             self.rootCacheLock = open(os.path.join(self.rootSharedCachePath, "rootcache.lock"), "a+")
 
+        if self.buildroot.is_bootstrap and self.buildroot.use_bootstrap_image \
+                and not os.path.exists(self.rootCacheFile):
+            getLog().info("Using bootstrap image: %s", self.buildroot.bootstrap_image)
+
+            # pull the latest image
+            getLog().info("Pulling image: %s", self.buildroot.bootstrap_image)
+            cmd = ["podman", "pull", self.buildroot.bootstrap_image]
+            mockbuild.util.do(cmd, printOutput=True)
+
+            # start a container and detach immediately
+            cmd = ["podman", "run", "--detach", self.buildroot.bootstrap_image, "/bin/true"]
+            container_id = mockbuild.util.do(cmd, returnOutput=True)
+            container_id = container_id.strip()
+
+            # export container and compress it
+            getLog().info("Exporting container: %s as %s", self.buildroot.bootstrap_image, self.rootCacheFile)
+            cmd_podman = ["podman", "export", container_id]
+            podman = subprocess.Popen(cmd_podman, stdout=subprocess.PIPE)
+            cache_file = open(self.rootCacheFile, "w")
+            cmd_compressor = [self.compressProgram, "--stdout"]
+            compressor = subprocess.Popen(cmd_compressor, stdin=podman.stdout, stdout=cache_file)
+            compressor.communicate()
+            podman.communicate()
+            cache_file.close()
+
+            # remove the container
+            cmd = ["podman", "rm", container_id]
+            mockbuild.util.do(cmd)
+
         # optimization: don't unpack root cache if chroot was not cleaned (unless we are using tmpfs)
         if os.path.exists(self.rootCacheFile):
             if (not self.buildroot.chroot_was_initialized or self._haveVolatileRoot()):
@@ -150,6 +180,17 @@ class RootCache(object):
                 )
                 for item in self.exclude_dirs:
                     mockbuild.util.mkdirIfAbsent(self.buildroot.make_chroot_path(item))
+
+                if self.buildroot.is_bootstrap and self.buildroot.use_bootstrap_image:
+                     # The bootstrap image frequently lacks distribution-gpg-keys.
+                     # Copy the files from the host to avoid invoking package manager
+                     # or rebuilding the cached bootstrap chroot.
+                     keys_path = "/usr/share/distribution-gpg-keys"
+                     dest_path = os.path.dirname(keys_path)
+                     getLog().debug("Copying %s to the bootstrap chroot" % keys_path)
+                     cmd = ["cp", "-a", keys_path, self.buildroot.make_chroot_path(dest_path)]
+                     mockbuild.util.do(cmd)
+
                 self._rootCacheUnlock()
                 self.buildroot.chrootWasCached = True
                 self.state.finish("unpacking root cache")

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -931,6 +931,9 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['use_container_host_hostname'] = True
     config_opts['use_bootstrap_container'] = False
 
+    config_opts['use_bootstrap_image'] = False
+    config_opts['bootstrap_image'] = 'fedora:latest'
+
     config_opts['internal_dev_setup'] = True
 
     # cleanup_on_* only take effect for separate --resultdir


### PR DESCRIPTION
Running mock for the latest distro on an old one doesn't always work mainly
due to a new compression format or a new checksum algorithm. Using the image
skips the installation step and allows using the latest runtime directly.

To turn this feature on, add following to the config file:
config_opts['use_bootstrap_image'] = True

You can also override image tag (defaults to 'fedora:latest'):
config_opts['bootstrap_image'] = 'fedora:latest'