### PR TITLE
don't play with uid_manager unnecessarily

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -340,8 +340,6 @@ class Buildroot(object):
         self.logging_initialized = True
 
         with self.uid_manager:
-            self.uid_manager.becomeUser(0, 0)
-
             util.mkdirIfAbsent(self.resultdir)
             # attach logs to log files.
             # This happens in addition to anything that
@@ -357,7 +355,6 @@ class Buildroot(object):
                 fh.setLevel(logging.NOTSET)
                 log.addHandler(fh)
                 log.info("Mock Version: %s", self.config['version'])
-            self.uid_manager.restorePrivs()
 
     @traceLog()
     def _init_aux_files(self):

--- a/mock/py/mockbuild/plugins/package_state.py
+++ b/mock/py/mockbuild/plugins/package_state.py
@@ -70,8 +70,6 @@ class PackageState(object):
             cmd = "rpm -qa --root '%s' --qf '%%{nevra} %%{buildtime} %%{size} %%{pkgid} installed\\n' > %s" % (
                 self.buildroot.make_chroot_path(), out_file)
             with self.buildroot.uid_manager:
-                self.buildroot.uid_manager.becomeUser(0, 0)
                 mockbuild.util.do(cmd, shell=True, env=self.buildroot.env)
-                self.buildroot.uid_manager.restorePrivs()
             self.inst_done = True
             self.state.finish("Outputting list of installed packages")


### PR DESCRIPTION
This reverts commit 92aaabe44824bb2bd95792dcf4b80767ba30d24a and part of
commit a239b59b871c8cf2a74e23cfa2335012b50d1181.

Fixes: #341, #322 (corrected fix), rhbz#1751944