### PR TITLE
mock: re-render jinja in configuration

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -155,8 +155,15 @@ class TemplatedDictionary(MutableMapping):
         else:
             return value
     def __render_string(self, value):
-        template = jinja2.Template(value)
-        return _to_native(template.render(self.__dict__))
+        orig = last = value
+        max_recursion = self.__dict__.get('jinja_max_recursion', 5)
+        for _ in range(max_recursion):
+            template = jinja2.Template(value)
+            value = _to_native(template.render(self.__dict__))
+            if value == last:
+                return value
+            last = value
+        raise ValueError("too deep jinja re-evaluation on '{}'".format(orig))
 
 
 #def _to_bytes(obj, arg_encoding='utf-8', errors='strict', nonstring='strict'):


### PR DESCRIPTION
We previously allowed only one level of jinja expansion.  This is not
enough nowadays after the "jinjification" series of commits starting
with 559516800938.

E.g. hw_info plugin initialization seemed to triggered problems (#422)
by accessing (and mkdir) self.buildroot.resultdir.  That property is
defined like:

    buildroot.resultdir = config['resultdir'] % config

while the related jinja values look like (for fedora-rawhide-x86_64):

    'resultdir'   => '{{basedir}}/{{root}}/result'
    'root'        => 'fedora-rawhide-{{ target_arch }}''
    'target_arch' => 'x86_64'

so with the single-level expansion the buildroot.resultdir was
e.g. '/var/lib/mock/fedora-rawhide-{{ target_arch }}'.