### PR TITLE
buildroot: pre-create builddir before changing it's owner

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -470,6 +470,7 @@ class Buildroot(object):
         build_dirs = ['RPMS', 'SPECS', 'SRPMS', 'SOURCES', 'BUILD', 'BUILDROOT',
                       'originals']
         with self.uid_manager:
+            util.mkdirIfAbsent(self.make_chroot_path(self.builddir))
             self.uid_manager.changeOwner(self.make_chroot_path(self.builddir))
             for item in build_dirs:
                 path = self.make_chroot_path(self.builddir, item)


### PR DESCRIPTION
When we didn't create the directory first, the tolerant chown in
self.uid_manager.changeOwner ignored non-existent directory.  Later we
created the directory in mkdirs(builddir/SPECS) request anyways, but
we didn't change the owner anymore.

Reproducer:
$ touch empty.spec
$ mock --scrub=root-cache --scrub=chroot && mock -n --buildsrpm --spec=empty.spec --sources=.
...
PermissionError: [Errno 13] Permission denied: '/var/lib/mock/.../root/builddir/build/SOURCES'

Fixes: rhbz#1694420