### PR TITLE
Add `module_setup_commands` configuration option

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -153,8 +153,7 @@
 # These three are overrided in bootstrap by default as we usually do not want additional packages
 # and modules in bootstrap chroot.
 #config_opts['bootstrap_chroot_additional_packages'] = []
-#config_opts['bootstrap_module_enable'] = []
-#config_opts['bootstrap_module_install'] = []
+#config_opts['bootstrap_module_setup_commands'] = []
 
 # if you want mock to automatically run createrepo on the rpms in your
 # resultdir.
@@ -419,9 +418,23 @@
 ## Important! You should register your host machine first!
 # config_opts['subscription-manager.conf'] = 'put file contents here.'
 ## This will only work with DNF and when repo is configured with modules=1 for repo in dnf.conf.
-## This is executed just before 'chroot_setup_cmd'.
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
+
+# List of module commands to be executed when initializing chroot, before
+# `chroot_setup_cmd`.  Each command is a pair like `(action, module_specs)`
+# where `module_specs` is a comma-separated list of module specifications.
+# The commands are executed in order they are configured here, and each
+# `action` can be executed multiple times.
+#
+## Artificial example: (a) Disable any potentially enabled postgresql module
+## stream, (b) enable _specific_ postgresql and ruby module streams,
+## (c) install the development nodejs profile and (d) disable it immediately.
+#config_opts['module_setup_commands'] = [
+#  ('disable', 'postgresql'),
+#  ('enable',  'postgresql:12, ruby:2.6'),
+#  ('install', 'nodejs:13/development'),
+#  ('disable', 'nodejs'),
+#]
+
 ## Use this to force foreing architecture (requires qemu-user-static)
 # config_opts['forcearch'] = None
 # If you change chrootgid, you must also change "mock" to the correct group

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -1209,11 +1209,13 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['hostname'] = None
     config_opts['module_enable'] = []
     config_opts['module_install'] = []
+    config_opts['module_setup_commands'] = []
     config_opts['forcearch'] = None
 
     config_opts['bootstrap_chroot_additional_packages'] = []
     config_opts['bootstrap_module_enable'] = []
     config_opts['bootstrap_module_install'] = []
+    config_opts['bootstrap_module_setup_commands'] = []
 
     # security config
     config_opts['no_root_shells'] = False

--- a/mock/tests/test_buildroot.py
+++ b/mock/tests/test_buildroot.py
@@ -1,0 +1,24 @@
+""" Tests for buildroot.py """
+
+from unittest.mock import MagicMock
+from mockbuild import util, buildroot
+
+
+def test_module_config():
+    """ test _module_commands_from_config method """
+    def _check(config, output):
+        assert buildroot.Buildroot._module_commands_from_config(config) \
+            == output
+    _check([("enable", "module:stream")],
+           [["module", "enable", "module:stream"]])
+    _check([("enable", "module:stream, module2:stream2")],
+           [["module", "enable", "module:stream", "module2:stream2"]])
+    _check([("disable", "module:*,module2:*"),
+            ("enable", "module:stream, module2:stream2"),
+            ("install", "pg:12")],
+           [["module", "disable", "module:*", "module2:*"],
+            ["module", "enable", "module:stream", "module2:stream2"],
+            ["module", "install", "pg:12"]])
+
+    _check([("info", "")], [["module", "info"]])
+    _check([("info", None)], [["module", "info"]])


### PR DESCRIPTION
It obsoletes `module_enable` and `module_install` configuration options
(still supported) but allows users to also configure "disable",
"remove", "list", and other commands.

It may or may not be useful in future, but we also execute the commands
from `module_setup_commands` as they are specified, so people can do
things like `disable foo:*` and then `enable foo:stream`.

Replaces: #586