### PR TITLE
bootstrap: bind-mount the inner root mount privately

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -755,7 +755,7 @@ def main():
                                  options="rprivate"))
         buildroot.mounts.managed_mounts.append(
             BindMountPoint(buildroot.make_chroot_path(), inner_mount,
-                           recursive=True))
+                           recursive=True, options="rprivate"))
 
     signal.signal(signal.SIGTERM, partial(handle_signals, buildroot))
     signal.signal(signal.SIGPIPE, partial(handle_signals, buildroot))


### PR DESCRIPTION
This caused problems with dnf caches before when we called
    commands.clean() -> commands.init()
sequence (typically mock --chain).

That's because commands.clean() calls buildroot.mounts.umountall(),
which according to the order of bind-mounts first "recursively" (lazily)
umounted the inner-chroot from bootstrap chroot.  That though affected
the original chroot mount as well (umounted caches).  The following
particular dnf cache unmount attempts failed since the mount points were
already unmounted...  this kept the mount points in 'mounted = True'
state.

Having the 'mounted = True' caused that the 'init()' command did not
re-mount the caches.

Fixes: #483
Supersedes: #508