### PR TITLE
sign: don't ignore signing command failure

### DIFF
--- a/mock/py/mockbuild/plugins/sign.py
+++ b/mock/py/mockbuild/plugins/sign.py
@@ -40,4 +40,4 @@ class Sign(object):
                 cmd = "{0} {1}".format(self.conf['cmd'], opts)
                 getLog().info("Executing %s", cmd)
                 with self.buildroot.uid_manager:
-                    subprocess.call(cmd, shell=True, env=os.environ)
+                    subprocess.check_call(cmd, shell=True, env=os.environ)


### PR DESCRIPTION
The exception raised by check_call won't be caught, and will bubble up
to mock.py - and the whole trace-back will be printed.  This isn't very
nice, though three's no exception mechanism implemented in the hook
design, and we already raise generic Exceptions in e.g. overlayfs
plugin.  NB, the RPM signing process is important enough to simply
ignore its failure.

Originally reported in:
https://pagure.io/koji/issue/2570