### PR TITLE
Accept MOCK_TRACE_LOG=false env variable

### DIFF
--- a/mock/etc/consolehelper/mock
+++ b/mock/etc/consolehelper/mock
@@ -2,5 +2,5 @@ USER=root
 PROGRAM=/usr/libexec/mock/mock
 SESSION=false
 FALLBACK=false
-KEEP_ENV_VARS=COLUMNS,SSH_AUTH_SOCK,http_proxy,ftp_proxy,https_proxy,no_proxy
+KEEP_ENV_VARS=COLUMNS,SSH_AUTH_SOCK,http_proxy,ftp_proxy,https_proxy,no_proxy,MOCK_TRACE_LOG
 BANNER=You are not in the `mock` group. See https://github.com/rpm-software-management/mock/wiki#setup

--- a/mock/py/mockbuild/trace_decorator.py
+++ b/mock/py/mockbuild/trace_decorator.py
@@ -106,6 +106,9 @@ def traceLog(logger=None):
         return trace
         #end of trace()
 
+    if os.environ.get("MOCK_TRACE_LOG", "true") == "false":
+        return noop
+
     if logging.getLogger("trace").propagate:
         return decorator
     else:


### PR DESCRIPTION
When this environment variable is exported in environment, mock doesn't
go into the traceLog() logic (uses noop() tracing) - so it simplifies
the (i)pdb debugging a lot.