### PR TITLE
mock: call buildroot.install(), not commands.install()

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -901,7 +901,7 @@ def run_command(options, args, config_opts, commands, buildroot, state):
             return 50
 
         commands.init()
-        commands.install(*args)
+        buildroot.install(*args)
 
     elif options.mode == 'update':
         commands.init()
@@ -912,7 +912,7 @@ def run_command(options, args, config_opts, commands, buildroot, state):
             log.critical("You must specify a package list to remove.")
             return 50
         commands.init()
-        commands.remove(*args)
+        buildroot.remove(*args)
 
     elif options.mode == 'rebuild':
         if config_opts['scm'] or (options.spec and options.sources):


### PR DESCRIPTION
Complements 33ebacd8ce03130a8443bc28850d8c973fe891b9