### PR TITLE
nspawn: better handle --console=pipe

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -662,16 +662,6 @@ def main():
         os.setgroups((mockgid, config_opts['chrootgid']))
         uidManager.dropPrivsTemp()
 
-    if util.USE_NSPAWN and '--pipe' not in config_opts['nspawn_args']:
-        # Detect if host's systemd-nspawn supports --pipe argument and use it.
-        # Before --pipe was implemented in nspawn, the default behavoior was
-        # the same as later with --pipe.
-        output = subprocess.check_output('systemd-nspawn --help || true',
-                                         shell=True)
-        output = output.decode('utf-8', errors='ignore')
-        if '--pipe' in output and '--console' in output:
-            config_opts['nspawn_args'] += ['--pipe']
-
     # verify that our unprivileged uid is in the mock group
     groupcheck(uidManager.unprivGid, config_opts['chrootgid'])
 


### PR DESCRIPTION
We can not use `--pipe` globally to not break interactive shell in
--shell mode.  So with new systemd-nspawn mimic the behavior of old
systemd-nspawn.

Complements: b1b5730c6d584f98abc901693c547d7d0910e92b
Relates: #432
Fixes: #459