### PR TITLE
Fix doChroot() nspawn wrapper

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -256,7 +256,10 @@ class Buildroot(object):
             if 'gid' not in kargs:
                 kargs['gid'] = uid.getresgid()[1]
             if 'user' not in kargs:
-                kargs['gid'] = pwd.getpwuid(kargs['uid'])[0]
+                try:
+                    kargs['user'] = pwd.getpwuid(kargs['uid'])[0]
+                except KeyError:
+                    pass
             self.uid_manager.becomeUser(0, 0)
 
         try:


### PR DESCRIPTION
We need to be ready to catch KeyError if the getresuid() doesn't have
the corresponding /etc/passwd entry.

Also fix C&P issue, the code wanted to set kargs['user'], not
kargs['gid'].

Fixes: #571