### PR TITLE
mock: pre-create directory for file bind-mounts

### DIFF
--- a/mock/integration-tests/23-local-mirrorlist.tst
+++ b/mock/integration-tests/23-local-mirrorlist.tst
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+if test -z "$TESTDIR"; then
+    TESTDIR=$(dirname "$(readlink -f "$0")")
+fi
+
+. "${TESTDIR}/functions"
+set -e
+
+: "${MOCKCMD=mock}"
+
+header "mock and local mirrorlist with expanded variables"
+
+TMPDIR=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+mirrorlist=$TMPDIR/x86_64/mirrorlist
+config=$TMPDIR/rawhide.cfg
+
+mkdir "$(dirname "$mirrorlist")"
+cat > "$mirrorlist" <<EOF
+https://raw.githubusercontent.com/rpm-software-management/mock-test-data/master/repo/
+EOF
+
+# "local" mirror list pointing to external repository hosted on GitHub.
+cat > "$config" <<EOF
+include("fedora-rawhide-x86_64")
+config_opts["root"] = "test-local-mirrorlist"
+config_opts["dnf.conf"] +=  """
+[always_available]
+name=Always Available
+mirrorlist=$TMPDIR/\$basearch/mirrorlist
+gpgcheck=0
+"""
+EOF
+
+for isolation in simple nspawn; do
+    for bootstrap in bootstrap-chroot no-bootstrap-chroot; do
+        mock="$MOCKCMD --isolation=$isolation  --$bootstrap -r $config"
+        $mock --install always-installable
+        $mock --scrub=chroot
+        $mock --scrub=bootstrap
+    done
+done

--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -99,6 +99,8 @@ class BindMountPoint(MountPoint):
             if os.path.isdir(self.srcpath):
                 util.mkdirIfAbsent(self.bindpath)
             elif not os.path.exists(self.bindpath):
+                normbindpath = os.path.normpath(self.bindpath)
+                util.mkdirIfAbsent(os.path.dirname(normbindpath))
                 util.touch(self.bindpath)
             cmd = ['/bin/mount', '-n']
             if self.recursive:


### PR DESCRIPTION
We do this for bind-mounted directories, too - so why not for file
bind-mounts.

Resolves: rhbz#1816696 (again)