### PR TITLE
bootstrap: assure /bin/yum is from dnf-yum on el8

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -5,6 +5,7 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'centos:8'
 
+config_opts['yum_install_cmd'] = 'dnf-yum dnf-plugins-core'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-8.tpl
@@ -5,7 +5,7 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 
 config_opts['dnf_install_command'] += ' subscription-manager'
-config_opts['yum_install_command'] += ' subscription-manager'
+config_opts['yum_install_command'] = 'dnf-yum dnf-plugins-core subscription-manager'
 
 config_opts['root'] = 'rhel-8-{{ target_arch }}'
 


### PR DESCRIPTION
This is likely a bug caused by the fact that `--yum` option tells:
1. to use /bin/yum on host to install bootstrap
2. to install /bin/yum inside bootstrap to install normal chroot.

The problem of 1. is that a) in el8-bootstrap is that yum.rpm is not
easily installable (see #233) and b) that user typically doesn't want to
use /bin/yum in bootstrap to install dnf-capable system.

So 1. and 2. are two orthogonal things, and we should have two config
options for this (or use --yum only to affect host pkg manager
decision).

Fixes: #233