### PR TITLE
search config files in multiple possible paths

### DIFF
--- a/mock-core-configs/etc/mock/amazonlinux-2-aarch64.cfg
+++ b/mock-core-configs/etc/mock/amazonlinux-2-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/amazonlinux-2.tpl')
+include('templates/amazonlinux-2.tpl')
 
 config_opts['root'] = 'amzn-2-aarch64'
 config_opts['target_arch'] = 'aarch64'

--- a/mock-core-configs/etc/mock/amazonlinux-2-x86_64.cfg
+++ b/mock-core-configs/etc/mock/amazonlinux-2-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/amazonlinux-2.tpl')
+include('templates/amazonlinux-2.tpl')
 
 config_opts['root'] = 'amzn-2-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/mock-core-configs/etc/mock/centos-stream-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/centos-stream.tpl')
+include('templates/centos-stream.tpl')
 
 config_opts['root'] = 'centos-stream-aarch64'
 config_opts['target_arch'] = 'aarch64'

--- a/mock-core-configs/etc/mock/centos-stream-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/centos-stream.tpl')
+include('templates/centos-stream.tpl')
 
 config_opts['root'] = 'centos-stream-ppc64le'
 config_opts['target_arch'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/centos-stream-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/centos-stream.tpl')
+include('templates/centos-stream.tpl')
 
 config_opts['root'] = 'centos-stream-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/mock-core-configs/etc/mock/epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-aarch64.cfg
@@ -1,5 +1,5 @@
-include('/etc/mock/templates/centos-8.tpl')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/centos-8.tpl')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = 'epel-8-aarch64'
 config_opts['target_arch'] = 'aarch64'

--- a/mock-core-configs/etc/mock/epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-8-ppc64le.cfg
@@ -1,5 +1,5 @@
-include('/etc/mock/templates/centos-8.tpl')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/centos-8.tpl')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = 'epel-8-ppc64le'
 config_opts['target_arch'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-x86_64.cfg
@@ -1,5 +1,5 @@
-include('/etc/mock/templates/centos-8.tpl')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/centos-8.tpl')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = 'epel-8-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/mock-core-configs/etc/mock/fedora-29-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-29.tpl')
+include('templates/fedora-29.tpl')
 
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/fedora-29-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-armhfp.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-29.tpl')
+include('templates/fedora-29.tpl')
 
 config_opts['target_arch'] = 'armv7hl'
 config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')

--- a/mock-core-configs/etc/mock/fedora-29-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-i386.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-29.tpl')
+include('templates/fedora-29.tpl')
 
 config_opts['target_arch'] = 'i686'
 config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')

--- a/mock-core-configs/etc/mock/fedora-29-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-29.tpl')
+include('templates/fedora-29.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/fedora-29-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-s390x.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-29.tpl')
+include('templates/fedora-29.tpl')
 
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/fedora-29-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-29-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-29.tpl')
+include('templates/fedora-29.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/fedora-30-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-30.tpl')
+include('templates/fedora-30.tpl')
 
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/fedora-30-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-armhfp.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-30.tpl')
+include('templates/fedora-30.tpl')
 
 config_opts['target_arch'] = 'armv7hl'
 config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')

--- a/mock-core-configs/etc/mock/fedora-30-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-i386.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-30.tpl')
+include('templates/fedora-30.tpl')
 
 config_opts['target_arch'] = 'i686'
 config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')

--- a/mock-core-configs/etc/mock/fedora-30-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-30.tpl')
+include('templates/fedora-30.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/fedora-30-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-s390x.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-30.tpl')
+include('templates/fedora-30.tpl')
 
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/fedora-30-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-30-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-30.tpl')
+include('templates/fedora-30.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/fedora-31-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-31-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-31.tpl')
+include('templates/fedora-31.tpl')
 
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/fedora-31-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-31-armhfp.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-31.tpl')
+include('templates/fedora-31.tpl')
 
 config_opts['target_arch'] = 'armv7hl'
 config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')

--- a/mock-core-configs/etc/mock/fedora-31-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-31-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-31.tpl')
+include('templates/fedora-31.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/fedora-31-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-31-s390x.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-31.tpl')
+include('templates/fedora-31.tpl')
 
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/fedora-31-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-31-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-31.tpl')
+include('templates/fedora-31.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/fedora-rawhide-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-rawhide.tpl')
+include('templates/fedora-rawhide.tpl')
 
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/fedora-rawhide-armhfp.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-armhfp.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-rawhide.tpl')
+include('templates/fedora-rawhide.tpl')
 
 config_opts['target_arch'] = 'armv7hl'
 config_opts['legal_host_arches'] = ('armv7l', 'armv8l', 'aarch64')

--- a/mock-core-configs/etc/mock/fedora-rawhide-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-rawhide.tpl')
+include('templates/fedora-rawhide.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/fedora-rawhide-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-s390x.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-rawhide.tpl')
+include('templates/fedora-rawhide.tpl')
 
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/fedora-rawhide-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/fedora-rawhide.tpl')
+include('templates/fedora-rawhide.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rhel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-7.tpl')
+include('templates/rhel-7.tpl')
 
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rhel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-ppc64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-7.tpl')
+include('templates/rhel-7.tpl')
 
 config_opts['target_arch'] = 'ppc64'
 config_opts['legal_host_arches'] = ('ppc64',)

--- a/mock-core-configs/etc/mock/rhel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-7.tpl')
+include('templates/rhel-7.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rhel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-7.tpl')
+include('templates/rhel-7.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rhel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-8.tpl')
+include('templates/rhel-8.tpl')
 
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rhel-8-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-ppc64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-8.tpl')
+include('templates/rhel-8.tpl')
 
 config_opts['target_arch'] = 'ppc64'
 config_opts['legal_host_arches'] = ('ppc64',)

--- a/mock-core-configs/etc/mock/rhel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-8.tpl')
+include('templates/rhel-8.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rhel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/rhel-8.tpl')
+include('templates/rhel-8.tpl')
 
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rhelepel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/rhel-8-aarch64.cfg')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/rhel-8-aarch64.cfg')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhelepel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/rhelepel-8-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-ppc64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/rhel-8-ppc64.cfg')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/rhel-8-ppc64.cfg')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhelepel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/rhelepel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/rhel-8-ppc64le.cfg')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/rhel-8-ppc64le.cfg')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhelepel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/rhelepel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/rhel-8-x86_64.cfg')
-include('/etc/mock/templates/epel-8.tpl')
+include('templates/rhel-8-x86_64.cfg')
+include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhelepel-8-{{ target_arch }}"

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -610,7 +610,6 @@ def main():
         config_path = options.configdir
 
     config_opts = util.load_config(config_path, options.chroot, uidManager, __VERSION__, PKGPYTHONDIR)
-    config_opts['config_path'] = config_path
 
     # cmdline options override config options
     util.set_config_opts_per_cmdline(config_opts, options, args)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1339,6 +1339,9 @@ def check_config(config_opts):
 
 @traceLog()
 def include(config_file, config_opts, is_statement=False):
+    if not os.path.isabs(config_file):
+        config_file = os.path.join(config_opts['config_path'], config_file)
+
     if os.path.exists(config_file):
         if is_statement and config_file in config_opts['config_paths']:
             getLog().warning("Multiple inclusion of %s, skipping" % config_file)
@@ -1461,6 +1464,7 @@ def load_config(config_path, name, uidManager, version, pkg_python_dir):
     config_opts = setup_default_config_opts(gid, version, pkg_python_dir)
 
     # array to save config paths
+    config_opts['config_path'] = config_path
     config_opts['config_paths'] = []
     config_opts['chroot_name'] = name
 


### PR DESCRIPTION
Fix #350

The point of this change is to use non-installed template files.

When `include` function is called on a file specified by an absolute
path, nothing changes. However, when a relative path is specified
(which for .tpl files now is), then the file is searched in multiple
possible locations:

1) The same directory where the .cfg config is
2) `templates` directory in the same location where .cfg config is
3) /etc/mock/templates