### PR TITLE
Add the Devel repo for CentOS 8 and CentOS Stream

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -46,6 +46,14 @@ mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTool
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
+[Devel]
+name=CentOS-$releasever - Devel WARNING! FOR BUILDROOT USE ONLY!
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=Devel&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/Devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
 [centosplus]
 name=CentOS-$releasever - Plus
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=centosplus&infra=$infra

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -98,6 +98,13 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
+[PowerTools-source]
+name=CentOS-$releasever - PowerTools Sources
+baseurl=http://vault.centos.org/centos/8/PowerTools/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
 [extras-source]
 name=CentOS-$releasever - Extras Sources
 baseurl=http://vault.centos.org/centos/8/extras/Source/

--- a/mock-core-configs/etc/mock/templates/centos-stream.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream.tpl
@@ -89,6 +89,13 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
+[Stream-PowerTools-source]
+name=CentOS-Stream - PowerTools Sources
+baseurl=http://vault.centos.org/centos/8-stream/PowerTools/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
 [Stream-extras-source]
 name=CentOS-Stream - Extras Sources
 baseurl=http://vault.centos.org/centos/8-stream/extras/Source/

--- a/mock-core-configs/etc/mock/templates/centos-stream.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream.tpl
@@ -75,6 +75,13 @@ gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
+[Stream-Devel]
+name=CentOS-Stream - Devel WARNING! FOR BUILDROOT USE ONLY!
+baseurl=http://mirror.centos.org/centos/8-stream/Devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
 [Stream-BaseOS-source]
 name=CentOS-Stream - BaseOS Sources
 baseurl=http://vault.centos.org/centos/8-stream/BaseOS/Source/


### PR DESCRIPTION
This repository is disabled by default because we should offer
equivalent repository sources to RHEL by default and there is no
guarantee on the usability of the content shipped here.

In addition, a trivial commit adding the PowerTools source repo
(disabled like other source repos) has been included for completeness.

Fixes #537.