### PR TITLE
ignore ./var/log when creating root_cache - fixes #309

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -205,7 +205,8 @@
 # config_opts['plugin_conf']['root_cache_opts']['decompress_program'] = "pigz"
 # config_opts['plugin_conf']['root_cache_opts']['extension'] = ".gz"
 # config_opts['plugin_conf']['root_cache_opts']['exclude_dirs'] = ["./proc", "./sys", "./dev",
-#                                                                  "./var/tmp/ccache", "./var/cache/yum" ]
+#                                                                  "./var/tmp/ccache", "./var/cache/yum", 
+#                                                                  "./var/cache/dnf", "./var/log" ]
 # config_opts['plugin_conf']['hw_info_enable'] = True
 # config_opts['plugin_conf']['hw_info_opts'] = {}
 #

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -979,7 +979,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
             'tar': "gnutar",
             'compress_program': 'pigz',
             'decompress_program': None,
-            'exclude_dirs': ["./proc", "./sys", "./dev", "./tmp/ccache", "./var/cache/yum", "./var/cache/dnf"],
+            'exclude_dirs': ["./proc", "./sys", "./dev", "./tmp/ccache", "./var/cache/yum", "./var/cache/dnf", "./var/log"],
             'extension': '.gz'},
         'bind_mount_enable': True,
         'bind_mount_opts': {


### PR DESCRIPTION
proposed solution for https://github.com/rpm-software-management/mock/issues/309