### PR TITLE
configs: drop long time useless epel-6-ppc64

### DIFF
--- a/mock-core-configs/etc/mock/epel-6-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-6-ppc64.cfg
@@ -1,5 +1,0 @@
-include('templates/epel-6.tpl')
-
-config_opts['root'] = 'epel-6-ppc64'
-config_opts['target_arch'] = 'ppc64'
-config_opts['legal_host_arches'] = ('ppc64',)


### PR DESCRIPTION
There's no ppc64 mirror working for centos-6 nowadays.

Relates: #452