### PR TITLE
chain: raise error for --localrepo without --chain

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -258,9 +258,8 @@ Enable networking. If you want to have reproducible builds then your builds shou
 This option overrides config_opts['rpmbuild_networking'] and config_opts['use_host_resolv'], setting both True.
 .TP
 \fB\-\-localrepo\fR=\fIREPO\fR\fR
-Set the path to put the results/repo in. This path needs to be somewhere
-accessible to users other than you for reading as the mock process doesn't run
-as you. Will make a tempdir if not set.
+Set the path to put the results/repo in (works only in \fB\-\-chain\fR mode).
+Will make a tempdir if not set.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Show usage information and exit.

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -212,7 +212,8 @@ def command_parse():
                                         "mounted from separate device (LVM/overlayfs)")
     # chain
     parser.add_option('--localrepo', default=None,
-                      help="local path for the local repo, defaults to making its own")
+                      help=("local path for the local repo, defaults to making "
+                            "its own (--chain mode only)"))
     parser.add_option('-c', '--continue', default=False, action='store_true',
                       dest='cont',
                       help="if a pkg fails to build, continue to the next one")
@@ -403,6 +404,11 @@ def command_parse():
         if not options.scm:
             raise mockbuild.exception.BadCmdline("Must specify both --spec and "
                                                  "--sources with --buildsrpm")
+
+    if options.localrepo and options.mode != 'chain':
+        raise mockbuild.exception.BadCmdline(
+            "The --localrepo option works only with --chain")
+
     if options.spec:
         options.spec = os.path.expanduser(options.spec)
     if options.sources:


### PR DESCRIPTION
While we are on it, drop ownership note in manual page (after
5df0a075ee5a the requirement is dropped).

Fixes: #375