### PR TITLE
ELN should use for build Everything repository

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -31,6 +31,9 @@ module_platform_id=platform:eln
 protected_packages=
 
 # repos
+# The Everything repository have to be enabled to get all of the packages because
+# some of them are not present anywhere else. Also the AppStream repository
+# have to be enabled because it contain modules. Everything else is not required.
 [local]
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
@@ -38,11 +41,45 @@ cost=2000
 enabled=0
 skip_if_unavailable=False
 
+[eln]
+name=Fedora - ELN - Developmental packages for the next Enterprise Linux release
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Everything/$basearch/os/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+enabled=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
+skip_if_unavailable=False
+
+[eln-debuginfo]
+name=Fedora - ELN - Debug
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Everything/$basearch/debug/tree
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
+skip_if_unavailable=False
+
+[eln-source]
+name=Fedora - ELN - Source
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Everything/source/tree/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+enabled=0
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
+skip_if_unavailable=False
+
+
 [eln-baseos]
 name=Fedora - ELN BaseOS - Developmental packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/$basearch/os/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
-enabled=1
+enabled=0
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1
@@ -70,7 +107,6 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary
 skip_if_unavailable=False
-
 
 
 [eln-appstream]
@@ -111,7 +147,7 @@ skip_if_unavailable=False
 name=Fedora - ELN CodeReady Linux Builders - Build packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
 #metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
-enabled=1
+enabled=0
 repo_gpgcheck=0
 type=rpm
 gpgcheck=1


### PR DESCRIPTION
ELN BaseOS, AppStream and CRB repositories are for runtime. However, as in RHEL there are even packages which are just in the buildroot. These packages are not part of the repositories above but only Everything repository.

So to reflect how the next RHEL will be build we should use only the Everything repository which should contain all the packages not just ones which will be shipped.

Hopefully, this should be the ultimate solution for our ELN missing packages problem. @sgallagher @mmathesius could you please do a review for me here? Thanks!

The everything repository have the missing packages required for Anaconda build.