### PR TITLE
mockchain: don't run buildroot.finalize() for each package

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -475,10 +475,6 @@ class Commands(object):
                             do_rebuild(self.config, self, buildroot, options, [pkg])
                     except Error:
                         build_ret_code = 1
-                    finally:
-                        buildroot.finalize()
-                        if buildroot.bootstrap_buildroot is not None:
-                            buildroot.bootstrap_buildroot.finalize()
                 except (RootError,) as e:
                     log.warning(e.msg)
                     failed.append(pkg)


### PR DESCRIPTION
That invalidates mount points, and probably cleans the buildroot too
much without reason.  There's automatic buildroot.clean() call before
each package anyways.

Fixes: #479