### PR TITLE
Add Amazon Linux 2 configs

### DIFF
--- a/mock-core-configs/etc/mock/amazonlinux-2-aarch64.cfg
+++ b/mock-core-configs/etc/mock/amazonlinux-2-aarch64.cfg
@@ -1,0 +1,5 @@
+include('/etc/mock/templates/amazonlinux-2.tpl')
+
+config_opts['root'] = 'amzn-2-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/amazonlinux-2-x86_64.cfg
+++ b/mock-core-configs/etc/mock/amazonlinux-2-x86_64.cfg
@@ -1,0 +1,5 @@
+include('/etc/mock/templates/amazonlinux-2.tpl')
+
+config_opts['root'] = 'amzn-2-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
+++ b/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
@@ -1,0 +1,24 @@
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build yum'
+config_opts['dist'] = 'amzn2' # only useful for --resultdir variable subst
+config_opts['plugin_conf']['ccache_enable'] = False
+config_opts['package_manager'] = 'yum'
+config_opts['releasever'] = '2'
+
+config_opts['yum.conf'] = """
+[main]
+cachedir=/var/cache/yum
+debuglevel=1
+logfile=/var/log/yum.log
+reposdir=/dev/null
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+
+[amzn2]
+name=AMZN2
+mirrorlist=http://amazonlinux.default.amazonaws.com/$releasever/core/latest/$basearch/mirror.list
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/amazon-linux/RPM-GPG-KEY-amazon-linux-2
+enabled=1
+"""


### PR DESCRIPTION
This PR adds amazon linux 2 config files with references to gpg keys provided by this [PR for distribution-gpg-keys](https://github.com/xsuchy/distribution-gpg-keys/pull/24/commits/3601e86a359892eea54e57d3e900199b9ee4ed5b). 