### PR TITLE
modularity: add support for disabling modules

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -154,6 +154,7 @@
 # and modules in bootstrap chroot.
 #config_opts['bootstrap_chroot_additional_packages'] = []
 #config_opts['bootstrap_module_enable'] = []
+#config_opts['bootstrap_module_disable'] = []
 #config_opts['bootstrap_module_install'] = []
 
 # if you want mock to automatically run createrepo on the rpms in your
@@ -421,6 +422,7 @@
 ## This will only work with DNF and when repo is configured with modules=1 for repo in dnf.conf.
 ## This is executed just before 'chroot_setup_cmd'.
 # config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_disable'] = ['list', 'of', 'modules']
 # config_opts['module_install'] = ['module1/profile', 'module2/profile']
 ## Use this to force foreing architecture (requires qemu-user-static)
 # config_opts['forcearch'] = None

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -153,8 +153,8 @@
 # These three are overrided in bootstrap by default as we usually do not want additional packages
 # and modules in bootstrap chroot.
 #config_opts['bootstrap_chroot_additional_packages'] = []
-#config_opts['bootstrap_module_enable'] = []
 #config_opts['bootstrap_module_disable'] = []
+#config_opts['bootstrap_module_enable'] = []
 #config_opts['bootstrap_module_install'] = []
 
 # if you want mock to automatically run createrepo on the rpms in your
@@ -421,8 +421,8 @@
 # config_opts['subscription-manager.conf'] = 'put file contents here.'
 ## This will only work with DNF and when repo is configured with modules=1 for repo in dnf.conf.
 ## This is executed just before 'chroot_setup_cmd'.
-# config_opts['module_enable'] = ['list', 'of', 'modules']
 # config_opts['module_disable'] = ['list', 'of', 'modules']
+# config_opts['module_enable'] = ['list', 'of', 'modules']
 # config_opts['module_install'] = ['module1/profile', 'module2/profile']
 ## Use this to force foreing architecture (requires qemu-user-static)
 # config_opts['forcearch'] = None

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -322,6 +322,9 @@ class Buildroot(object):
         if 'module_enable' in self.config and self.config['module_enable']:
             cmd = ['module', 'enable'] + self.config['module_enable']
             self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
+        if 'module_disable' in self.config and self.config['module_disable']:
+            cmd = ['module', 'disable'] + self.config['module_disable']
+            self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
         if 'module_install' in self.config and self.config['module_install']:
             cmd = ['module', 'install'] + self.config['module_install']
             self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -319,11 +319,11 @@ class Buildroot(object):
 
         update_state = '{0} install'.format(self.pkg_manager.name)
         self.state.start(update_state)
-        if 'module_enable' in self.config and self.config['module_enable']:
-            cmd = ['module', 'enable'] + self.config['module_enable']
-            self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
         if 'module_disable' in self.config and self.config['module_disable']:
             cmd = ['module', 'disable'] + self.config['module_disable']
+            self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
+        if 'module_enable' in self.config and self.config['module_enable']:
+            cmd = ['module', 'enable'] + self.config['module_enable']
             self.pkg_manager.init_install_output += self.pkg_manager.execute(*cmd, returnOutput=1)
         if 'module_install' in self.config and self.config['module_install']:
             cmd = ['module', 'install'] + self.config['module_install']

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1209,11 +1209,13 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     }
     config_opts['hostname'] = None
     config_opts['module_enable'] = []
+    config_opts['module_disable'] = []
     config_opts['module_install'] = []
     config_opts['forcearch'] = None
 
     config_opts['bootstrap_chroot_additional_packages'] = []
     config_opts['bootstrap_module_enable'] = []
+    config_opts['bootstrap_module_disable'] = []
     config_opts['bootstrap_module_install'] = []
 
     # security config

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1208,14 +1208,14 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         '%_netsharedpath': '/proc:/sys',
     }
     config_opts['hostname'] = None
-    config_opts['module_enable'] = []
     config_opts['module_disable'] = []
+    config_opts['module_enable'] = []
     config_opts['module_install'] = []
     config_opts['forcearch'] = None
 
     config_opts['bootstrap_chroot_additional_packages'] = []
-    config_opts['bootstrap_module_enable'] = []
     config_opts['bootstrap_module_disable'] = []
+    config_opts['bootstrap_module_enable'] = []
     config_opts['bootstrap_module_install'] = []
 
     # security config


### PR DESCRIPTION
Add support for disabling dnf modules.

CentOS 8 use case:
disable the go-toolset module so that newer golang rpms can be installed from local repos.