### PR TITLE
Cleanup rpmdb before determining installed packages

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -241,6 +241,7 @@ class Buildroot(object):
 
     def all_chroot_packages(self):
         """package set, result of rpm -qa in the buildroot"""
+        self.nuke_rpm_db()
         out = util.do([self.config['rpm_command'], "-qa",
                        "--root", self.make_chroot_path()],
                       returnOutput=True, printOutput=False, shell=False)


### PR DESCRIPTION
In doChroot we do the same, before we call host's rpm against chroot
rpmdb.  We need to do the same in all_chroot_packages().  This caused
problems on EL7 when building packages dynamic BuildRequires in new
chroots (Fedora 31+):

    ERROR: Command failed:
     # /bin/rpm -qa --root /var/lib/mock/fedora-rawhide-x86_64/root

Very likely we'll have to invent new doChroot()-like abstraction to
automatically call such RPM commands either from host (bootstrap
disabled) or from bootstrap chroot (bootstrap enabled), issue #525.