### PR TITLE
Fix use of nspawn (#678)

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -645,6 +645,11 @@ def setup_operations_timeout(config_opts):
     _OPS_TIMEOUT = config_opts.get('opstimeout', 0)
 
 
+def set_use_nspawn(value):
+    global USE_NSPAWN
+    USE_NSPAWN = value
+
+
 class BindMountedFile(str):
     'see host_file() doc'
     def __new__(cls, value, on_host=None):


### PR DESCRIPTION
877b332 broke this by splitting the code that actually decides
what `USE_NSPAWN` should be into the `config` module...where it
now only set `config.USE_NSPAWN`, but everything that actually
changes behaviour based on the value reads `util.USE_NSPAWN`,
which was now always False.

This feels a bit ugly, but should at least solve the problem in
a safe way, by having the parsing code in `config` update the
value of the actual variable in `util`.

Signed-off-by: Adam Williamson <awilliam@redhat.com>