### PR TITLE
expand braced variables

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -353,8 +353,10 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
                 expand[key] = self.config['dnf_vars'][key]
 
         for key, value in expand.items():
-            key = "$" + key
-            string = string.replace(key, value)
+            # replace both $key and ${key}
+            # dnf allows braced variables
+            string = string.replace('$' + key, value)
+            string = string.replace('${' + key + '}', value)
 
         return string
 

--- a/mock/tests/test_package_manager.py
+++ b/mock/tests/test_package_manager.py
@@ -179,7 +179,7 @@ class TestPackageManager:
         os.makedirs(repo_directory)
         config = (
             "[main]\n"
-            "baseurl = file://{0}/$basearch/$releasever/$test\n"
+            "baseurl = file://{0}/$basearch/${{releasever}}/$test\n"
         ).format(self.workdir)
 
         mounts = self.get_user_bind_mounts_from_config(config)


### PR DESCRIPTION
If a baseurl has "${releasever}", dnf understands that, but mock does
not.