### PR TITLE
mock: conflict with old core-configs

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -16,6 +16,10 @@ URL:        https://github.com/rpm-software-management/mock/
 Source:     https://github.com/rpm-software-management/mock/releases/download/%{name}-%{version}-1/%{name}-%{version}.tar.gz
 BuildArch:  noarch
 
+# The mock.rpm requires this.  Other packages may provide this if they tend to
+# replace the mock-core-configs.rpm functionality.
+Provides: mock-configs
+
 # distribution-gpg-keys contains GPG keys used by mock configs
 Requires:   distribution-gpg-keys >= 1.36
 

--- a/mock/docs/release-instructions.txt
+++ b/mock/docs/release-instructions.txt
@@ -29,7 +29,7 @@ Release checklist overview:
    $ tito tag
    When you release both mock and mock-core-configs together, you
    likely want to (a) first tag 'mock-core-configs' package, (b) bump
-   'Requires: mock-core-configs >= ??' dependency and (c) then tag
+   'Conflicts: mock-core-configs < ??' in mock.spec and (c) then tag
    new mock version.
 5) push to main git repo (only from master branch):
    $ git push

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -25,7 +25,14 @@ Requires: usermode-consoleonly
 Requires: usermode
 %endif
 Requires: createrepo_c
-Requires: mock-core-configs >= 32.4
+
+# We know that the current version of mock isn't compatible with older variants,
+# and we want to enforce automatic upgrades.
+Conflicts: mock-core-configs < 32.4
+
+# Requires 'mock-core-configs', or replacement (GitHub PR#544).
+Requires: mock-configs
+
 Requires: systemd
 %if 0%{?fedora} || 0%{?rhel} >= 8
 Requires: systemd-container


### PR DESCRIPTION
.. instead of Require'ing them.  Since core-configs are optional thing,
this is acceptable use of Conflicts tag:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Conflicts/#_optional_functionality