### PR TITLE
hw_info: don't create root-owned files

### DIFF
--- a/mock/py/mockbuild/plugins/hw_info.py
+++ b/mock/py/mockbuild/plugins/hw_info.py
@@ -32,7 +32,7 @@ class HwInfo(object):
     # 'Private' API
     # =============
     @traceLog()
-    def _PreInitHook(self):
+    def _unprivPreInitHook(self):
         getLog().info("enabled HW Info plugin")
         out_file = self.buildroot.resultdir + '/hw_info.log'
         out = codecs.open(out_file, 'w', 'utf-8', 'replace')
@@ -53,4 +53,8 @@ class HwInfo(object):
         out.write(output)
 
         out.close()
-        self.buildroot.uid_manager.changeOwner(out_file, gid=self.config['chrootgid'])
+
+    @traceLog()
+    def _PreInitHook(self):
+        with self.buildroot.uid_manager:
+            self._unprivPreInitHook()


### PR DESCRIPTION
We don't mind if the tools in hw_info plugin are called as root or not
(both ways would work well) but since root-owned hw_info.log file
causes problems on NFS mounts, and to not overcomplicate things, it is
better to drop the privileges around the whole logic in hw_info plugin.

Fixes: #85