### PR TITLE
opensuse: tolerate a 1-minute baseurl outages

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-aarch64.cfg
@@ -10,6 +10,13 @@ config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
+# Due to the nature of the OpenSUSE mirroring system, we can not use
+# metalinks easily and also we can not rely on the fact that baseurl's
+# always work (issue #553) -- by design we need to expect a one minute
+# repository problems (configured four attempts means 3 periods of 20s).
+config_opts['package_manager_max_attempts'] = 4
+config_opts['package_manager_attempt_delay'] = 20
+
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1

--- a/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.1-x86_64.cfg
@@ -10,6 +10,13 @@ config_opts['macros']['%dist'] = '.suse.lp151'
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
+# Due to the nature of the OpenSUSE mirroring system, we can not use
+# metalinks easily and also we can not rely on the fact that baseurl's
+# always work (issue #553) -- by design we need to expect a one minute
+# repository problems (configured four attempts means 3 periods of 20s).
+config_opts['package_manager_max_attempts'] = 4
+config_opts['package_manager_attempt_delay'] = 20
+
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1

--- a/mock-core-configs/etc/mock/opensuse-leap-15.2-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.2-aarch64.cfg
@@ -10,6 +10,13 @@ config_opts['macros']['%dist'] = '.suse.lp152'
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
+# Due to the nature of the OpenSUSE mirroring system, we can not use
+# metalinks easily and also we can not rely on the fact that baseurl's
+# always work (issue #553) -- by design we need to expect a one minute
+# repository problems (configured four attempts means 3 periods of 20s).
+config_opts['package_manager_max_attempts'] = 4
+config_opts['package_manager_attempt_delay'] = 20
+
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1

--- a/mock-core-configs/etc/mock/opensuse-leap-15.2-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.2-x86_64.cfg
@@ -10,6 +10,13 @@ config_opts['macros']['%dist'] = '.suse.lp152'
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
+# Due to the nature of the OpenSUSE mirroring system, we can not use
+# metalinks easily and also we can not rely on the fact that baseurl's
+# always work (issue #553) -- by design we need to expect a one minute
+# repository problems (configured four attempts means 3 periods of 20s).
+config_opts['package_manager_max_attempts'] = 4
+config_opts['package_manager_attempt_delay'] = 20
+
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -7,6 +7,13 @@ config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VER
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
+# Due to the nature of the OpenSUSE mirroring system, we can not use
+# metalinks easily and also we can not rely on the fact that baseurl's
+# always work (issue #553) -- by design we need to expect a one minute
+# repository problems (configured four attempts means 3 periods of 20s).
+config_opts['package_manager_max_attempts'] = 4
+config_opts['package_manager_attempt_delay'] = 20
+
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1


### PR DESCRIPTION
Per discussion in #553 it isn't correct to specify "metalink=" for
OpenSUSE repositories, but mirrored "baseurl=".  But the "baseurl="
links are expected to have up t0 1-minute downtimes.  Therefore we need
to re-try the dnf command in case of repo failure.

Fixes: #553
Replaces: #585