### PR TITLE
bootstrap: don't install distribution-gpg-keys pkg

### DIFF
--- a/mock-core-configs/etc/mock/templates/rhel-7.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-7.tpl
@@ -2,8 +2,8 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils f
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7Server'
 
-config_opts['dnf_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el7/noarch/distribution-gpg-keys-1.34-1.el7.noarch.rpm'
-config_opts['yum_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el7/noarch/distribution-gpg-keys-1.34-1.el7.noarch.rpm'
+config_opts['dnf_install_command'] += ' subscription-manager'
+config_opts['yum_install_command'] += ' subscription-manager'
 
 config_opts['root'] = 'rhel-7-{{ target_arch }}'
 

--- a/mock-core-configs/etc/mock/templates/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-8.tpl
@@ -4,8 +4,8 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 
-config_opts['dnf_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el8/noarch/distribution-gpg-keys-1.34-1.el8.noarch.rpm'
-config_opts['yum_install_command'] += ' subscription-manager https://kojipkgs.fedoraproject.org//packages/distribution-gpg-keys/1.34/1.el8/noarch/distribution-gpg-keys-1.34-1.el8.noarch.rpm'
+config_opts['dnf_install_command'] += ' subscription-manager'
+config_opts['yum_install_command'] += ' subscription-manager'
 
 config_opts['root'] = 'rhel-8-{{ target_arch }}'
 

--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -128,8 +128,8 @@
 
 # when 'use_bootstrap_container' is True, these commands are used to build
 # the minimal chroot for the respective package manager
-# config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
-# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
+# config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils'
+# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils'
 # config_opts['system_yum_command'] = '/usr/bin/yum'
 # config_opts['system_dnf_command'] = '/usr/bin/dnf'
 
@@ -399,7 +399,7 @@
 # config_opts['dnf_builddep_opts'] = []
 # config_opts['microdnf_command'] = '/usr/bin/microdnf'
 ## "dnf-install" is special keyword which tells mock to use install but with DNF
-# config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
+# config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core shadow-utils'
 # config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
 # config_opts['microdnf_builddep_opts'] = []
 # config_opts['microdnf_common_opts'] = []

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -205,7 +205,6 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
 
     @traceLog()
     def copy_distribution_gpg_keys(self):
-        # The bootstrap image frequently lacks distribution-gpg-keys.
         # Copy the files from the host to avoid invoking package manager
         # or rebuilding the cached bootstrap chroot.
         keys_path = "/usr/share/distribution-gpg-keys"

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1138,15 +1138,15 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     # configurable commands executables
     config_opts['yum_command'] = '/usr/bin/yum'
     config_opts['system_yum_command'] = '/usr/bin/yum'
-    config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils distribution-gpg-keys'
+    config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils'
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
     config_opts['dnf_command'] = '/usr/bin/dnf'
     config_opts['system_dnf_command'] = '/usr/bin/dnf'
-    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
+    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils'
     config_opts['microdnf_command'] = '/usr/bin/microdnf'
     # "dnf-install" is special keyword which tells mock to use install but with DNF
     config_opts['microdnf_install_command'] = \
-        'dnf-install microdnf dnf dnf-plugins-core shadow-utils distribution-gpg-keys'
+        'dnf-install microdnf dnf dnf-plugins-core shadow-utils'
     config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
     config_opts['microdnf_builddep_opts'] = []
     config_opts['microdnf_common_opts'] = []


### PR DESCRIPTION
We copy the gpg keys from host nowadays, and after 63ab868920e8c0 for
all bootstrap chroots (not only in bootstrap image case).

So make the '<PKGMANAGER>_install_command' config options simpler, and
lower repo-prerequisites (no need to have distribution-gpg-keys in
repository)

Complements: 63ab868920e8c0
Fixes: #380, #308 