### PR TITLE
don't override defaults for USE_NSPAWN

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -322,7 +322,6 @@ def command_parse():
                       default=False,
                       help="Obsoleted. Use --isolation=nspawn")
     parser.add_option("--isolation", action="store", dest="isolation",
-                      default="nspawn",
                       help="what level of isolation to use. Valid option: simple, nspawn")
     parser.add_option("--enable-network", action="store_true", dest="enable_network",
                       default=False,

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1298,13 +1298,15 @@ def set_config_opts_per_cmdline(config_opts, options, args):
     if options.new_chroot:
         USE_NSPAWN = True
         log.error('Option --new-chroot has been deprecated. Use --isolation=nspawn instead.')
-    if options.isolation == 'simple':
-        USE_NSPAWN = False
-    elif options.isolation == 'nspawn':
-        USE_NSPAWN = True
-    else:
-        raise exception.BadCmdline("Bad option for '--isolation'. Unknown value: %s"
-                                   % (options.isolation))
+
+    if options.isolation is not None:
+        if options.isolation == 'simple':
+            USE_NSPAWN = False
+        elif options.isolation == 'nspawn':
+            USE_NSPAWN = True
+        else:
+            raise exception.BadCmdline("Bad option for '--isolation'. Unknown value: %s"
+                                       % (options.isolation))
 
     if options.enable_network:
         config_opts['rpmbuild_networking'] = True


### PR DESCRIPTION
So the configuration is respected, and the obsoleted options
--old-chroot and --new-chroot still work.