### PR TITLE
allow --install /usr/bin/time [GH#474]

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -706,8 +706,11 @@ class Buildroot(object):
         if not bootstrap:
             return filename
 
-        if not os.path.exists(filename):
+        # optimized of
+        # not os.path.exists(filename) or not filename.lower().endswith('.rpm')
+        if not (os.path.exists(filename) and filename.lower().endswith('.rpm')):
             # probably just '--install pkgname'
+            # or '--install /usr/bin/time'
             return filename
 
         basename = os.path.basename(filename)


### PR DESCRIPTION
do not modify argument if the file exist, but argument does not have *rpm extension.

It works now for:

--install zsh
--install mock.rpm
--install /usr/bin/time

Fixes: #474