### PR TITLE
mock: use_bootstrap_container=True default

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -123,7 +123,7 @@
 # that chroot to make the actual build chroot, set this to True.
 # This is useful when the target may require newer RPM features
 # than are available on the host.
-# config_opts['use_bootstrap_container'] = False
+# config_opts['use_bootstrap_container'] = True
 
 # when 'use_bootstrap_container' is True, these commands are used to build
 # the minimal chroot for the respective package manager

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -972,7 +972,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['rpmbuild_networking'] = False
     config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
     config_opts['use_container_host_hostname'] = True
-    config_opts['use_bootstrap_container'] = False
+    config_opts['use_bootstrap_container'] = True
 
     config_opts['use_bootstrap_image'] = False
     config_opts['bootstrap_image'] = 'fedora:latest'


### PR DESCRIPTION
.. again, after some time.  The residual issues should be fixed now, and
the mock caches were enhanced to make this less obtrusive (PR#365).

Switching per discussion/announcement in:
https://lists.fedoraproject.org/archives/list/\
buildsys@lists.fedoraproject.org/thread/XHTQD4AAAEGPTDPQ2TCGXUCY3MAC52G2/