### PR TITLE
Hotfix preexec_fn problem on RHEL 8 s390x

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -268,7 +268,7 @@ def getAddtlReqs(hdr, conf):
 
 @traceLog()
 def unshare(flags):
-    getLog().debug("Unsharing. Flags: %s", flags)
+    #getLog().debug("Unsharing. Flags: %s", flags)
     try:
         res = _libc.unshare(flags)
         if res:


### PR DESCRIPTION
This symptoms look like a combination of several problems.

It was pretty complicated to debug (we can not easily see tracebacks
from subprocess's if we set stdout/err to subprocess.PIPE and handling
that in logOutput() too late);  with the help of traceback.print_exc(),
I catched the error in ChildPreExec.__call__(), and it looked like:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mockbuild/util.py", line 821, in __call__
    log = getLog()
  File "/usr/lib/python3.6/site-packages/mockbuild/util.py", line 520, in condUnshareIPC
    logger.info("Child dead, killing orphans")
  File "/usr/lib/python3.6/site-packages/mockbuild/util.py", line 461, in unshare
    # https://github.com/rpm-software-management/mock/issues/113
  File "/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py", line 22, in __init__
    # works around problem where reconfiguring the logging module means loggers
  File "/usr/lib64/python3.6/inspect.py", line 1478, in getouterframes
    frameinfo = (frame,) + getframeinfo(frame, context)
  File "/usr/lib64/python3.6/inspect.py", line 1452, in getframeinfo
    lines, lnum = findsource(frame)
  File "/usr/lib64/python3.6/inspect.py", line 828, in findsource
    if pat.match(lines[lnum]): break
```

Which looks like a Python bug?  But doing getLog() inside the preexec_fn
wouldn't probably work anyways (separate process, not sharing output
file descriptors).

Relates: #653