### PR TITLE
Use configured yum commands in bootstrap

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -395,10 +395,9 @@ class Yum(_PackageManager):
         self.install_command = config['yum_install_command']
         self.builddep_command = [config['yum_builddep_command']]
         if bootstrap_buildroot is not None:
-            # we are in bootstrap so use old names
-            self.command = '/usr/bin/yum'
-            yum_deprecated_path = '/usr/bin/yum'
-            yum_builddep_deprecated_path = '/usr/bin/yum-builddep'
+            # we are in bootstrap so use configured names
+            yum_deprecated_path = config['yum_command']
+            yum_builddep_deprecated_path = config['yum_builddep_command']
             yum_deprecated_path = bootstrap_buildroot.make_chroot_path(yum_deprecated_path)
             yum_builddep_deprecated_path = bootstrap_buildroot.make_chroot_path(yum_builddep_deprecated_path)
         else:


### PR DESCRIPTION
When the target buildroot is constructed using yum, the commands to invoke yum are hard-coded as '/usr/bin/yum' and '/usr/bin/yum-builddep' regardless of what may have been configured in config_opts. This was a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1446294

Since these are the default values of `config_opts['yum_command']` and `config_opts['yum_builddep_command']` anyway, it should be safe to use the values of these options instead of hard-coding them.

Without this change, it's not possible to use yum as package manager when the target system has yum in /usr/bin/yum-deprecated rather than /usr/bin/yum. With the change, the user can specify
`config_opts['yum_command'] = '/usr/bin/yum-deprecated'` and it works as expected.