### PR TITLE
sign-plugin: use %(rpms) variable expansion again

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -308,9 +308,9 @@
 # config_opts['plugin_conf']['sign_enable'] = False
 # config_opts['plugin_conf']['sign_opts'] = {}
 # config_opts['plugin_conf']['sign_opts']['cmd'] = 'rpmsign'
-# The options to pass to the signing command. {{rpms}} will be expanded to
+# The options to pass to the signing command. %(rpms)s will be expanded to
 # the rpms in the results folder.
-# config_opts['plugin_conf']['sign_opts']['opts'] = '--addsign {{rpms}} -D "%%_gpg_name your_name" -D "%%_gpg_path /home/your_name/.gnupg"'
+# config_opts['plugin_conf']['sign_opts']['opts'] = '--addsign %(rpms)s -D "%%_gpg_name your_name" -D "%%_gpg_path /home/your_name/.gnupg"'
 
 #############################################################################
 #

--- a/mock/integration-tests/19-sign-plugin.tst
+++ b/mock/integration-tests/19-sign-plugin.tst
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+
+: "${MOCKCMD=mock}"
+if test -z "$TESTDIR"; then
+    TESTDIR=$(dirname "$(readlink -f "$0")")
+fi
+
+. ${TESTDIR}/functions
+
+header "testing that sign plugin works"
+
+confdir=$HOME/.config
+mkdir -p "$confdir"
+
+case $(rpm --eval "%__gpg") in
+    *gpg-mock) ;;
+    *) die "you need to run prepare-user.sh first" ;;
+esac
+
+
+local_config=$confdir/mock.cfg
+
+test -f "$local_config" && die "please remove $local_config first"
+
+TMPDIR=$(mktemp -d) || die "can't create temporary directory"
+
+cat > "$local_config" <<EOF
+config_opts['plugin_conf']['sign_enable'] = True
+config_opts['plugin_conf']['sign_opts'] = {}
+config_opts['plugin_conf']['sign_opts']['cmd'] = 'rpmsign'
+# For the future: Even if change the default, please keep this line
+# so we check compatibility.
+config_opts['plugin_conf']['sign_opts']['opts'] = '--addsign %(rpms)s'
+EOF
+cleanup() {
+    rm "$local_config"
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+runcmd "$MOCKCMD --rebuild ${TESTDIR}/test-C-1.1-0.src.rpm --resultdir $TMPDIR" \
+    || die "mock rebuild failed"
+
+rpmoutput=$(rpm --qf '%{NAME} %{SIGPGP:pgpsig}\n' -qp "$TMPDIR"/*.rpm 2>/dev/null)
+lines=0
+while read -r line; do
+    case $line in
+        *"Key ID"*) ;;
+        *) die "some packages are not signed" ;;
+    esac
+    lines=$(( lines + 1 ))
+done <<<"$rpmoutput"
+
+test $lines -eq 2 || die "two packages are expected to be signed"
+
+exit 0

--- a/mock/integration-tests/functions
+++ b/mock/integration-tests/functions
@@ -15,3 +15,4 @@ runcmd() {
     return $ret
 }
 
+die () { echo >&2 "ERROR: $*" ; exit 1 ; }

--- a/mock/integration-tests/prepare/README
+++ b/mock/integration-tests/prepare/README
@@ -1,0 +1,16 @@
+============================================
+Prepare (destructively) box for mock testing
+============================================
+
+WARNING:  Scripts in this directory modify your machine!  Always execute on
+          machine which will be disposed.
+
+Scripts
+-------
+
+'prepare-user.sh' - This script is meant to be executed right after creating
+        a new separate user for testing mock.  Typically:
+            useradd testuser
+            usermod -a -G mock testuser
+            su - testuser
+            $ ./prepare-user.sh

--- a/mock/integration-tests/prepare/prepare-user.sh
+++ b/mock/integration-tests/prepare/prepare-user.sh
@@ -1,0 +1,68 @@
+#! /bin/bash
+
+ask_yes() {
+    read -p "$* [y/N] " -n 1 -r
+    echo
+    case $REPLY in
+        y|Y) true  ;;
+        *)   false ;;
+    esac
+}
+
+die()  { echo >&2 "$*"    ; exit 1 ; }
+info() { echo >&2 " * $*" ; }
+
+test "$(id -u -n)" != root || die "don't run this as root"
+
+ask_yes "This is going to DESTRUCTIVELY configure this user account." \
+        "Do you want to continue?" || die "-> stopped"
+
+# re-create workdir
+workdir="$HOME/.mocktests"
+rm -rf "$workdir"
+mkdir -p "$workdir"
+
+
+info "Prepare sign plugin"
+rpmmacros=$HOME/.rpmmacros
+rm -f "$rpmmacros"
+
+gpgdir=$workdir/gpg
+mkdir "$gpgdir"
+chmod 0700 "$gpgdir"
+
+# generate gpg key without password
+cat > "$workdir/gpg-batch" <<EOF
+%echo Generating a basic OpenPGP key
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: John Doe
+Name-Email: jdoe@foo.com
+Expire-Date: 0
+Passphrase: redhat
+%commit
+%echo done
+EOF
+
+gpg=$workdir/gpg-mock
+cat > "$gpg" <<EOF
+#! /bin/sh
+
+echo -n >&2 "running: \$0 "
+for arg; do
+    echo -n >&2 "\$(printf %q "\$arg") "
+done
+echo
+exec /usr/bin/gpg --homedir "$gpgdir" "\$@"
+EOF
+chmod +x "$gpg"
+
+"$gpg" --batch --generate-key "$workdir/gpg-batch"
+
+cat > "$rpmmacros" <<EOF
+# GENERATED AUTOMATICALLY by $0
+# from man(8) rpmsign
+%_gpg_name John Doe <jdoe@foo.com>
+%__gpg $gpg
+EOF

--- a/mock/py/mockbuild/plugins/sign.py
+++ b/mock/py/mockbuild/plugins/sign.py
@@ -36,9 +36,8 @@ class Sign(object):
             rpms = [os.path.join(self.buildroot.resultdir, rpm) for rpm in self.buildroot.final_rpm_list]
             if rpms:
                 getLog().info("Signing %s", ', '.join(rpms))
-                self.conf['rpms'] = ' '.join(rpms)
-                cmd = "{0} {1}".format(self.conf['cmd'], self.conf['opts'])
-                del self.conf['rpms']
+                opts = self.conf['opts'] % {'rpms': ' '.join(rpms), 'resultdir': self.buildroot.resultdir}
+                cmd = "{0} {1}".format(self.conf['cmd'], opts)
                 getLog().info("Executing %s", cmd)
                 with self.buildroot.uid_manager:
                     subprocess.call(cmd, shell=True, env=os.environ)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1083,7 +1083,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         'sign_enable': False,
         'sign_opts': {
             'cmd': 'rpmsign',
-            'opts': '--addsign {{rpms}}',
+            'opts': '--addsign %(rpms)s',
         },
         'hw_info_enable': True,
         'hw_info_opts': {


### PR DESCRIPTION
It is non-trivial to assure that {{ rpms }} specified in mock
configuration isn't expanded (to empty string) too early.  Proper
solution to that will take some time, so for now revert back to the
%(rpms) syntax.

We should stay compatible with %(rpms) if we decided to move to
{{ rpms }} again in future.

Add integration test for rpmsign, plus preparation script.

This reverts commit d44ec018b59822c8ba6dcffb0002148b57a69457.

Fixes: #476, rhbz#1806577