### PR TITLE
bootstrap: fix --rootdir option

### DIFF
--- a/mock/integration-tests/22-rootdir.tst
+++ b/mock/integration-tests/22-rootdir.tst
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if test -z "$TESTDIR"; then
+    TESTDIR=$(dirname "$(readlink -f "$0")")
+fi
+
+. "${TESTDIR}/functions"
+set -e
+
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+header "mock with --rootdir option"
+
+for isolation in simple nspawn; do
+    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$TMPDIR --scrub=chroot"
+    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$TMPDIR --scrub=bootstrap"
+    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$TMPDIR --bootstrap-chroot ${TESTDIR}/test-C-1.1-0.src.rpm"
+done

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -48,10 +48,12 @@ class Buildroot(object):
         self.root_name = config['root']
         self.mockdir = config['basedir']
         self.basedir = os.path.join(config['basedir'], config['root'])
-        if 'rootdir' in config:
-            self.rootdir = config['rootdir']
-        else:
+        self.rootdir = config['rootdir']
+
+        # don't mixup bootstrap && normal chroot root dirs
+        if is_bootstrap:
             self.rootdir = os.path.join(self.basedir, 'root')
+
         self.resultdir = config['resultdir'] % config
 
         # In bootstrap buildroot, resultdir _should_ be basically unused (nobody
@@ -255,11 +257,6 @@ class Buildroot(object):
                 kargs['uid'] = uid.getresuid()[1]
             if 'gid' not in kargs:
                 kargs['gid'] = uid.getresgid()[1]
-            if 'user' not in kargs:
-                try:
-                    kargs['user'] = pwd.getpwuid(kargs['uid'])[0]
-                except KeyError:
-                    pass
             self.uid_manager.becomeUser(0, 0)
 
         try:

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1008,6 +1008,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['version'] = version
     config_opts['basedir'] = '/var/lib/mock'  # root name is automatically added to this
     config_opts['resultdir'] = '{{basedir}}/{{root}}/result'
+    config_opts['rootdir'] = '{{basedir}}/{{root}}/root'
     config_opts['cache_topdir'] = '/var/cache/mock'
     config_opts['clean'] = True
     config_opts['check'] = True
@@ -1431,8 +1432,8 @@ def set_config_opts_per_cmdline(config_opts, options, args):
 
     check_config(config_opts)
     # can't cleanup unless resultdir is separate from the root dir
-    rootdir = os.path.join(config_opts['basedir'], config_opts['root'])
-    if is_in_dir(config_opts['resultdir'] % config_opts, rootdir):
+    basechrootdir = os.path.join(config_opts['basedir'], config_opts['root'])
+    if is_in_dir(config_opts['resultdir'] % config_opts, basechrootdir):
         config_opts['cleanup_on_success'] = False
         config_opts['cleanup_on_failure'] = False
 


### PR DESCRIPTION
We don't want to
1. evaluate rootdir = basedir + 'root' on two places, and
2. mixup bootstrap with normal chroot.

Fixes: #560