### PR TITLE
mock: create builddir on proper place

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -491,8 +491,8 @@ class Buildroot(object):
     def _setup_build_dirs(self):
         build_dirs = ['RPMS', 'SPECS', 'SRPMS', 'SOURCES', 'BUILD', 'BUILDROOT',
                       'originals']
+        util.mkdirIfAbsent(self.make_chroot_path(self.builddir))
         with self.uid_manager:
-            util.mkdirIfAbsent(self.make_chroot_path(self.builddir))
             self.uid_manager.changeOwner(self.make_chroot_path(self.builddir))
             for item in build_dirs:
                 path = self.make_chroot_path(self.builddir, item)


### PR DESCRIPTION
When we still have a root uid, before 'uid_manager.__enter__' call.

Complements: 712fe3c3257bbf2bd0e60cc9d8ca2c177a05afa2