### PR TITLE
lvm_root: drop hack related to bootstrap

### DIFF
--- a/mock/integration-tests/20-lvm-plugin.tst
+++ b/mock/integration-tests/20-lvm-plugin.tst
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+
+: "${MOCKCMD=mock}"
+if test -z "$TESTDIR"; then
+    TESTDIR=$(dirname "$(readlink -f "$0")")
+fi
+
+. ${TESTDIR}/functions
+
+header "testing that lvm plugin works"
+
+confdir=$HOME/.config
+mkdir -p "$confdir"
+
+test -f "/test-lvm-disk" || die "Please run prepare-lvm.sh first"
+
+local_config=$confdir/mock.cfg
+
+test -f "$local_config" && die "please remove $local_config first"
+
+TMPDIR=$(mktemp -d) || die "can't create temporary directory"
+
+cat > "$local_config" <<EOF
+config_opts['plugin_conf']['root_cache_enable'] = False
+config_opts['plugin_conf']['lvm_root_enable'] = True
+config_opts['plugin_conf']['lvm_root_opts'] = {
+    'volume_group': 'mock',
+    'size': '4G',
+    'pool_name': 'pool',
+    'umount_root': False
+}
+EOF
+
+cleanup() {
+    rm "$local_config"
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+runcmd "$MOCKCMD --rebuild ${TESTDIR}/test-C-1.1-0.src.rpm --resultdir $TMPDIR" \
+    || die "mock rebuild failed"
+
+runcmd "$MOCKCMD --shell '/bin/true'" || die "mock shell failed"
+
+runcmd "$MOCKCMD --scrub=all" || die "mock scrub failed"
+
+# repeated run should succeed as well, rhbz#1805179
+runcmd "$MOCKCMD --scrub=all" || die "mock scrub failed"
+
+exit 0

--- a/mock/integration-tests/20-lvm-plugin.tst
+++ b/mock/integration-tests/20-lvm-plugin.tst
@@ -48,4 +48,7 @@ runcmd "$MOCKCMD --scrub=all" || die "mock scrub failed"
 # repeated run should succeed as well, rhbz#1805179
 runcmd "$MOCKCMD --scrub=all" || die "mock scrub failed"
 
+test "$(find /var/lib/mock -maxdepth 1 -name '*.lock' | wc -l)" -eq 0 || \
+    die "there are lock files leftovers"
+
 exit 0

--- a/mock/integration-tests/prepare/README
+++ b/mock/integration-tests/prepare/README
@@ -14,3 +14,7 @@ Scripts
             usermod -a -G mock testuser
             su - testuser
             $ ./prepare-user.sh
+
+'prepare-lvm.sh' - The script creates /test-lvm-disk file and loop device from
+        that file to be used as lvm storage.  You'll need this to execute this
+        as root before running 20-lvm-plugin.tst.

--- a/mock/integration-tests/prepare/prepare-lvm.sh
+++ b/mock/integration-tests/prepare/prepare-lvm.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+
+die()  { echo >&2 "$*"    ; exit 1 ; }
+
+set -x
+set -e
+
+test "$(id -u -n)" = root || die "this needs to be run as root"
+
+filename=/test-lvm-disk
+
+if test -f "$filename"; then
+    die "file $filename already exists, did you run this script before?"
+fi
+
+dd if=/dev/zero of="$filename" bs=1M count=8000
+device=$(losetup -f "$filename" --show)
+pvcreate "$device"
+vgcreate mock "$device"

--- a/mock/py/mockbuild/plugins/lvm_root.py
+++ b/mock/py/mockbuild/plugins/lvm_root.py
@@ -255,14 +255,6 @@ class LvmPlugin(object):
                         self.force_umount_root()
             self.mount = mounts.FileSystemMountPoint(self.root_path, self.fs_type,
                                                      lv_path, options=mount_options)
-        # If there is a bind mount of the root into bootstrap buildroot,
-        # replace it with mount of the actual filesystem. This is necessary to
-        # prevent shared mount propagation from unmounting it later on
-        for i, mount in enumerate(self.buildroot.mounts.managed_mounts):
-            if mount.mountsource == self.root_path:
-                newmount = mounts.FileSystemMountPoint(mount.mountpath, self.fs_type,
-                                                       lv_path, options=mount_options)
-                self.buildroot.mounts.managed_mounts[i] = newmount
 
     def umount(self):
         if not self.mount:

--- a/mock/py/mockbuild/plugins/lvm_root.py
+++ b/mock/py/mockbuild/plugins/lvm_root.py
@@ -33,8 +33,8 @@ def current_mounts():
 class Lock(object):
     def __init__(self, path, name, sleep_time):
         lock_name = '.{0}.lock'.format(name)
-        lock_path = os.path.join(path, lock_name)
-        self.lock_file = open(lock_path, 'a+')
+        self.lock_path = os.path.join(path, lock_name)
+        self.lock_file = open(self.lock_path, 'a+')
         self.sleep_time = sleep_time
 
     def lock(self, exclusive, block=False):
@@ -63,6 +63,11 @@ class Lock(object):
         if unsatisfied_fn:
             unsatisfied_fn()
 
+    def scrub(self):
+        try:
+            os.unlink(self.lock_path)
+        except FileNotFoundError:
+            pass
 
 class LvmPlugin(object):
     postinit_name = 'postinit'
@@ -340,7 +345,7 @@ class LvmPlugin(object):
         # Relock as shared for following operations, noop if shared already
         self.lock.lock(exclusive=False)
 
-    def hook_scrub(self, what):
+    def scrub(self, what):
         if what not in ('lvm', 'all') or not self.lv_exists(self.pool_name):
             return
         self.pool_lock.lock(exclusive=True)
@@ -357,6 +362,11 @@ class LvmPlugin(object):
             lvm_do(['lvremove', '-f', self.vg_name + '/' + self.pool_name])
             self.buildroot.root_log.info("deleted LVM cache thinpool")
         self.unset_current_snapshot()
+
+    def hook_scrub(self, what):
+        self.scrub(what)
+        self.lock.scrub()
+        self.pool_lock.scrub()
 
     def hook_list_snapshots(self):
         current = self.get_current_snapshot()


### PR DESCRIPTION
Remove one old hack that tried to secure the chroot root mount point
re-mounted into bootstrap.  This isn't needed nowadays because we
always pre over-mount that directory by tmpfs with private flag, so
there's no risk that umount in bootstrap will also umount the main mount
point.

This commit complements 4658933b12f405681b29a3fbda224a499511810e,
b87244a88f39d856f303732eca09434a6d9da4c6 and friends.

Fixes: rhbz#1805179