### PR TITLE
mock: fix dynamic buildrequires unnecesarry loop

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -708,6 +708,7 @@ class Commands(object):
                 except Error as e:
                     if e.resultcode != 11:
                         raise e
+                finally:
                     max_loops -= 1
                     self.buildroot.root_log.info("Dynamic buildrequires detected")
                     self.buildroot.root_log.info("Going to install missing buildrequires")


### PR DESCRIPTION
per discussion here: https://github.com/rpm-software-management/rpm/issues/963
Mock should accept return code 0 from rpm.

Relates: #434