### PR TITLE
bootstrap: fix for Fedora Toolbox environment

### DIFF
--- a/mock-core-configs/etc/mock/templates/epel-6.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-6.tpl
@@ -2,7 +2,7 @@ config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware RHEL uses 6Server or 6Client
 config_opts['releasever'] = '6'
-config_opts['use_nspawn'] = False
+config_opts['isolation'] = 'simple'
 config_opts['bootstrap_image'] = 'centos:6'
 config_opts['package_manager'] = 'yum'
 

--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -259,8 +259,12 @@ It can be specified multiple times.
 Enable networking. If you want to have reproducible builds then your builds should run without a network.
 This option overrides config_opts['rpmbuild_networking'] and config_opts['use_host_resolv'], setting both True.
 .TP
-\fB\-\-isolation\fR=\fILEVEL\fR\fR
-What should be used for isolation of chroot. The valid options are 'simple' and 'nspawn'. The 'simple' method uses chroot() call. The 'nspawn' method utilize systemd-nspawn(1) and run the chroot inside that container. The default is 'nspawn'.
+\fB\-\-isolation\fR={\fIauto\fR|\fInspawn\fR|\fIsimple\fR}
+What should be used for isolation of chroot.  The \fIsimple\fR method uses
+chroot() call.  The \fInspawn\fR  method utilizes systemd-nspawn(1) and runs the
+commands inside container.  The \fIauto\fR tries to use \fInspawn\fR, and falls
+back to \fIsimple\fR if system-nspawn can not be used (e.g. if mock is run in
+container).  The default is \fIauto\fR.
 .TP
 \fB\-\-localrepo\fR=\fIREPO\fR\fR
 Set the path to put the results/repo in (works only in \fB\-\-chain\fR mode).

--- a/mock/etc/bash_completion.d/mock
+++ b/mock/etc/bash_completion.d/mock
@@ -96,7 +96,7 @@ _mock()
             return
             ;;
         --isolation)
-            COMPREPLY=( $( compgen -W "simple nspawn" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "auto simple nspawn" -- "$cur" ) )
             return
             ;;
         --remove|remove)

--- a/mock/etc/mock/site-defaults.cfg
+++ b/mock/etc/mock/site-defaults.cfg
@@ -71,12 +71,15 @@
 # relative to build user's homedir
 # config_opts['exclude_from_homedir_cleanup'] = ['build/SOURCES']
 
-# Mock uses systemd-nspawn(1) by default. When use_nspawn is set to False,
-# simple os.chroot() is used instead.
-# config_opts['use_nspawn'] = True
-# If you're using nspawn, then by default networking will be turned off
-# for rpmbuild.  This helps ensure more reproducible builds.
-# config_opts['rpmbuild_networking'] = False
+# Choose the isolation method for running commands in buildroot.  Possible
+# values are 'nspawn' (mock uses systemd-nspawn(1)), 'simple' (simple
+# os.chroot() is used) or 'auto' (use 'nspawn' when possible, and fallback to
+# 'chroot').
+#config_opts['isolation'] = 'auto'
+
+# If you're using isolation='nspawn', then by default networking will be turned
+# off for rpmbuild.  This helps ensure more reproducible builds.
+#config_opts['rpmbuild_networking'] = False
 # Additional args for nspawn
 # config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
 ## When RPM is build in container then build hostname is set to name of

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -668,6 +668,9 @@ def main():
     # configure logging
     setup_logging(config_path, config_opts, options)
 
+    # see if we need to force old-chroot because systemd-nspawn can't work
+    util.check_for_nspawn_support()
+
     # verify that we're not trying to build an arch that we can't
     check_arch_combination(config_opts['rpmbuild_arch'], config_opts)
 

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -668,9 +668,6 @@ def main():
     # configure logging
     setup_logging(config_path, config_opts, options)
 
-    # see if we need to force old-chroot because systemd-nspawn can't work
-    util.check_for_nspawn_support()
-
     # verify that we're not trying to build an arch that we can't
     check_arch_combination(config_opts['rpmbuild_arch'], config_opts)
 

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -593,6 +593,12 @@ class Buildroot(object):
                 if util.cmpKernelVer(kver, '2.6.18') >= 0 and src_path == '/dev/ptmx':
                     continue
 
+                if os.path.ismount(chroot_path):
+                    # repeated call of bootstrap._init() in chain() in container
+                    # where we can not mknod so we bindmount instead
+                    self.root_log.debug("file %s is already mounted", chroot_path)
+                    continue
+
                 # create node, but only if it exist on host too
                 # except for loop devices, which only show up on the host after they are first used
                 if os.path.exists(src_path) or "loop" in src_path:

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -185,8 +185,8 @@ class _PackageManager(object):
         # intentionally we do not call bootstrap hook here - it does not have sense
         env = self.config['environment'].copy()
         env.update(util.get_proxy_environment(self.config))
-        # use a special home directory with only our desired RPM configuration
-        env['HOME'] = self.buildroot.ensure_rpm_config_home()
+        # use our predefined $HOME/.rpmmacros with desired RPM configuration
+        env['HOME'] = self.buildroot.make_chroot_path(self.buildroot.homedir)
         env['LC_MESSAGES'] = 'C.UTF-8'
         if self.buildroot.nosync_path:
             env['LD_PRELOAD'] = self.buildroot.nosync_path

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1181,6 +1181,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['macros'] = {
         '%_topdir': '%s/build' % config_opts['chroothome'],
         '%_rpmfilename': '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm',
+        '%_netsharedpath': '/proc:/sys',
     }
     config_opts['hostname'] = None
     config_opts['module_enable'] = []

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -978,6 +978,29 @@ def find_non_nfs_dir():
     raise exception.Error('Cannot find non-NFS directory in: %s' % dirs)
 
 
+def nspawn_supported():
+    """Detect some situations where the systemd-nspawn chroot code won't work"""
+    with open("/proc/1/cmdline", "rb") as f:
+        # if PID 1 has a non-0 UID, then we're running in a user namespace
+        # without a PID namespace. systemd-nspawn won't work
+        if os.fstat(f.fileno()).st_uid != 0:
+            return False
+
+        argv0 = f.read().split(b'\0')[0]
+
+        # If PID 1 is not systemd, then we're in a PID namespace, or systemd
+        # isn't running on the system: systemd-nspawn won't work.
+        return os.path.basename(argv0) == b'systemd'
+
+
+def check_for_nspawn_support():
+    global USE_NSPAWN
+
+    if USE_NSPAWN and not nspawn_supported():
+        getLog().info("systemd-nspawn not supported, disabling")
+        USE_NSPAWN = False
+
+
 @traceLog()
 def setup_default_config_opts(unprivUid, version, pkgpythondir):
     "sets up default configuration."


### PR DESCRIPTION
We need to set HOME=make_chroot_path('/builddir')
when running `dnf --installroot`.  But since we before created the
macros file in join(basedir, 'rpmconfig') directory.  But that host
directory wasn't bind-mounted to bootstrap chroot.  To actually mount
it, the HOME directory needs to be below rootdir.

And since we had such directory with macros file already -
`<chroot>/builddir` - instead of doing the similar thing on two places,
rather make sure we create the final /builddir/.rpmmacros a bit earlier
so the initial `dnf install @build` can leverage from it.

Now, we can define the %_netsharedpath a standard way.

Replaces: d8d224ff6f5be4f8ed7f73a056d63e104df3d48c