### PR TITLE
mock: use getpass.getuser() instead of os.getlogin()

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import sys
 import tempfile
+import getpass
 from urllib.parse import urlsplit
 
 # 3rd party imports
@@ -387,8 +388,8 @@ class Commands(object):
         log = getLog()
         if not options.tmp_prefix:
             try:
-                options.tmp_prefix = os.getlogin()
-            except OSError as e:
+                options.tmp_prefix = getpass.getuser()
+            except Exception:  # pylint: disable=broad-except
                 log.error("Could not find login name for tmp dir prefix add --tmp_prefix")
                 sys.exit(1)
         pid = os.getpid()


### PR DESCRIPTION
This is mostly suggested by help(os.getlogin):

| Return the name of the user logged in on the controlling terminal of
| the process. For most purposes, it is more useful to use
| getpass.getuser() since the latter checks the environment variables
| LOGNAME or USERNAME to find out who the user is, and falls back to
| pwd.getpwuid(os.getuid())[0] to get the login name of the current real
| user id.

The motivation here is that by default, in `docker run --rm -ti
fedora:31` the call to os.getlogin() fails and user is forced to pass
the option --tmp_prefix.  The original use of getlogin() isn't well
documented and doesn't seem to be intended over getuser().  Also, there
used to be other getlogin() call in mock, but was dropped for the
similar reasons in b9798b15ce00b3c059c50e159f931759a3f6a517.