### PR TITLE
mock: re-define %python3_pkgversion on el7

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -3,6 +3,9 @@
 
 %global __python %{__python3}
 %global python_sitelib %{python3_sitelib}
+%if 0%{?rhel} == 7
+%global python3_pkgversion 36
+%endif
 
 Summary: Builds packages inside chroots
 Name: mock


### PR DESCRIPTION
The default RHEL 7 %python3_pkgversion contains value '3', which isn't
sufficient for mock.  We actually need `epel-rpm-macros` to be installed
so the macro %python3_pkgversion is re-defined to 36.

This patch fixes builds on EL7 _host_ machines.  The presence of
`epel-rpm-macros` isn't guaranteed there by default even when EPEL 7
repo is enabled (epel-rpm-macros is "only" installed into EPEL7 minimal
buildroot).

Fixes: #545