### PR TITLE
mock: print stdout/stderr if 'install_srpm' failed

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -646,7 +646,8 @@ class Commands(object):
                                 shell=False, uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
                                 user=self.buildroot.chrootuser,
                                 nspawn_args=self._get_nspawn_args(),
-                                unshare_net=self.private_network)
+                                unshare_net=self.private_network,
+                                returnOutput=True)
 
     @traceLog()
     def rebuild_installed_srpm(self, spec_path, timeout):


### PR DESCRIPTION
It is kind of strange to use returnOutput=True here when we don't
actually use the output in caller, but this parameter also causes that
the raised exception (in case of command failure) contains both stderr
and stdout.  As a result, mock ends with very clear error:

    /usr/bin/systemd-nspawn -q -M 0f25244d38ab4d32a46a109813628224 -D
    ... all the nspawn args ....
    /bin/rpm -Uvh --nodeps /builddir/build/originals/python-copr-1.100-1.git.36.dff5221.fc31.src.rpm
    error: Missing rpmlib features for python-copr-1.100-1.git.36.dff5221.fc31.noarch:
    error:  rpmlib(DynamicBuildRequires) <= 4.15.0-1
    error: /builddir/build/originals/python-copr-1.100-1.git.36.dff5221.fc31.src.rpm cannot be installed

Instead of:

    /usr/bin/systemd-nspawn -q -M 0f25244d38ab4d32a46a109813628224 -D
    ... all the nspawn args ....
    /bin/rpm -Uvh --nodeps /builddir/build/originals/python-copr-1.100-1.git.36.dff5221.fc31.src.rpm

Fixes: #461