### PR TITLE
mock-core-configs: fix epel-6.tpl config bug

### DIFF
--- a/mock-core-configs/etc/mock/epel-6-i386.cfg
+++ b/mock-core-configs/etc/mock/epel-6-i386.cfg
@@ -1,4 +1,4 @@
-include('/home/thrnciar/mock/mock-core-configs/etc/mock/templates/epel-6.tpl')
+include('templates/epel-6.tpl')
 
 config_opts['root'] = 'epel-6-i386'
 config_opts['target_arch'] = 'i686'

--- a/mock-core-configs/etc/mock/epel-6-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-ppc64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/epel-6.tpl')
+include('templates/epel-6.tpl')
 
 config_opts['root'] = 'epel-6-ppc64'
 config_opts['target_arch'] = 'ppc64'

--- a/mock-core-configs/etc/mock/epel-6-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/epel-6.tpl')
+include('templates/epel-6.tpl')
 
 config_opts['root'] = 'epel-6-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/mock-core-configs/etc/mock/templates/epel-6.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-6.tpl
@@ -50,22 +50,22 @@ gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-6
 gpgcheck=1
 skip_if_unavailable=False
 
-{% if basearch == "x86_64" %}
-    [sclo]
-    name=sclo
-    baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
-    gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
-    gpgcheck=1
-    includepkgs=devtoolset*
-    skip_if_unavailable=False
+{% if target_arch == "x86_64" %}
+[sclo]
+name=sclo
+baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
 
-    [sclo-rh]
-    name=sclo-rh
-    baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/rh/
-    gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
-    gpgcheck=1
-    includepkgs=devtoolset*
-    skip_if_unavailable=False
+[sclo-rh]
+name=sclo-rh
+baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/rh/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
+gpgcheck=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
 {% endif %}
 
 [testing]


### PR DESCRIPTION
The indent broke dnf, and 'basearch' config option doesn't exist.

Complements: 564552e441afca0b6dcca651ff7f868421ccbafd