### PR TITLE
Fix site-defaults.cfg reference to docs

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -100,6 +100,7 @@ fi
 # reference valid mock.rpm's docdir with example site-defaults.cfg
 mock_docs=%{_pkgdocdir}
 mock_docs=${mock_docs//mock-core-configs/mock}
+mock_docs=${mock_docs//-%version/-*}
 sed -i "s~@MOCK_DOCS@~$mock_docs~" %{buildroot}%{_sysconfdir}/mock/site-defaults.cfg
 
 %pre


### PR DESCRIPTION
On systems where %_pkgdocdir isn't specified or it points to versioned
directory, the docs directory looks like `../mock-core-configs-32.3/`
and we want to point user to `../mock-2.3/`.  At that build-time moment
we aren't able to tell the version of _mock_, so it is better to point
the user only to shell wild-card `../mock-*/`.

Per report in #597