### PR TITLE
chain: fix mockchain with --bootstrap-chroot

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -154,19 +154,8 @@ class Commands(object):
     def init(self, **kwargs):
         try:
             if self.bootstrap_buildroot is not None:
-                # add the extra bind mount to the outer chroot
-                inner_mount = self.bootstrap_buildroot.make_chroot_path(self.buildroot.make_chroot_path())
                 util.mkdirIfAbsent(self.buildroot.make_chroot_path())
                 self.bootstrap_buildroot.initialize(**kwargs)
-                # Hide re-mounted chroot from host by rprivate tmpfs.
-                self.buildroot.mounts.managed_mounts.append(
-                    FileSystemMountPoint(filetype='tmpfs',
-                                         device='hide_root_in_bootstrap',
-                                         path=inner_mount,
-                                         options="rprivate"))
-                self.buildroot.mounts.managed_mounts.append(
-                    BindMountPoint(self.buildroot.make_chroot_path(), inner_mount,
-                                   recursive=True))
             self.buildroot.initialize(**kwargs)
             if not self.buildroot.chroot_was_initialized:
                 self._show_installed_packages()


### PR DESCRIPTION
The chroot mount into bootstrap chroot was added to 'managed_mounts' for
each build.  So the final managed_mounts array grow and got mixed order,
.. and the main chroot directory become invisible eventually
(overmounted by empty tmpfs filesystem).

So now, move the managed_mounts.append() call to place where it is going
to be executed only once, even for --chain mode.

I tested mockchain before - and I thought that mockchain works fine with
--bootstrap-chroot, but I was confused because I had
`plugin_conf.tmpfs_opts.keep_mounted=True` configuration and this
effectively hides this bug.

Fixes: #469