### PR TITLE
Add 'kernel-rpm-macros' to centos-8.tpl

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -1,4 +1,4 @@
-config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep kernel-rpm-macros'
 config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'


### PR DESCRIPTION
This adds `kernel-rpm-macros` to the Centos 8 build root.  It is needed to provide the `%kernel_module_package_buildreqs` macro when building source RPMs for kernel modules.  This fix allows us to build the ZFS kmod source RPMs under Centos 8.
