### PR TITLE
bootstrap: fix --install and --installdeps

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -726,6 +726,10 @@ def main():
     signal.signal(signal.SIGPIPE, partial(handle_signals, buildroot))
     signal.signal(signal.SIGHUP, partial(handle_signals, buildroot))
 
+    # postprocess option arguments for bootstrap
+    if options.mode in ['installdeps', 'install']:
+        args = [buildroot.file_on_cmdline(arg) for arg in args]
+
     log.info("Signal handler active")
     commands = Commands(config_opts, uidManager, plugins, state, buildroot, bootstrap_buildroot)
 

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -216,6 +216,7 @@ class Commands(object):
     def installSpecDeps(self, spec_file):
         try:
             # pylint: disable=no-member
+            spec_file = util.host_file(spec_file)
             spec = rpm.spec(spec_file).sourceHeader.dsFromHeader()
             self.uid_manager.becomeUser(0, 0)
             for i in range(len(spec)): # pylint: disable=consider-using-enumerate


### PR DESCRIPTION
To fix --install* options for bootstrap transparently, all the files
given on command-line need to be bind-mounted into bootstrap chroot so
they can be processed _inside_.

Since the files on command-line may be relative to cwd and we don't want
to create arbitrary directory structures within bootstrap buildroot, we
simply bind-mount the files into "home" directory.  The obvious
consequence is that multiple files with the same basename could clash
inside in the homedir, so we rather raise an error as soon as possible
instead of overmounting the same path.

Fixes: rhbz#1447627