### PR TITLE
configs: declare minimal version of mock

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -22,6 +22,8 @@ Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
 Requires:   distribution-gpg-keys >= 1.36
+# specify minimal compatible version of mock
+Requires:   mock >= 2.0
 
 Requires(post): coreutils
 %if 0%{?fedora} || 0%{?mageia} || 0%{?rhel} > 7

--- a/mock/docs/release-instructions.txt
+++ b/mock/docs/release-instructions.txt
@@ -28,9 +28,9 @@ Release checklist overview:
 4) tag the git tree:
    $ tito tag
    When you release both mock and mock-core-configs together, you
-   likely want to (a) first tag 'mock-core-configs' package, (b) bump
-   'Conflicts: mock-core-configs < ??' in mock.spec and (c) then tag
-   new mock version.
+   likely want to (a) first tag 'mock-core-configs' package with bumped
+   'Requires: mock >= ??', (b) bump 'Conflicts: mock-core-configs < ??' in
+   mock.spec and (c) then tag new mock version.
 5) push to main git repo (only from master branch):
    $ git push
    $ git push --tags


### PR DESCRIPTION
We could use `Conflicts:` here instead, but mock-core-configs doesn't
seem to have any use-case without mock package, at least no Fedora
Rawhide package ATM [1] directly depends on isolated mock-core-configs.
FTR, this isn't truth vice-versa, per 66da47e2960baafb35.

[1] https://src.fedoraproject.org/lookaside/rpm-specs-latest.tar.xz