### PR TITLE
mock: use 'private' mount option, not 'rprivate'

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -747,15 +747,15 @@ def main():
         # add the extra bind mount to the outer chroot
         inner_mount = bootstrap_buildroot.make_chroot_path(buildroot.make_chroot_path())
 
-        # Hide re-mounted chroot from host by rprivate tmpfs.
+        # Hide re-mounted chroot from host by private tmpfs.
         buildroot.mounts.managed_mounts.append(
             FileSystemMountPoint(filetype='tmpfs',
                                  device='hide_root_in_bootstrap',
                                  path=inner_mount,
-                                 options="rprivate"))
+                                 options="private"))
         buildroot.mounts.managed_mounts.append(
             BindMountPoint(buildroot.make_chroot_path(), inner_mount,
-                           recursive=True, options="rprivate"))
+                           recursive=True, options="private"))
 
     signal.signal(signal.SIGTERM, partial(handle_signals, buildroot))
     signal.signal(signal.SIGPIPE, partial(handle_signals, buildroot))


### PR DESCRIPTION
The 'mount --rbind -o rprivate' on EL7 does weird things;  it looks like
it actually reverses the '--rbind' option and does only '--bind'.  Using
just 'private' seems to do the same (good) thing on both EL7 and modern
Fedora.

This fixes yum_chache plugin on EL7.