### PR TITLE
config: explicitly disable bootstrap for OpenSUSE

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
+config_opts['use_bootstrap'] = False
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
+config_opts['use_bootstrap'] = False
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
+config_opts['use_bootstrap'] = False
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
+config_opts['use_bootstrap'] = False
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -5,6 +5,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['use_bootstrap'] = False
 
 config_opts['dnf.conf'] = """
 [main]


### PR DESCRIPTION
First, doing bootstrap to install `dnf` stack, to later install `zypper`
distro doesn't make sense to me.

Second, per issue #500, ssl certificates inside OpenSUSE bootstrap
chroot work differently from Fedora (at least OpenSUSE uses different
paths).

That said, to make everything work smoothly, we would have to have at
least another `class Zypper(_PackageManager)` abstraction, and better
handle certificates so we have compatibility for Fedora <-> OpenSUSE.

Fixes: #500