### PR TITLE
Fix package manager decisions

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -378,7 +378,9 @@
 # This is used by DNF and can be used in dnf.conf as $key and will be replaced by its value
 # config_opts['dnf_vars'] = { 'key': 'value', 'key2': 'value2' }
 #
-# Flip this if you want to get rid of warning message on systems which does not support DNF
+# Flip this if you want to get rid of warning message on systems which do not
+# support the desired package manager (e.g. when only Yum is available on host,
+# but the chosen buildroot expects to be installed via Dnf).
 # Warning! Setting this to False will automatically use Yum on RHEL{6,7} platforms.
 # config_opts['dnf_warning'] = True
 #

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -329,9 +329,6 @@ class Yum(_PackageManager):
         self.command = config['yum_command']
         self.install_command = config['yum_install_command']
         self.builddep_command = [config['yum_builddep_command']]
-        # the command in bootstrap may not exists yet
-        if bootstrap_buildroot is None:
-            self._check_command()
         if bootstrap_buildroot is not None:
             # we are in bootstrap so use old names
             self.command = '/usr/bin/yum'
@@ -353,6 +350,9 @@ class Yum(_PackageManager):
                     '--config', self.buildroot.make_chroot_path('etc', 'yum', 'yum.conf')]
             if os.path.exists(yum_builddep_deprecated_path):
                 self.builddep_command = ['/usr/bin/yum-builddep-deprecated']
+        # the command in bootstrap may not exists yet
+        if bootstrap_buildroot is None:
+            self._check_command()
 
     @traceLog()
     def _write_plugin_conf(self, name):

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -89,7 +89,7 @@ in Mock config.""".format(desired.upper(), manager.upper()))
 
 
 def package_manager_class(config_opts, buildroot, bootstrap_buildroot=None):
-    pm = config_opts.get('package_manager', 'yum')
+    pm = config_opts.get('package_manager', 'dnf')
 
     if buildroot.is_bootstrap:
         # pkgmanager _to install_ bootstrap.  we don't care about the package

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -39,6 +39,11 @@ def package_manager_exists_on_host(name, config_opts):
     option = '{}_command'.format(name)
     pathname = config_opts[option]
     if not os.path.isfile(pathname):
+        if pathname == '/usr/bin/yum':
+            # only _exact_ match here, with custom config like
+            # /usr/local/bin/yum user must know where yum is
+            if os.path.isfile('/usr/bin/yum-deprecated'):
+                return True
         return False
     real_pathname = os.path.realpath(pathname)
     # resolve symlinks, and detect that e.g. /bin/yum doesn't point to /bin/dnf


### PR DESCRIPTION
Fixes #233.

From commits:
```
1) More careful package management choice

Previously we only warned when 'dnf' was expected for chroot
initialization, but wasn't available.  Now we detect this situation also
for other package managers (e.g. missing /bin/yum, etc.).

When installing bootstrap chroot, we aren't anymore that much picky
about host pkg manager.  This means that '/bin/yum' doesn't have to be
installed at all on host to install yum-based bootstrap, but more
importantly '/bin/dnf' doesn't have to exist on YUM based hosts when
installing DNF based chroots.  This should demotivate users from using
'--yum' option on YUM based options to install bootstrap (#233).

2)  Detect '/bin/yum' symlink to 'dnf'

In such case we actually talk to 'dnf', and it doesn't make any sense to
instantiate Yum class.  This is generalized to other package managers
as well, even though it is less likely to happen.
```