### PR TITLE
Add showrc plugin to record the output of rpm --showrc

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -231,6 +231,10 @@
 # config_opts['plugin_conf']['procenv_enable'] = False
 # config_opts['plugin_conf']['procenv_opts'] = {}
 #
+# config_opts['plugin_conf']['showrc'] = False
+# config_opts['plugin_conf']['showrc'] = {}
+#
+#
 # bind mount plugin is enabled by default but has no configured directories to
 # mount
 # config_opts['plugin_conf']['bind_mount_enable'] = True

--- a/mock/py/mockbuild/plugins/compress_logs.py
+++ b/mock/py/mockbuild/plugins/compress_logs.py
@@ -27,7 +27,8 @@ class CompressLogsPlugin(object):
     def _compress_logs(self):
         logger = getLog()
         for f_name in ('root.log', 'build.log', 'state.log', 'available_pkgs.log',
-                       'installed_pkgs.log', 'hw_info.log', 'procenv.log'):
+                       'installed_pkgs.log', 'hw_info.log', 'procenv.log',
+                       'showrc.log'):
             f_path = os.path.join(self.buildroot.resultdir, f_name)
             if os.path.exists(f_path):
                 command = "{0} {1}".format(self.command, f_path)

--- a/mock/py/mockbuild/plugins/showrc.py
+++ b/mock/py/mockbuild/plugins/showrc.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+
+# python library imports
+import codecs
+
+# our imports
+from mockbuild.trace_decorator import getLog, traceLog
+import mockbuild.util
+
+requires_api_version = "1.1"
+
+
+# plugin entry point
+@traceLog()
+def init(plugins, conf, buildroot):
+    ShowRC(plugins, conf, buildroot)
+
+
+class ShowRC(object):
+    # pylint: disable=too-few-public-methods
+    """Get the runtime rpm --showrc"""
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.showrc_opts = conf
+        self.config = buildroot.config
+
+        # actually run our plugin at this step
+        plugins.add_hook("prebuild", self._PreBuildHook)
+
+    # =============
+    # 'Private' API
+    # =============
+    @traceLog()
+    def _PreBuildHook(self):
+        getLog().info("enabled ShowRC plugin")
+
+        out_file = self.buildroot.resultdir + '/showrc.log'
+        with codecs.open(out_file, 'w', 'utf-8', 'replace') as out:
+
+            cmd = ["/usr/bin/rpm", "--showrc"]
+            output = mockbuild.util.do(cmd, shell=False, returnOutput=True, raiseExc=False)
+            out.write(output)
+
+        self.buildroot.uid_manager.changeOwner(out_file, gid=self.config['chrootgid'])

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -92,7 +92,7 @@ personality_defs = {
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
-               'hw_info', 'procenv']
+               'hw_info', 'procenv', 'showrc']
 
 USE_NSPAWN = False
 
@@ -1137,6 +1137,9 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
         },
         'procenv_enable': False,
         'procenv_opts': {
+        },
+        'showrc_enable': False,
+        'showrc_opts': {
         },
         'compress_logs_enable': False,
         'compress_logs_opts': {


### PR DESCRIPTION
For deeper insight into what macros existed and how they were defined at build time, I added a plugin that will record the output of `rpm --showrc`.  This would be handy when trying to determine exactly what packaging macros were present in the buildroot.