### PR TITLE
bootstrap: drop shadow-utils from dnf_install_command for opensuse chroots

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
Fix: #395