### PR TITLE
mock: selinuxfs && nspawn once more

### DIFF
--- a/mock/py/mockbuild/plugins/selinux.py
+++ b/mock/py/mockbuild/plugins/selinux.py
@@ -53,7 +53,8 @@ class SELinux(object):
 
         self.buildroot.mounts.add(BindMountPoint(srcpath=self.filesystems, bindpath=self.chrootFilesystems))
 
-        self.buildroot.mounts.add(
+        self.buildroot.mounts.essential_mounts.append(
+            # essential mounts since we _always_ need to hide it
             FileSystemMountPoint(filetype='tmpfs',
                                  device='mock_hide_selinux_fs',
                                  path=buildroot.make_chroot_path('/sys/fs/selinux'))


### PR DESCRIPTION
The /sys/fs/selinux mountpoint is by definition essential mount, and we
basically need to overmount it before we execute package manager.  Nb.,
see the original commit b8b721b76adb7ed7338066e6cb4f6a091b5fc675.

See also: fa1ddc50cf4ae86cdada5d2f539f4d2d3e3bca50
Fixes: rhbz#1756972