### PR TITLE
config: Change all openSUSE configs to use the download redirector

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -32,15 +32,15 @@ protected_packages=
 
 [opensuse-leap-oss]
 name=openSUSE Leap $releasever - aarch64 - OSS
-#baseurl=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/
-metalink=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/
+#metalink=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 
 [updates-oss]
 name=openSUSE Leap $releasever - aarch64 - Updates - OSS
-#baseurl=http://download.opensuse.org/ports/update/leap/$releasever/oss/
-metalink=http://download.opensuse.org/ports/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/ports/update/leap/$releasever/oss/
+#metalink=http://download.opensuse.org/ports/update/leap/$releasever/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -32,15 +32,15 @@ protected_packages=
 
 [opensuse-leap-oss]
 name=openSUSE Leap $releasever - x86_64 - OSS
-#baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
-metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+#metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 
 [updates-oss]
 name=openSUSE Leap $releasever - x86_64 - Updates - OSS
-#baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
-metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
+#metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 

--- a/mock-core-configs/etc/mock/opensuse-leap-15.2-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.2-aarch64.cfg
@@ -32,15 +32,15 @@ protected_packages=
 
 [opensuse-leap-oss]
 name=openSUSE Leap $releasever - aarch64 - OSS
-#baseurl=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/
-metalink=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/
+#metalink=http://download.opensuse.org/ports/aarch64/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 
 [updates-oss]
 name=openSUSE Leap $releasever - aarch64 - Updates - OSS
-#baseurl=http://download.opensuse.org/ports/update/leap/$releasever/oss/
-metalink=http://download.opensuse.org/ports/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/ports/update/leap/$releasever/oss/
+#metalink=http://download.opensuse.org/ports/update/leap/$releasever/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 

--- a/mock-core-configs/etc/mock/opensuse-leap-15.2-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.2-x86_64.cfg
@@ -32,15 +32,15 @@ protected_packages=
 
 [opensuse-leap-oss]
 name=openSUSE Leap $releasever - x86_64 - OSS
-#baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
-metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+#metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 
 [updates-oss]
 name=openSUSE Leap $releasever - x86_64 - Updates - OSS
-#baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
-metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
+#metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -39,14 +39,14 @@ protected_packages=
 [opensuse-tumbleweed-oss]
 name=openSUSE Tumbleweed - {{ target_arch }} - OSS
 {% if target_arch in ['x86_64', 'i586'] %}
-#baseurl=http://download.opensuse.org/tumbleweed/repo/oss/
-metalink=http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/tumbleweed/repo/oss/
+#metalink=http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% elif target_arch in ['ppc64le', 'ppc64'] %}
-#baseurl=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
-metalink=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
+#metalink=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% elif target_arch in ['aarch64'] %}
-#baseurl=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/
-metalink=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/
+#metalink=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% endif %}
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1


### PR DESCRIPTION
openSUSE's MirrorBrain instance does the wrong thing with metalinks
and cannot guarantee the sanity of the repository content, so we
need to switch to the download redirector.

Hopefully one day we can switch back...

Fixes #553.