### PR TITLE
lvm: don't recall set_current_snapshot unnecessarily

### DIFF
--- a/mock/py/mockbuild/plugins/lvm_root.py
+++ b/mock/py/mockbuild/plugins/lvm_root.py
@@ -334,7 +334,6 @@ class LvmPlugin(object):
         if not self.buildroot.chroot_was_initialized:
             snapshot_name = self.prefix_name(self.postinit_name)
             self.make_snapshot(snapshot_name)
-            self.set_current_snapshot(snapshot_name)
             self.buildroot.root_log.info(
                 "created {name} snapshot".format(name=self.postinit_name))
         # Relock as shared for following operations, noop if shared already


### PR DESCRIPTION
Per discussion in PR#594, it is useless to re-call set_current_snapshot
after make_snapshot.