### PR TITLE
bootstrap: don't install shadow-utils

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-aarch64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-i586.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-ppc64le.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-x86_64.cfg
@@ -8,7 +8,6 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u %(uid)s -g %(gid)s -d %(hom
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
-config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core distribution-gpg-keys'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -128,8 +128,8 @@
 
 # when 'use_bootstrap_container' is True, these commands are used to build
 # the minimal chroot for the respective package manager
-# config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils'
-# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils'
+# config_opts['yum_install_command'] = 'install yum yum-utils'
+# config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core'
 # config_opts['system_yum_command'] = '/usr/bin/yum'
 # config_opts['system_dnf_command'] = '/usr/bin/dnf'
 
@@ -399,7 +399,7 @@
 # config_opts['dnf_builddep_opts'] = []
 # config_opts['microdnf_command'] = '/usr/bin/microdnf'
 ## "dnf-install" is special keyword which tells mock to use install but with DNF
-# config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core shadow-utils'
+# config_opts['microdnf_install_command'] = 'dnf-install microdnf dnf dnf-plugins-core'
 # config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
 # config_opts['microdnf_builddep_opts'] = []
 # config_opts['microdnf_common_opts'] = []

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1138,15 +1138,15 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     # configurable commands executables
     config_opts['yum_command'] = '/usr/bin/yum'
     config_opts['system_yum_command'] = '/usr/bin/yum'
-    config_opts['yum_install_command'] = 'install yum yum-utils shadow-utils'
+    config_opts['yum_install_command'] = 'install yum yum-utils'
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
     config_opts['dnf_command'] = '/usr/bin/dnf'
     config_opts['system_dnf_command'] = '/usr/bin/dnf'
-    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core shadow-utils'
+    config_opts['dnf_install_command'] = 'install dnf dnf-plugins-core'
     config_opts['microdnf_command'] = '/usr/bin/microdnf'
     # "dnf-install" is special keyword which tells mock to use install but with DNF
     config_opts['microdnf_install_command'] = \
-        'dnf-install microdnf dnf dnf-plugins-core shadow-utils'
+        'dnf-install microdnf dnf dnf-plugins-core'
     config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
     config_opts['microdnf_builddep_opts'] = []
     config_opts['microdnf_common_opts'] = []


### PR DESCRIPTION
We don't actually need the mockbuild user in bootstrap, so stop doing
useradd (etc.) and drop 'shadow-utils' from *_install_command config
option.  This speeds the installroot transaction a bit, but also
the opensuse chroots don't have this package, so we needed to override
the configs before.

Relates: #395