### PR TITLE
clean: don't clean bootstrap chroot

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -91,8 +91,6 @@ class Commands(object):
             self.backup_results()
         self.state.start("clean chroot")
         self.buildroot.delete()
-        if self.bootstrap_buildroot is not None:
-            self.bootstrap_buildroot.delete()
         self.state.finish("clean chroot")
 
     @traceLog()


### PR DESCRIPTION
There's separate '--scrub=bootstrap' option, or '--scrub=all' for that,
but '--cleanup' semantics is to cleanup buildroot only (and not to
invalidate cached bootstrap).