### PR TITLE
Call orphansKill also "postyum" time

### DIFF
--- a/mock/integration-tests/001-orphanskill-explicit.tst
+++ b/mock/integration-tests/001-orphanskill-explicit.tst
@@ -6,27 +6,38 @@
 # Test orphanskill feature (explicit)
 #
 header "Test orphanskill feature (explicit)"
+
+tmpdir=/var/tmp
+
 runcmd "$MOCKCMD --offline --init"
-runcmd "$MOCKCMD --offline --disable-plugin=tmpfs --copyin integration-tests/daemontest.c /tmp"
-runcmd "$MOCKCMD --offline --disable-plugin=tmpfs --chroot -- gcc -Wall -o /tmp/daemontest /tmp/daemontest.c"
-# ask for sudo password, so later we do not need to wait for password, because the second sudo need to be
-# executed within 10 seconds
-sudo echo init sudo
-echo -e '#!/bin/sh\n/tmp/daemontest\nsleep 60\n' >> $CHROOT/tmp/try
-# the following should launch about three processes in the chroot: bash, sleep, daemontest
-$MOCKCMD --offline --disable-plugin=tmpfs --chroot -- bash /tmp/try &
-sleep 10
-mockpid=$!
-sleep 1
-# now we 'prematurely' kill mock. This should leave the three orphans above
-sudo kill -9 $mockpid
-sleep 1
-if ! pgrep daemontest; then
-    echo "Daemontest failed. daemontest should be running now but is not."
-    exit 1
-fi
-$MOCKCMD --offline --disable-plugin=tmpfs --orphanskill
-if pgrep daemontest; then
-    echo "Daemontest FAILED. found a daemontest process running after exit." 
-    exit 1
-fi
+runcmd "$MOCKCMD --install gcc"
+runcmd "$MOCKCMD --offline --disable-plugin=tmpfs --copyin integration-tests/daemontest.c $tmpdir"
+runcmd "$MOCKCMD --offline --disable-plugin=tmpfs --chroot -- gcc -Wall -o $tmpdir/daemontest $tmpdir/daemontest.c"
+
+echo "#!/bin/sh
+set -x
+$tmpdir/daemontest
+sleep 60" >> "$CHROOT$tmpdir/try"
+
+for isolation in simple nspawn; do
+    for bootstrap in --bootstrap-chroot --no-bootstrap-chroot; do
+        selector="--isolation=$isolation $bootstrap"
+
+        # the following should launch about three processes in the chroot: bash,
+        # sleep, daemontest
+        runcmd "$MOCKCMD $selector --offline --disable-plugin=tmpfs --chroot -- bash $tmpdir/try" &
+        mockpid=$!
+        sleep 10
+
+        ! test -d /proc/$mockpid && die "Mock stopped too early ($selector)."
+        ! pgrep daemontest && die "Daemontest failed. daemontest should be running now but is not ($selector)."
+
+        runcmd "$MOCKCMD $selector --offline --disable-plugin=tmpfs --orphanskill"
+
+        wait "$mockpid" && "Unexpected success of mock ($selector)."
+
+        pgrep daemontest && die "Daemontest FAILED. found a daemontest process running after exit ($selector)."
+    done
+done
+
+exit 0

--- a/mock/integration-tests/05-orphanskill-std.tst
+++ b/mock/integration-tests/05-orphanskill-std.tst
@@ -10,12 +10,50 @@ if pgrep daemontest; then
     echo "Exiting because there is already a daemontest running."
     exit 1
 fi
-runcmd "$MOCKCMD --offline --init"
-runcmd "$MOCKCMD --offline --copyin integration-tests/daemontest.c /tmp"
-runcmd "$MOCKCMD --offline --chroot -- gcc -Wall -o /tmp/daemontest /tmp/daemontest.c"
-runcmd "$MOCKCMD --offline --chroot -- /tmp/daemontest"
-if pgrep daemontest; then
-    echo "Daemontest FAILED. found a daemontest process running after exit." 
-    exit 1
-fi
 
+daemon_package=https://github.com/rpm-software-management/mock-test-data/raw/master/daemontest-1-0.src.rpm
+
+for isolation in nspawn; do
+# https://github.com/rpm-software-management/mock/issues/542
+#for isolation in nspawn simple; do
+    for bootstrap in --bootstrap-chroot --no-bootstrap-chroot; do
+        selector="--isolation=$isolation $bootstrap"
+        mock="$MOCKCMD $selector"
+
+        tmpdir=/var/tmp
+
+        runcmd "$mock --offline --init"
+        runcmd "$mock --install gcc"
+        runcmd "$mock --offline --copyin integration-tests/daemontest.c $tmpdir"
+        runcmd "$mock --offline --chroot -- gcc -Wall -o $tmpdir/daemontest $tmpdir/daemontest.c"
+
+        runcmd "$mock --offline --chroot -- $tmpdir/daemontest"
+        pgrep daemontest && die "Daemontest FAILED. found a daemontest process running after exit ($selector)."
+
+        runcmd "$mock --chain $daemon_package" \
+            || die "Can't build daemon package ($selector)."
+
+        pgrep daemontest && die "Leftover daemontest process ($selector)."
+
+        runcmd "$mock --chain $daemon_package --postinstall --config-opts=cleanup_on_success=False" \
+            || die "Can't build && install the daemon package ($selector)."
+
+        pgrep daemontest && die "Leftover daemontest process after --postinstall ($selector)."
+
+        runcmd "$mock --shell 'set -x; /usr/bin/daemontest ; sleep 60 ;'" &
+        mockchild=$!
+        sleep 10 # give mock some time to start the daemontest process
+
+        pgrep daemontest || die "The daemontest process doesn't exit ($selector)."
+        runcmd "$mock --orphanskill"
+
+        wait "$mockchild" && "Unexpected success of mock ($selector)."
+
+        pgrep daemontest && die "The daemontest should be killed ($selector)."
+
+        # "uninstall" the $rpm from chroot
+        runcmd "$MOCKCMD --scrub chroot" || die "Can't scrub ($selector).".
+    done
+done
+
+exit 0

--- a/mock/integration-tests/daemontest.c
+++ b/mock/integration-tests/daemontest.c
@@ -68,7 +68,9 @@ void daemonize()
 {
 int i,lfp;
 char str[10];
-    if(getppid()==1) return; /* already a daemon */
+    /* nspawn implies pid = 1, and to test --isolation=nspawn we need to drop
+       session leader status even there */
+    /* if(getppid()==1) return; */ /* already a daemon */
     i=fork();
     if (i<0) exit(1); /* fork error */
     if (i>0) exit(0); /* parent exits */

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -236,6 +236,11 @@ class _PackageManager(object):
             raise error
 
         self.plugins.call_hooks("postyum")
+
+        # Scriptlets in dnf transaction shouldn't keep leftover processes
+        # running in background, but it may happen.
+        util.orphansKill(self.buildroot.make_chroot_path(), manual_forced=True)
+
         # intentionally we do not call bootstrap hook here - it does not have sense
         return out
 

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -324,10 +324,18 @@ def get_machinectl_uuid(chroot_path):
 
 
 @traceLog()
-def orphansKill(rootToKill):
-    """kill off anything that is still chrooted."""
+def orphansKill(rootToKill, manual_forced=False):
+    """
+    Kill off anything that is still chrooted.
+
+    When USE_NSPAWN==False, this method manually detects the running processes
+    in chroot by reading the /proc file-system.  When USE_NSPAWN==True, it just
+    relies on '/bin/machinectl terminate' call.
+
+    When manual_forced==True, the manual kill based on /proc is enforced.
+    """
     getLog().debug("kill orphans")
-    if USE_NSPAWN is False:
+    if USE_NSPAWN is False or manual_forced:
         for killsig in [signal.SIGTERM, signal.SIGKILL]:
             for fn in [d for d in os.listdir("/proc") if d.isdigit()]:
                 try:


### PR DESCRIPTION
Some packages may keep leftover processes on background after it's
installation, triggered by scriptlets.

Even though this is definitely packaging issue (bug in package) the
background processes keep using the chroot's root filesystem and refuse
us to umount the filesystem later (e.g. when tmpfs is enabled).

Since the dnf commands are not run under systemd-nspawn (when bootstrap
is disabled), we need to add new option which ignores the USE_NSPAWN
flag.

Fixes: #183