### PR TITLE
jinja earlier

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -640,12 +640,7 @@ def main():
     # cmdline options override config options
     util.set_config_opts_per_cmdline(config_opts, options, args)
 
-    # setup 'redhat_subscription_key_id' option before enabling jinja
     util.subscription_redhat_init(config_opts)
-
-    # Now when all options are correctly loaded from config files and program
-    # options, turn the jinja templating ON.
-    config_opts['__jinja_expand'] = True
 
     # allow a different mock group to be specified
     if config_opts['chrootgid'] != mockgid:

--- a/mock/py/mockbuild/plugins/lvm_root.py
+++ b/mock/py/mockbuild/plugins/lvm_root.py
@@ -86,7 +86,7 @@ class LvmPlugin(object):
         self.basepath = buildroot.mockdir
         self.snap_info = os.path.join(self.basepath, snapinfo_name)
         self.lock = self.create_lock('lvm')
-        self.pool_lock = self.create_lock('lmv-pool')
+        self.pool_lock = self.create_lock('lvm-pool')
         self.mount = None
 
         prefix = 'hook_'

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1532,6 +1532,11 @@ def load_config(config_path, name, uidManager, version, pkg_python_dir):
 
     if config_opts['use_container_host_hostname'] and '%_buildhost' not in config_opts['macros']:
         config_opts['macros']['%_buildhost'] = socket.getfqdn()
+
+    # Now when all options are correctly loaded from config files, turn the
+    # jinja templating ON.
+    config_opts['__jinja_expand'] = True
+
     return config_opts
 
 


### PR DESCRIPTION
    config: turn ON the jinja rendering a bit earlier
    
    We need to turn on the jinja rendering before we call the
    set_config_opts_per_cmdline() function because some code there might
    easily want to read some config option with not-yet-rendered value.
    
    For example, we were bitten by the 'cleanup_on_success' decisions in
    set_config_opts_per_cmdline(); the check [1] whether resultdir resides
    below basedir gave us wrong answers because it worked with wrong data:
    
        resultdir = {{basedir}}/{{root}}/result
        rootdir   = /var/lib/mock/fedora-rawhide-{{ target_arch }}
    
    .. and the result was that for successful build we removed the basedir
    together with resultdir containing successfully built RPMs.
    
    [1] https://github.com/rpm-software-management/mock/blob/\
        7a3bdb2fd135eefb04d74ef1db34eeedad1a16a2/\
        mock/py/mockbuild/util.py#L1327

