### PR TITLE
Use a different .rpmmacros for install/build time

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -186,8 +186,8 @@ class _PackageManager(object):
         # intentionally we do not call bootstrap hook here - it does not have sense
         env = self.config['environment'].copy()
         env.update(util.get_proxy_environment(self.config))
-        # use our predefined $HOME/.rpmmacros with desired RPM configuration
-        env['HOME'] = self.buildroot.make_chroot_path(self.buildroot.homedir)
+        # installation-time specific homedir
+        env['HOME'] = self.buildroot.prepare_installation_time_homedir()
         env['LC_MESSAGES'] = 'C.UTF-8'
         if self.buildroot.nosync_path:
             env['LD_PRELOAD'] = self.buildroot.nosync_path

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1205,7 +1205,6 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['macros'] = {
         '%_topdir': '%s/build' % config_opts['chroothome'],
         '%_rpmfilename': '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm',
-        '%_netsharedpath': '/proc:/sys',
     }
     config_opts['hostname'] = None
     config_opts['module_enable'] = []


### PR DESCRIPTION
This was unified before under an assumption that nobody installs any
RPMs from within the mock chroot (except for the mock bootstrap chroot
itself).

But apparently tools like lorax and dracut do this, and then they miss
the /sys and /proc directories (normally installed by filesystem.rpm).
So let's split the logic again.

Before 85d544291da we created the installation .rpmmacros inside
"basedir" which was breaking --bootstrap-chroot inside Fedora Toolbox.
That was because the "basedir" isn't recursively bind-mounted below the
bootstrap chroot and thus the bootstrapped RPM failed to find the file.
Newly we create it in "rootdir" instead.

Resolves: rhbz#1848201
Reverts: 85d544291da69dbc521369c8b9b87baa3f7ffc42