### PR TITLE
Fix mount.py plugin

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -89,7 +89,7 @@ personality_defs = {
     'mips64r6': PER_LINUX, 'mips64r6el': PER_LINUX,
 }
 
-PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'bind_mount',
+PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
                'hw_info', 'procenv']


### PR DESCRIPTION
Without 'mount' plugin on PLUGIN_LIST, any previous given configuration
in util.py is replaced with empty config (so 'dirs' dict is dropped).

Accessing "config_opts['plugin_conf']['mount_opts']['dirs']" then by
user configuration causes traceback.

Fixes: #578, #583