### PR TITLE
mock: don't clean between consecutive builds

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -472,7 +472,9 @@ class Commands(object):
                         if os.path.exists(success_file):
                             build_ret_code = 2
                         else:
-                            do_rebuild(self.config, self, buildroot, options, [pkg])
+                            config_opts = self.config.copy()
+                            config_opts["clean"] = False
+                            do_rebuild(config_opts, self, buildroot, options, [pkg])
                     except Error:
                         build_ret_code = 1
                     finally:

--- a/mock/py/mockbuild/rebuild.py
+++ b/mock/py/mockbuild/rebuild.py
@@ -17,9 +17,9 @@ log = logging.getLogger()
 def rebuild_generic(items, commands, buildroot, config_opts, cmd, post=None, clean=True):
     start = time.time()
     try:
-        for item in items:
+        for i, item in enumerate(items):
             log.info("Start(%s)  Config(%s)", item, buildroot.shared_root_name)
-            if clean:
+            if clean and i == 0:
                 commands.clean()
             commands.init(prebuild=not config_opts.get('short_circuit'))
             ret = cmd(item)


### PR DESCRIPTION
Fixes: #483

The issue doesn't seem to be --chain specific. It is reproducible by both

    mock -r <chroot> --chain foo.src.rpm bar.src.rpm
    mock -r <chroot> foo.src.rpm bar.src.rpm --resultdir=/foobar

Unfortunatelly the fix can't be done in some common code, but separately
for both of these cases. Basically we need to make sure to not call
`commands.clean()` between consecutive builds. Interesting is, that
if --chain is not used, we can clean before the first build and still
go from cache, but when using --chain, we can't clean before any of them.