### PR TITLE
add rpkg spec preprocessing capability

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -318,6 +318,11 @@
 # the rpms in the results folder.
 # config_opts['plugin_conf']['sign_opts']['opts'] = '--addsign %(rpms)s -D "%%_gpg_name your_name" -D "%%_gpg_path /home/your_name/.gnupg"'
 
+# Enable preprocessing step before srpm build by using rpkg utilities
+# config_opts['plugin_conf']['rpkg_preprocessor_enable'] = False
+# config_opts['plugin_conf']['rpkg_preprocessor_opts']['requires'] = ['preproc-rpmspec']
+# config_opts['plugin_conf']['rpkg_preprocessor_opts']['cmd'] = '/usr/bin/preproc-rpmspec %(source_spec)s --output %(target_spec)s'
+
 #############################################################################
 #
 # environment for chroot

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -28,7 +28,7 @@ from .util import USE_NSPAWN, setup_operations_timeout
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
-               'hw_info', 'procenv', 'showrc']
+               'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor']
 
 
 def nspawn_supported():
@@ -191,7 +191,11 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         'compress_logs_opts': {
             'command': 'gzip',
         },
-
+        'rpkg_preprocessor_enable': False,
+        'rpkg_preprocessor_opts': {
+            'requires': ['preproc-rpmspec'],
+            'cmd': '/usr/bin/preproc-rpmspec %(source_spec)s --output %(target_spec)s',
+        },
     }
 
     config_opts['environment'] = {

--- a/mock/py/mockbuild/plugins/rpkg_preprocessor.py
+++ b/mock/py/mockbuild/plugins/rpkg_preprocessor.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+# Written by clime
+# Copyright (C) 2020 clime <clime@fedoraproject.org>
+
+# python library imports
+import os
+import os.path
+import re
+import subprocess
+import configparser
+import shlex
+
+# our imports
+import mockbuild.util
+from mockbuild.trace_decorator import getLog, traceLog
+from mockbuild.exception import PkgError
+
+requires_api_version = "1.1"
+
+
+# plugin entry point
+@traceLog()
+def init(plugins, conf, buildroot):
+    RpkgPreprocessor(plugins, conf, buildroot)
+
+
+class RpkgPreprocessor(object):
+    """preprocess spec file by using rpkg utilities"""
+    # pylint: disable=too-few-public-methods
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.config = buildroot.config
+        self.state = buildroot.state
+        self.opts = conf
+        self.log = getLog()
+        plugins.add_hook("pre_srpm_build", self._preprocess_proxy)
+        self.log.info("rpkg_preprocessor: initialized")
+
+    @traceLog()
+    def _install_requires(self, requires):
+        try:
+            self.buildroot.uid_manager.becomeUser(0, 0)
+            self.buildroot.pkg_manager.install(*requires, check=True)
+        finally:
+            self.buildroot.uid_manager.restorePrivs()
+
+    @traceLog()
+    def _preprocess_proxy(self, host_chroot_spec, host_chroot_sources):
+        if not host_chroot_sources or not os.path.isdir(host_chroot_sources):
+            self.log.debug("Sources not specified or not a directory. "
+                           "Skipping rpkg preprocessing step.")
+            return
+
+        self._preprocess(host_chroot_spec, host_chroot_sources)
+
+    @traceLog()
+    def _preprocess(self, host_chroot_spec, host_chroot_sources):
+        rpkg_conf_path = os.path.join(host_chroot_sources, 'rpkg.conf')
+
+        if not os.path.isfile(rpkg_conf_path):
+            self.log.info("rpkg.conf not found. "
+                          "Skipping rpkg preprocessing step.")
+            return
+
+        parser = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation())
+
+        try:
+            parser.read(rpkg_conf_path)
+        except configparser.ParsingError as e:
+            raise PkgError("Parsing of %s failed with error: %s" % (rpkg_conf_path, repr(e)))
+
+        try:
+            preprocess_spec = parser.getboolean('rpkg', 'preprocess_spec')
+        except (configparser.Error, ValueError):
+            self.log.warning(
+                "Could not get boolean value of rpkg.preprocess_spec option from rpkg.conf.")
+            preprocess_spec = False
+
+        if not preprocess_spec:
+            self.log.info("preprocess_spec not enabled in rpkg.conf. "
+                          "Skipping rpkg preprocessing step.")
+            return
+
+        # try to locate spec file in SOURCES, which will be our input
+        host_chroot_sources_spec = os.path.join(host_chroot_sources,
+                                                os.path.basename(host_chroot_spec))
+
+        if not os.path.isfile(host_chroot_sources_spec):
+            raise PkgError("%s is not a file. Spec file needs to be among sources." %
+                           host_chroot_sources_spec)
+
+        self.log.info("Installing rpkg preprocessing requires...")
+        self._install_requires(self.opts.get('requires', []))
+
+        # get rid of host rootdir prefixes
+        rootdir_prefix = self.buildroot.make_chroot_path()
+        chroot_spec = host_chroot_spec.replace(rootdir_prefix, '')
+        chroot_sources = host_chroot_sources.replace(rootdir_prefix, '')
+        chroot_sources_spec = host_chroot_sources_spec.replace(rootdir_prefix, '')
+
+        command_str = self.opts.get('cmd') % {'source_spec': chroot_sources_spec,
+                                              'target_spec': chroot_spec}
+        command = shlex.split(command_str)
+
+        # determine whether to use private network or not based on rpmbuild_networking
+        private_network = (not self.config.get('rpmbuild_networking', False))
+
+        self.buildroot.doChroot(
+            command,
+            shell=False,
+            cwd=chroot_sources,
+            logger=self.buildroot.build_log,
+            uid=self.buildroot.chrootuid,
+            gid=self.buildroot.chrootgid,
+            user=self.buildroot.chrootuser,
+            unshare_net=private_network,
+            nspawn_args=self.config.get('nspawn_args', []),
+            printOutput=self.config.get('print_main_output', True)
+        )


### PR DESCRIPTION
Hello!

This pull request adds spec preprocessing capability to mock by using `preproc` and `rpkg-macros` packages (and also `preproc-rpmspec` which is a wrapper around these two). The whole rationale for this pull request is described here: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/FSVFSQJ5R4WKLH7WIYZQ22CUXAEYZPNK/

I have manually tested it from `epel-6` up to `fedora-rawhide` under `x86_64` architecture. The needed packages are not yet in stable Fedoras (and EPELs) so using copr repos, as described below, is needed. Rawhide update is probably going to come sooner.

The preprocessing is enabled only if new config option `config_opts['rpkg_preprocessing']` is `True` (by default it is set to `False`). There are two other new config options `config_opts['rpkg_preprocessing_requires']` and `config_opts['rpkg_preprocessing_cmd']` which specify what package is needed to perform the preprocessing task and how the command should be called.

Even if the the feature is enabled in mock, one still needs to have `rpkg.conf` file in the repository with the following content to get the spec file preprocessed:
```
[rpkg]
preprocess_spec = True
```

If this is satisfied as well, the rpkg preprocessing requirements are installed into the chroot and the preprocessing command is run which takes the spec file under `/buildir/build/SOURCES/`, pipes it to `preproc` that has `rpkg-macros` loaded and the output spec file is then put under `/buildir/build/SPECS/` instead of the original unprocessed spec file.

Please, let me know if any tests or further improvements are needed. I noticed a small issue that under Fedora chroots, dnf always refreshes repos twice, once at the beginning when `dnf update` is invoked and then slightly after when `self.buildroot.pkg_manager.install(*rpkg_preprocessing_requires, check=True)` is called. Maybe this could be optimized but I didn't figure how.

An example spec file that contains macros to be processed by `preproc` may look like this:
https://pagure.io/hello_rpkg_release/blob/master/f/hello_rpkg.spec.rpkg

I have run the tests by manually adding the following copr repos into mock configuration files (together with creating the needed `rpkg.conf` file with the above mentioned content):
```
[copr:copr.fedorainfracloud.org:clime:preproc]
name=Copr repo for preproc owned by clime
baseurl=https://download.copr.fedorainfracloud.org/results/clime/preproc/fedora-$releasever-$basearch/
type=rpm-md
skip_if_unavailable=True
gpgcheck=1
gpgkey=https://download.copr.fedorainfracloud.org/results/clime/preproc/pubkey.gpg
repo_gpgcheck=0
enabled=1
enabled_metadata=1

[copr:copr.fedorainfracloud.org:clime:rpkg-macros]
name=Copr repo for rpkg-macros owned by clime
baseurl=https://download.copr.fedorainfracloud.org/results/clime/rpkg-macros/fedora-$releasever-$basearch/
type=rpm-md
skip_if_unavailable=True
gpgcheck=1
gpgkey=https://download.copr.fedorainfracloud.org/results/clime/rpkg-macros/pubkey.gpg
repo_gpgcheck=0
enabled=1
enabled_metadata=1

[copr:copr.fedorainfracloud.org:clime:preproc-rpmspec]
name=Copr repo for preproc-rpmspec owned by clime
baseurl=https://download.copr.fedorainfracloud.org/results/clime/preproc-rpmspec/fedora-$releasever-$basearch/
type=rpm-md
skip_if_unavailable=True
gpgcheck=1
gpgkey=https://download.copr.fedorainfracloud.org/results/clime/preproc-rpmspec/pubkey.gpg
repo_gpgcheck=0
enabled=1
enabled_metadata=1
```