### PR TITLE
Fix sign plugin testsuite

### DIFF
--- a/mock/integration-tests/19-sign-plugin.tst
+++ b/mock/integration-tests/19-sign-plugin.tst
@@ -42,12 +42,16 @@ trap cleanup EXIT
 runcmd "$MOCKCMD --rebuild ${TESTDIR}/test-C-1.1-0.src.rpm --resultdir $TMPDIR" \
     || die "mock rebuild failed"
 
-rpmoutput=$(rpm --qf '%{NAME} %{SIGPGP:pgpsig}\n' -qp "$TMPDIR"/*.rpm 2>/dev/null)
+rpmoutput=$(rpm --qf '%{NAME} %{RSAHEADER}\n' -qp "$TMPDIR"/*.rpm 2>/dev/null)
 lines=0
 while read -r line; do
     case $line in
-        *"Key ID"*) ;;
-        *) die "some packages are not signed" ;;
+        "(none)") die "some packages are not signed" ;;
+        *)
+            if test ${#line} -lt 256; then
+                die "weird signature $line"
+            fi
+            ;;
     esac
     lines=$(( lines + 1 ))
 done <<<"$rpmoutput"


### PR DESCRIPTION
The SIGPGP tag isn't filled nowadays, we need to use RSAHEADER.

Relates: rhbz#1902342