### PR TITLE
Don't swallow preexec_fn exceptions

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -617,20 +617,24 @@ class ChildPreExec(object):
         getLog().debug("child environment: %s", env)
 
     def __call__(self, *args, **kargs):
-        if not self.shell:
-            os.setsid()
-        os.umask(0o02)
-        condUnshareNet(self.unshare_net)
-        condPersonality(self.personality)
-        condEnvironment(self.env)
-        # Even if nspawn is allowed to be used, it won't be used unless there
-        # is a chrootPath set
-        if not USE_NSPAWN or not self.chrootPath:
-            condChroot(self.chrootPath)
-            condDropPrivs(self.uid, self.gid)
-            condChdir(self.cwd)
-        condUnshareIPC(self.unshare_ipc)
-        reset_sigpipe()
+        try:
+            if not self.shell:
+                os.setsid()
+            os.umask(0o02)
+            condUnshareNet(self.unshare_net)
+            condPersonality(self.personality)
+            condEnvironment(self.env)
+            # Even if nspawn is allowed to be used, it won't be used unless there
+            # is a chrootPath set
+            if not USE_NSPAWN or not self.chrootPath:
+                condChroot(self.chrootPath)
+                condDropPrivs(self.uid, self.gid)
+                condChdir(self.cwd)
+            condUnshareIPC(self.unshare_ipc)
+            reset_sigpipe()
+        except:  # pylint: disable=bare-except
+            getLog().exception("Exception raised in ChildPreExec")
+            raise
 
 
 def setup_operations_timeout(config_opts):


### PR DESCRIPTION
If any exception is raised from preexec_fn, subprocess module just
swallows the exception, and prints non-explaining error:

    subprocess.SubprocessError: Exception occurred in preexec_fn.

Newly we temporarily catch the exception, and dump it to logs before we
re-raise it.