### PR TITLE
scrub bootstrap chroot accordingly

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -166,7 +166,7 @@ package and branch can be defined with \fB\-\-scm\-option\fP arguments,
 see site\-defaults.cfg for more information.
 .TP
 \fB\-\-scrub\fR=\fITYPE\fP
-Completely remove the specified chroot or cache dir or all of the chroot and cache.  \fITYPE\fR is one of all, chroot, cache, root\-cache, c\-cache, yum\-cache or dnf\-cache. In fact, dnf\-cache is just alias for yum\-cache, and both remove Dnf and Yum cache.
+Completely remove the specified chroot or cache dir or all of the chroot and cache.  \fITYPE\fR is one of all, chroot, bootstrap, cache, root\-cache, c\-cache, yum\-cache or dnf\-cache. In fact, dnf\-cache is just alias for yum\-cache, and both remove Dnf and Yum cache.
 .TP
 \fB\-\-shell\fP [\fICOMMAND [\fIARGS...]\fR]
 Run the specified command interactively within the chroot (no 'clean' is performed). If no command specified, /bin/sh is run. Note that COMMAND is shell expanded using the shell in chroot. Note that this command does not produce logs.

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -651,6 +651,10 @@ def main():
     state = State()
     plugins = Plugins(config_opts, state)
 
+    # When scrubbing all, we also want to scrub a bootstrap chroot
+    if options.scrub:
+        config_opts['use_bootstrap_container'] = True
+
     # outer buildroot to bootstrap the installation - based on main config with some differences
     bootstrap_buildroot = None
     if config_opts['use_bootstrap_container']:

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -147,7 +147,7 @@ def command_parse():
                       dest="mode",
                       help="completely remove the specified chroot")
     scrub_choices = ('chroot', 'cache', 'root-cache', 'c-cache', 'yum-cache',
-                     'dnf-cache', 'lvm', 'overlayfs', 'all')
+                     'dnf-cache', 'lvm', 'overlayfs', 'bootstrap', 'all')
     scrub_metavar = "[all|chroot|cache|root-cache|c-cache|yum-cache|dnf-cache]"
     parser.add_option("--scrub", action="callback", type="choice", default=[],
                       choices=scrub_choices, metavar=scrub_metavar,

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -134,6 +134,10 @@ class Commands(object):
                         self.buildroot.root_log.info("scrubbing yum-cache and dnf-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'yum_cache'), selinux=self.buildroot.selinux)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'dnf_cache'), selinux=self.buildroot.selinux)
+                    elif scrub == 'bootstrap' and self.bootstrap_buildroot is not None:
+                        self.buildroot.root_log.info("scrubbing bootstrap for %s", self.config_name)
+                        self.bootstrap_buildroot.delete()
+                        util.rmtree(self.bootstrap_buildroot.cachedir, selinux=self.bootstrap_buildroot.selinux)
 
             except IOError as e:
                 getLog().warning("parts of chroot do not exist: %s", e)

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -105,10 +105,12 @@ class Commands(object):
                 self.plugins.call_hooks('clean')
                 if self.bootstrap_buildroot is not None:
                     self.bootstrap_buildroot.plugins.call_hooks('clean')
+
                 for scrub in scrub_opts:
                     self.plugins.call_hooks('scrub', scrub)
                     if self.bootstrap_buildroot is not None:
                         self.bootstrap_buildroot.plugins.call_hooks('scrub', scrub)
+
                     if scrub == 'all':
                         self.buildroot.root_log.info("scrubbing everything for %s", self.config_name)
                         self.buildroot.delete()
@@ -119,34 +121,20 @@ class Commands(object):
                     elif scrub == 'chroot':
                         self.buildroot.root_log.info("scrubbing chroot for %s", self.config_name)
                         self.buildroot.delete()
-                        if self.bootstrap_buildroot is not None:
-                            self.bootstrap_buildroot.delete()
                     elif scrub == 'cache':
                         self.buildroot.root_log.info("scrubbing cache for %s", self.config_name)
                         util.rmtree(self.buildroot.cachedir, selinux=self.buildroot.selinux)
-                        if self.bootstrap_buildroot is not None:
-                            util.rmtree(self.bootstrap_buildroot.cachedir, selinux=self.bootstrap_buildroot.selinux)
                     elif scrub == 'c-cache':
                         self.buildroot.root_log.info("scrubbing c-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'ccache'), selinux=self.buildroot.selinux)
-                        if self.bootstrap_buildroot is not None:
-                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'ccache'),
-                                        selinux=self.bootstrap_buildroot.selinux)
                     elif scrub == 'root-cache':
                         self.buildroot.root_log.info("scrubbing root-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'root_cache'), selinux=self.buildroot.selinux)
-                        if self.bootstrap_buildroot is not None:
-                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'root_cache'),
-                                        selinux=self.bootstrap_buildroot.selinux)
                     elif scrub in ['yum-cache', 'dnf-cache']:
                         self.buildroot.root_log.info("scrubbing yum-cache and dnf-cache for %s", self.config_name)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'yum_cache'), selinux=self.buildroot.selinux)
                         util.rmtree(os.path.join(self.buildroot.cachedir, 'dnf_cache'), selinux=self.buildroot.selinux)
-                        if self.bootstrap_buildroot is not None:
-                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'yum_cache'),
-                                        selinux=self.bootstrap_buildroot.selinux)
-                            util.rmtree(os.path.join(self.bootstrap_buildroot.cachedir, 'dnf_cache'),
-                                        selinux=self.bootstrap_buildroot.selinux)
+
             except IOError as e:
                 getLog().warning("parts of chroot do not exist: %s", e)
                 raise


### PR DESCRIPTION
Fix #351

The `Commands.scrub` method requires `bootstrap_chroot` object initialized
in order to work with it. I.e. it doesn't scrub a bootstrap chroot unless
the `--bootstrap-chroot` parameter is set. Creating its own object inside
the method would duplicate a lot of existing code and doing it without the
object and its methods and properties is IMHO not a good idea.

Since the workaround for the #351 is

    mock -r <chroot> --bootstrap-chroot --scrub=all

we can just simply fix our parser to pretend like `--bootstrap-chroot`
was set, when using `--scrub`.