### PR TITLE
bootstrap: avoid using host rpm _show_installed_packages()

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -238,18 +238,9 @@ class Commands(object):
     @traceLog()
     def _show_installed_packages(self):
         '''report the installed packages in the chroot to the root log'''
+        pkgs = self.buildroot.all_chroot_packages()
         self.buildroot.root_log.info("Installed packages:")
-        self.buildroot.nuke_rpm_db()
-        util.do(
-            "%s --root %s -qa" % (self.config['rpm_command'],
-                                  self.buildroot.make_chroot_path()),
-            raiseExc=False,
-            shell=True,
-            env=self.buildroot.env,
-            uid=self.buildroot.chrootuid,
-            user=self.buildroot.chrootuser,
-            gid=self.buildroot.chrootgid,
-        )
+        self.buildroot.root_log.info('\n'.join(pkgs))
 
     #
     # UNPRIVILEGED:


### PR DESCRIPTION
Similar to commit 1a6e49605f14137cd6e68459dbe3397addfc5588,
_show_installed_packages() trips up if host rpm cannot read the
database format used inside the chroot.

Using buildroot.all_chroot_packages() where this is already dealt with
fixes the issue and reduces code duplication while at it.

Fixes: #565