### PR TITLE
Better support for bootstrap_package_manager config option

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -717,6 +717,11 @@ def main():
         # disable updating bootstrap chroot
         bootstrap_buildroot_config['update_before_build'] = False
 
+        # check if a different package manager is wanted for the bootstrap buildroot
+        if 'bootstrap_package_manager' in bootstrap_buildroot_config:
+            bootstrap_buildroot_config['package_manager'] = \
+                bootstrap_buildroot_config['bootstrap_package_manager']
+
         bootstrap_buildroot_state = State(bootstrap=True)
         bootstrap_plugins = Plugins(bootstrap_buildroot_config, bootstrap_buildroot_state)
         bootstrap_buildroot = Buildroot(bootstrap_buildroot_config,


### PR DESCRIPTION
The bootstrap buildroot is constructed before mapping `bootstrap_*` options into `bootstrap_buildroot_config`, but the constructor of the buildroot wants to know what the desired package manager to set up the bootstrap buildroot is. If a `bootstrap_package_manager` option is specified, this should be used as the desired package manager rather than what's been requested for set-up of the actual main buildroot.

This is not a terribly important option to get right since mock will check what's available on the host system and fall back sensibly. However, this will usually result in a warning message appearing in
the logs, which is nice to avoid.

For example, if building on Fedora (with dnf) for a target that uses yum, mock currently outputs a message about yum being symlink to dnf and hence using dnf instead, right at the start of construction of the bootstrap buildroot, even if `config_opts['bootstrap_package_manager'] = 'dnf'`.