### PR TITLE
mock: 'dnf.conf' is equivalent to 'yum.conf'

### DIFF
--- a/mock/tests/test_config_templates.py
+++ b/mock/tests/test_config_templates.py
@@ -9,3 +9,28 @@ def test_transitive_expand():
     assert config['c'] == '{{ b + " " + b }}'
     config['__jinja_expand'] = True
     assert config['c'] == 'test test test test'
+
+
+def test_aliases():
+    config = TemplatedDictionary(
+        alias_spec={
+            'dnf.conf': ['yum.conf', 'package_manager.conf'],
+        },
+    )
+
+    config['dnf.conf'] = "initial"
+    config['yum.conf'] += " appended"
+
+    config['__jinja_expand'] = True
+    assert config['package_manager.conf'] == "initial appended"
+    config['__jinja_expand'] = False
+
+    config['package_manager.conf'] = "replaced"
+
+    config['__jinja_expand'] = True
+    assert config['dnf.conf'] == config['yum.conf'] == 'replaced'
+
+    config['variable'] = "content"
+    config['package_manager.conf'] += " {{ variable }}"
+
+    assert config['dnf.conf'] == config['yum.conf'] == 'replaced content'


### PR DESCRIPTION
    mock: 'dnf.conf' is equivalent to 'yum.conf'
    
    Resolves: rhbz#1806039
    Relates: https://pagure.io/copr/copr/pull-request/1275
    Related discussions:
    https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2020-4f9536de5b
    https://pagure.io/koji/issue/2026
    https://lists.fedoraproject.org/archives/list/\
    devel@lists.fedoraproject.org/thread/IRMM6UYHRWOI3YM6IE4DTTV4YWF3J7G2/
