### PR TITLE
configure podman containers for Fedora, EPEL and Mageia

### DIFF
--- a/mock-core-configs/etc/mock/epel-6-i386.cfg
+++ b/mock-core-configs/etc/mock/epel-6-i386.cfg
@@ -6,6 +6,7 @@ config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware: RHEL uses 6Server or 6Client
 config_opts['releasever'] = '6'
 config_opts['use_nspawn'] = False
+config_opts['bootstrap_image'] = 'centos:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-6-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-ppc64.cfg
@@ -6,6 +6,7 @@ config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware: RHEL uses 6Server or 6Client
 config_opts['releasever'] = '6'
 config_opts['use_nspawn'] = False
+config_opts['bootstrap_image'] = 'centos:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-6-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-x86_64.cfg
@@ -7,6 +7,7 @@ config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '6'
 config_opts['use_nspawn'] = False
 config_opts['yum_install_command'] += ' --disablerepo=sclo*'
+config_opts['bootstrap_image'] = 'centos:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-aarch64.cfg
@@ -5,6 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 config_opts['yum_install_command'] += ' --disablerepo=sclo*'
+config_opts['bootstrap_image'] = 'centos:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64.cfg
@@ -4,6 +4,7 @@ config_opts['legal_host_arches'] = ('ppc64',)
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['bootstrap_image'] = 'centos:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64le.cfg
@@ -5,6 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 config_opts['yum_install_command'] += ' --disablerepo=sclo*'
+config_opts['bootstrap_image'] = 'centos:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-x86_64.cfg
@@ -5,6 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 config_opts['yum_install_command'] += ' --disablerepo=sclo*'
+config_opts['bootstrap_image'] = 'centos:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-6-armv5tl.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-armv5tl.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '6'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-6-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-armv7hl.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '6'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-6-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-i586.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '6'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-6-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-6-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '6'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:6'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-armv7hl.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-7-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-i586.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/mageia-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/mageia-7-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'mageia:7'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -3,6 +3,7 @@ config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'centos:8'
 
 
 config_opts['yum.conf'] = """

--- a/mock-core-configs/etc/mock/templates/fedora-29.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-29.tpl
@@ -6,6 +6,7 @@ config_opts['dist'] = 'fc29'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '29'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'fedora:29'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-30.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-30.tpl
@@ -6,6 +6,7 @@ config_opts['dist'] = 'fc30'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '30'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'fedora:30'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-31.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-31.tpl
@@ -8,6 +8,7 @@ config_opts['dist'] = 'fc31'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '31'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'fedora:31'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -8,6 +8,9 @@ config_opts['releasever'] = '32'
 
 config_opts['package_manager'] = 'dnf'
 
+config_opts['bootstrap_image'] = 'fedora:rawhide'
+
+
 config_opts['yum.conf'] = """
 [main]
 keepcache=1


### PR DESCRIPTION
This is a follow-up for PR#342


At the moment of creating this commit, all Fedora configs works
and it is possible to build in them using the podman image.

Both EPEL 6 and 7 works too, but there is no available image for
EPEL 8 yet. I've configured it though in order to have it prepared
once the image is ready.

Neither Mageia 6 nor 7 works properly. Mageia 6 fails with DNF
traceback and Mageia 7 fails because of failing to sync repos.
I guess those might fix _themselves_.

I haven't modified any other mock configs because

1) Those systems don't have Dnf/Yum (cauldron, opensuse)
2) I didn't know what are the official podman images for them
   (rhel, centos-stream)
3) It just didn't work and failed with traceback
   (amazonlinux, openmandriva-cooker)