### PR TITLE
configs: specify amazonlinux bootstrap image

### DIFF
--- a/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
+++ b/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
@@ -4,6 +4,8 @@ config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['package_manager'] = 'yum'
 config_opts['releasever'] = '2'
 
+config_opts['bootstrap_image'] = 'amazonlinux:2'
+
 config_opts['yum.conf'] = """
 [main]
 cachedir=/var/cache/yum


### PR DESCRIPTION
This allows us to build against amazonlinux-2-x86_64 on Fedora host
--use-bootstrap-image.