### PR TITLE
host overrides

### DIFF
--- a/mock-core-configs/etc/host-overrides/README
+++ b/mock-core-configs/etc/host-overrides/README
@@ -1,0 +1,9 @@
+directories in this folder should be named:
+  rhel-%{rhel}
+  fedora-%{fedora}
+  ...
+and are in SPEC files appended to config. E.g
+  host-override/fedora-%{fedora}/fedora-31-x86_64.cfg
+is appended to
+  mock/fedora-31-x86_64.cfg
+if we are building for fedora-%{fedora}

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-aarch64.cfg
@@ -1,0 +1,1 @@
+config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-armhfp.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-i386.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-aarch64.cfg
@@ -1,0 +1,1 @@
+config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-armhfp.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-i386.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-aarch64.cfg
@@ -1,0 +1,1 @@
+config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-armhfp.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-i386.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-aarch64.cfg
@@ -1,0 +1,1 @@
+config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-armhfp.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-i386.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-aarch64.cfg
@@ -1,0 +1,1 @@
+config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-armhfp.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-i386.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-aarch64.cfg
@@ -1,0 +1,1 @@
+config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-armhfp.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-i386.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -49,7 +49,22 @@ Config files which allow you to create chroots for:
 
 
 %build
-# nothing to do here
+cd etc/host-overrides
+HOST=none
+%if 0%{?fedora}
+HOST="fedora-%{fedora}"
+%endif
+%if 0%{?rhel}
+HOST="rhel-%{rhel}"
+%endif
+
+if [ -d "$HOST" ]; then
+  pushd "$HOST"
+  for i in *.cfg; do
+    cat "$i" >> "../../mock/$i"
+  done
+  popd
+fi
 
 
 %install


### PR DESCRIPTION
directories in `etc/host-overrides` folder should be named:
  rhel-%{rhel}
  fedora-%{fedora}
  ...
and are in SPEC files appended to config. E.g
  etc/host-override/fedora-30/fedora-31-x86_64.cfg
is appended to
  etc/mock/fedora-31-x86_64.cfg
if we are building mock-core-configs package for fedora-30