### PR TITLE
configs: drop cost=2000 from fedora-31+-i386

### DIFF
--- a/mock-core-configs/etc/mock/fedora-31-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-31-i386.cfg
@@ -31,7 +31,6 @@ protected_packages=
 [local]
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/f31-build/latest/i386/
-cost=2000
 enabled=1
 skip_if_unavailable=False
 """

--- a/mock-core-configs/etc/mock/fedora-rawhide-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-rawhide-i386.cfg
@@ -32,14 +32,12 @@ protected_packages=
 [local]
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/i386
-cost=2000
 enabled=1
 skip_if_unavailable=False
 
 [local-source]
 name=local-source
 baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/src/
-cost=2000
 enabled=0
 skip_if_unavailable=False
 """


### PR DESCRIPTION
Those configs don't have more repos, so the cost override doesn't make
sense.