### PR TITLE
Fix _copy_config() for broken symlinks in dst=

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -280,18 +280,17 @@ class Buildroot(object):
     def _copy_config(self, filename, symlink=False):
         etcdir = self.make_chroot_path('etc')
         conf_file = os.path.join(etcdir, filename)
-        if os.path.exists(conf_file):
+        try:
             os.remove(conf_file)
+        except FileNotFoundError:
+            pass
         orig_conf_file = os.path.join('/etc', filename)
+
         if os.path.exists(orig_conf_file):
             if symlink and os.path.islink(orig_conf_file):
                 linkto = os.readlink(orig_conf_file)
                 dst = self.make_chroot_path(orig_conf_file)
-                try:
-                    os.symlink(linkto, dst)
-                except FileExistsError:
-                    os.unlink(dst)
-                    os.symlink(linkto, dst)
+                os.symlink(linkto, dst)
             else:
                 shutil.copy2(orig_conf_file, etcdir)
         else:


### PR DESCRIPTION
shutil.copy*() ignores the broken symbolic link in dst=, and simply
attempts to create the symbolic link destination file [1] and that
operation is likely to fail in mock case.

We already tried to remove the destination file, but first it was a (a)
TOCTOU way and (b) also the used os.path.exists() returns False for
broken symlinks.  So newly, let's unlink the file first without asking,
and just ignore FileNotFoundError.

[1] https://bugs.python.org/issue34374

Fixes: rhbz#1878924