### PR TITLE
config: adding config for epel-8-s390x

### DIFF
--- a/mock-core-configs/etc/mock/epel-8-s390x.cfg
+++ b/mock-core-configs/etc/mock/epel-8-s390x.cfg
@@ -1,0 +1,5 @@
+include('templates/epel-8.tpl')
+
+config_opts['root'] = 'epel-8-s390x'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)


### PR DESCRIPTION
Adding missing config for s390x for epel 8 so we can use emulated s390x builders in copr.