### PR TITLE
mock: explicitly require distribution-gpg-keys

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -34,6 +34,7 @@ Requires: usermode
 %endif
 Requires: createrepo_c
 Requires: mock-core-configs >= 27.4
+Requires: distribution-gpg-keys
 %if 0%{?use_python2}
 Requires: pyliblzma
 %endif


### PR DESCRIPTION
There's transitive dependency through mock-core-configs, but it's better
to be explicit because --bootstrap-chroot now depends on this package
(mock-core-configs OTOH has the requires because it wants to enforce
proper version).