### PR TITLE
compress_logs: setup defaults to 'gzip'

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -295,12 +295,11 @@
 # config_opts['plugin_conf']['pm_request_enable'] = False
 # config_opts['plugin_conf']['pm_request_opts'] = {}
 
-### If you want to compress mock log, enable this plugin
+### If you want to compress mock logs, enable this plugin
 # config_opts['plugin_conf']['compress_logs_enable'] = False
-# config_opts['plugin_conf']['compress_logs_opts'] = {}
 ### Command used to compress logs - e.g. "/usr/bin/xz -9 --force"
-# config_opts['plugin_conf']['compress_logs_opts']['command'] = ""
-#
+# config_opts['plugin_conf']['compress_logs_opts']['command'] = "gzip"
+
 # Configuration options for the sign plugin:
 # config_opts['plugin_conf']['sign_enable'] = False
 # config_opts['plugin_conf']['sign_opts'] = {}

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1036,6 +1036,11 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         'procenv_enable': False,
         'procenv_opts': {
         },
+        'compress_logs_enable': False,
+        'compress_logs_opts': {
+            'command': 'gzip',
+        },
+
     }
 
     config_opts['environment'] = {


### PR DESCRIPTION
Now it is enough to set 'compress_logs_enable' to True, and the plugin
should work (it has some defaults).  It is now even useless to require
users to set 'compress_logs_opts' to {} first, so drop that instructoin
from site-defaults.cfg.