### PR TITLE
mock: copy source CA certificates

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -301,7 +301,7 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
 
     @traceLog()
     def copy_certs(self):
-        cert_path = "/etc/pki/ca-trust/extracted"
+        cert_path = "/etc/pki/ca-trust"
         pki_dir = self.buildroot.make_chroot_path(cert_path)
         try:
             copy_tree(cert_path, pki_dir)


### PR DESCRIPTION
Prior to this change, we would only copy the `extracted` SSL CA certificates into the chroot. If anything ran `update-ca-trust extract` inside the chroot, this would delete our custom SSL certificates from the `extracted` directory.

Copy the entire parent directory so that `sources` and `extracted` are both present in the chroot. With this change, `update-ca-trust extract` does not wipe out the CA certificates from the chroot.

Fixes: #588