### PR TITLE
mock: default to LANG=C.UTF-8

### DIFF
--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -323,8 +323,7 @@
 # config_opts['environment']['PATH'] = '/usr/bin:/bin:/usr/sbin:/sbin'
 # config_opts['environment']['PROMPT_COMMAND'] = r'printf "\033]0;<mock-chroot>\007"'
 # config_opts['environment']['PS1'] = r'<mock-chroot> \s-\v\$ '
-# config_opts['environment']['LANG'] = os.environ.setdefault('LANG', 'C.UTF-8')
-# config_opts['environment']['TZ'] = os.environ.setdefault('TZ', 'EST5EDT')
+# config_opts['environment']['LANG'] = 'C.UTF-8'
 #
 ## other example for PS1
 # config_opts['environment']['PS1'] = r'[\u@\h<mock-chroot>/\w]\[\033[01;31m\]${?/#0/}\[\033[00m\]\$'

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -950,15 +950,14 @@ def run(cmd, isShell=True):
 
 
 def clean_env():
-    env = {
+    return {
         'TERM': 'vt100',
         'SHELL': '/bin/sh',
         'HOME': '/builddir',
         'HOSTNAME': 'mock',
         'PATH': '/usr/bin:/bin:/usr/sbin:/sbin',
+        'LANG': 'C.UTF-8',
     }
-    env['LANG'] = os.environ.setdefault('LANG', 'C.UTF-8')
-    return env
 
 
 def get_fs_type(path):
@@ -1129,7 +1128,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         'PATH': '/usr/bin:/bin:/usr/sbin:/sbin',
         'PROMPT_COMMAND': r'printf "\033]0;<mock-chroot>\007"',
         'PS1': r'<mock-chroot> \s-\v\$ ',
-        'LANG': os.environ.setdefault('LANG', 'C.UTF-8'),
+        'LANG': 'C.UTF-8',
     }
 
     runtime_plugins = [runtime_plugin


### PR DESCRIPTION
And ignore host's configuration.  Users still can set this explicitly
in "config_opts['environment']['LANG']" when needed.

Drop 'TZ' from site-default.cfg, it isn't set in util.py anymore.

Fixes: #451