### PR TITLE
Auto-download the source RPMs from web with --rebuild

### DIFF
--- a/behave/features/auto-download-of-srpm.feature
+++ b/behave/features/auto-download-of-srpm.feature
@@ -1,0 +1,8 @@
+Feature: Check that we download source RPMs URLs
+
+    @autodownload
+    Scenario: Mock downloads SRPMs in --rebuild mode
+        Given an unique mock namespace
+        And pre-intitialized chroot
+        When an online source RPM is rebuilt
+        Then the build succeeds

--- a/behave/features/steps/other.py
+++ b/behave/features/steps/other.py
@@ -97,3 +97,9 @@ def step_impl(context, expected_message):
     err = context.last_cmd[2].splitlines()
     assert_that(err, has_length(1))
     assert_that(err[0], contains_string(expected_message))
+
+
+@when('an online source RPM is rebuilt')
+def step_impl(context):
+    url = context.test_storage + "mock-test-bump-version-1-0.src.rpm"
+    context.mock.rebuild([url])

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -88,6 +88,7 @@ BuildRequires: python%{python3_pkgversion}-jinja2
 BuildRequires: python%{python3_pkgversion}-pyroute2
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-pytest-cov
+BuildRequires: python%{python3_pkgversion}-requests
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 8

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -908,7 +908,19 @@ def run_command(options, args, config_opts, commands, buildroot, state):
                 options.sources = None
             else:
                 config_opts['clean'] = False
-        mockbuild.rebuild.do_rebuild(config_opts, commands, buildroot, options, args)
+
+        try:
+            srpms = []
+            for srpm_location in args:
+                with buildroot.uid_manager:
+                    srpm = util.FileDownloader.get(srpm_location)
+                if not srpm:
+                    raise mockbuild.exception.BadCmdline(
+                        "Invalid {} source RPM".format(srpm_location))
+                srpms.append(srpm)
+            mockbuild.rebuild.do_rebuild(config_opts, commands, buildroot, options, srpms)
+        finally:
+            util.FileDownloader.cleanup()
 
     elif options.mode == 'buildsrpm':
         mockbuild.rebuild.do_buildsrpm(config_opts, commands, buildroot, options, args)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 
 from ast import literal_eval
 import atexit
+import cgi
 import ctypes
 import errno
 import fcntl
@@ -22,6 +23,7 @@ import pickle
 import pipes
 import pwd
 import re
+import requests
 import select
 import signal
 import shlex
@@ -36,6 +38,7 @@ import tempfile
 import termios
 from textwrap import dedent
 import time
+from urllib.parse import urlsplit
 import uuid
 
 import distro
@@ -1868,3 +1871,76 @@ def subscription_redhat_init(opts):
 def is_host_rh_family():
     distro_name = distro.linux_distribution(full_distribution_name=False)[0]
     return distro_name in RHEL_CLONES + ['fedora']
+
+
+class FileDownloader:
+    tmpdir = None
+    backmap = None
+
+    @classmethod
+    def _initialize(cls):
+        if cls.tmpdir:
+            return
+        cls.backmap = {}
+        cls.tmpdir = tempfile.mkdtemp()
+
+    @classmethod
+    def get(cls, pkg_url_or_local_file):
+        """
+        If the pkg_url_or_local_file looks like a link, try to download it and
+        store it to a temporary directory - and return path to the local
+        downloaded file.
+
+        If the pkg_url_or_local_file is not a link, do nothing - just return
+        the pkg_url_or_local_file argument.
+        """
+        pkg = pkg_url_or_local_file
+        log = getLog()
+
+        url_prefixes = ['http://', 'https://', 'ftp://']
+        if not any([pkg.startswith(pfx) for pfx in url_prefixes]):
+            log.debug("Local file: %s", pkg)
+            return pkg
+
+        cls._initialize()
+        try:
+            url = pkg
+            log.info('Fetching remote file %s', url)
+            req = requests.get(url)
+            req.raise_for_status()
+            if req.status_code != requests.codes.ok:
+                log.error("Can't download {}".format(url))
+                return False
+
+            filename = urlsplit(req.url).path.rsplit('/', 1)[1]
+            if 'content-disposition' in req.headers:
+                _, params = cgi.parse_header(req.headers['content-disposition'])
+                if 'filename' in params and params['filename']:
+                    filename = params['filename']
+            pkg = cls.tmpdir + '/' + filename
+            with open(pkg, 'wb') as filed:
+                for chunk in req.iter_content(4096):
+                    filed.write(chunk)
+            cls.backmap[pkg] = url
+            return pkg
+        except Exception as err:  # pylint: disable=broad-except
+            log.error('Downloading error %s: %s', url, str(err))
+        return None
+
+    @classmethod
+    def original_name(cls, localname):
+        """ Get the URL from the local name """
+        if not cls.backmap:
+            return localname
+        return cls.backmap.get(localname, localname)
+
+    @classmethod
+    def cleanup(cls):
+        """ Remove the temporary storage with downloaded RPMs """
+        if not cls.tmpdir:
+            return
+        getLog().debug("Cleaning the temporary download directory: %s", cls.tmpdir)
+        cls.backmap = {}
+        # cleaning up our download dir
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+        cls.tmpdir = None

--- a/mock/requirements.txt
+++ b/mock/requirements.txt
@@ -2,3 +2,4 @@ distro
 jinja2
 pyroute2
 pytest-cov
+requests


### PR DESCRIPTION
The downloading mechanism worked before for --chain method, so move it
to a common place and reuse it for both --chain and --rebuild modes.