### PR TITLE
opensuse: copy ssl ca bundle to correct chroot path

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
+config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.0-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.0'
 config_opts['macros']['%dist'] = '.suse.lp150'
 config_opts['package_manager'] = 'dnf'
+config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
+config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -8,6 +8,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '15.1'
 config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
+config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -5,6 +5,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -453,3 +453,10 @@
 # Set timeout in seconds for common mock operations
 # if 0 is set, then no time limit is used
 # config_opts['opstimeout'] = 0
+
+# Copy host's SSL certificate bundle ('/etc/pki/tls/certs/ca-bundle.crt') into
+# specified location inside chroot.  This usually isn't needed because we copy
+# the whole /etc/pki/ca-trust/extracted directory recursively by default, and
+# Fedora or EL systems work with that.  But some destination chroots can have
+# different configuration, and copying the bundle helps.
+#config_opts['ssl_ca_bundle_path'] = None

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -303,6 +303,23 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
             warning = "Couldn't copy certs from host, %s doesn't exist or is not readable"
             self.buildroot.root_log.debug(warning, cert_path)
 
+        bundle_path = self.config['ssl_ca_bundle_path']
+        if bundle_path:
+            self.buildroot.root_log.debug('copying CA bundle into chroot')
+            host_bundle = os.path.realpath('/etc/pki/tls/certs/ca-bundle.crt')
+            chroot_bundle_path = self.buildroot.make_chroot_path(bundle_path)
+            chroot_bundle_dir = os.path.dirname(chroot_bundle_path)
+            try:
+                os.makedirs(chroot_bundle_dir)
+            except FileExistsError:
+                pass  # for repeated attempts
+
+            try:
+                shutil.copy(host_bundle, chroot_bundle_path)
+            except FileNotFoundError:
+                # when mock is not run on Fedora or EL
+                self.buildroot.root_log.debug("ca bundle not found on host")
+
     def initialize(self):
         self.copy_gpg_keys()
         self.copy_certs()

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1013,6 +1013,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
 
     config_opts['redhat_subscription_required'] = False
 
+    config_opts['ssl_ca_bundle_path'] = None
+
     # (global) plugins and plugin configs.
     # ordering constraings: tmpfs must be first.
     #    root_cache next.


### PR DESCRIPTION
OpenSUSE uses different pattern for ssl trusted CAs from Fedora, and to
actually make dnf (or rather transitively curl) inside bootstrap chroot
work we need to install the bundle onto
'/var/lib/ca-certificates/ca-bundle.pem'.

Fixes: #500
Supersedes: #509