### PR TITLE
Add missing CRB repository

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -105,4 +105,38 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
 skip_if_unavailable=False
+
+
+[eln-crb]
+name=Fedora - ELN CodeReady Linux Builders - Build packages for the next Enterprise Linux release
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
+skip_if_unavailable=False
+
+[eln-crb-debuginfo]
+name=Fedora - ELN CodeReady Linux Builders - Debug
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/debug/tree
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
+skip_if_unavailable=False
+
+[eln-crb-source]
+name=Fedora - ELN CodeReady Linux Builders - Source
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/source/tree/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
+skip_if_unavailable=False
 """


### PR DESCRIPTION
Without this a plenty of build dependencies are missing. At least Anaconda can't be build.

When building Anaconda I'm getting https://github.com/rhinstaller/anaconda/pull/2868#issuecomment-725525020 most of these dependencies are part of the CRB and from my understanding the CRB repository should be part of build-root which is exactly what mock is doing.

However, even with these I'm missing:
- gtk3-devel-docs
- libtimezonemap-devel

Wonder where these are...

@mmathesius could you please verify validity of this PR?