### PR TITLE
use TemplatedDictionary as standalone module

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -61,6 +61,7 @@ Requires: python%{python3_pkgversion}-jinja2
 Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-rpm
 Requires: python%{python3_pkgversion}-pyroute2
+Requires: python%{python3_pkgversion}-templated-dictionary
 BuildRequires: python%{python3_pkgversion}-devel
 %if %{with lint}
 BuildRequires: python%{python3_pkgversion}-pylint
@@ -89,6 +90,7 @@ BuildRequires: python%{python3_pkgversion}-pyroute2
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-pytest-cov
 BuildRequires: python%{python3_pkgversion}-requests
+BuildRequires: python%{python3_pkgversion}-templated-dictionary
 %endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 8

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -17,7 +17,7 @@ import re
 import socket
 import sys
 
-
+from templated_dictionary import TemplatedDictionary
 from . import exception
 from . import text
 from .file_util import is_in_dir
@@ -49,7 +49,7 @@ def nspawn_supported():
 @traceLog()
 def setup_default_config_opts(unprivUid, version, pkgpythondir):
     "sets up default configuration."
-    config_opts = text.TemplatedDictionary(alias_spec={'dnf.conf': ['yum.conf']})
+    config_opts = TemplatedDictionary(alias_spec={'dnf.conf': ['yum.conf']})
     config_opts['config_paths'] = []
     config_opts['version'] = version
     config_opts['basedir'] = '/var/lib/mock'  # root name is automatically added to this

--- a/mock/py/mockbuild/text.py
+++ b/mock/py/mockbuild/text.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
 
-from collections.abc import MutableMapping
 import locale
-import jinja2
 
 from .trace_decorator import getLog
 
@@ -20,89 +18,6 @@ def compat_expand_string(string, conf_dict):
     getLog().warning("Obsoleted %(foo) config expansion in '{}', "
                      "use Jinja alternative {{foo}}".format(string))
     return string % conf_dict
-
-
-# pylint: disable=no-member,unsupported-assignment-operation
-class TemplatedDictionary(MutableMapping):
-    """ Dictionary where __getitem__() is run through Jinja2 template """
-    def __init__(self, *args, alias_spec=None, **kwargs):
-        '''
-        Use the object dict.
-
-        Optional parameter 'alias_spec' is dictionary of form:
-        {'aliased_to': ['alias_one', 'alias_two', ...], ...}
-        When specified, and one of the aliases is accessed - the
-        'aliased_to' config option is returned.
-        '''
-        self.__dict__.update(*args, **kwargs)
-
-        self._aliases = {}
-        if alias_spec:
-            for aliased_to, aliases in alias_spec.items():
-                for alias in aliases:
-                    self._aliases[alias] = aliased_to
-
-    # The next five methods are requirements of the ABC.
-    def __setitem__(self, key, value):
-        key = self._aliases.get(key, key)
-        self.__dict__[key] = value
-
-    def __getitem__(self, key):
-        key = self._aliases.get(key, key)
-        if '__jinja_expand' in self.__dict__ and self.__dict__['__jinja_expand']:
-            return self.__render_value(self.__dict__[key])
-        return self.__dict__[key]
-
-    def __delitem__(self, key):
-        del self.__dict__[key]
-
-    def __iter__(self):
-        return iter(self.__dict__)
-
-    def __len__(self):
-        return len(self.__dict__)
-
-    # The final two methods aren't required, but nice to have
-    def __str__(self):
-        '''returns simple dict representation of the mapping'''
-        return str(self.__dict__)
-
-    def __repr__(self):
-        '''echoes class, id, & reproducible representation in the REPL'''
-        return '{}, TemplatedDictionary({})'.format(super(TemplatedDictionary, self).__repr__(),
-                                                    self.__dict__)
-
-    def copy(self):
-        return TemplatedDictionary(self.__dict__)
-
-    def __render_value(self, value):
-        if isinstance(value, str):
-            return self.__render_string(value)
-        elif isinstance(value, list):
-            # we cannot use list comprehension here, as we need to NOT modify the list (pointer to list)
-            # and we need to modifiy only individual values in the list
-            # If we would create new list, we cannot assign to it, which often happens in configs (e.g. plugins)
-            for i in range(len(value)):  # pylint: disable=consider-using-enumerate
-                value[i] = self.__render_value(value[i])
-            return value
-        elif isinstance(value, dict):
-            # we cannot use list comprehension here, same reasoning as for `list` above
-            for k in value.keys():
-                value[k] = self.__render_value(value[k])
-            return value
-        else:
-            return value
-
-    def __render_string(self, value):
-        orig = last = value
-        max_recursion = self.__dict__.get('jinja_max_recursion', 5)
-        for _ in range(max_recursion):
-            template = jinja2.Template(value, keep_trailing_newline=True)
-            value = _to_native(template.render(self.__dict__))
-            if value == last:
-                return value
-            last = value
-        raise ValueError("too deep jinja re-evaluation on '{}'".format(orig))
 
 
 def _to_text(obj, arg_encoding='utf-8', errors='strict', nonstring='strict'):

--- a/mock/requirements.txt
+++ b/mock/requirements.txt
@@ -3,3 +3,4 @@ jinja2
 pyroute2
 pytest-cov
 requests
+templated-dictionary

--- a/mock/tests/test_config_templates.py
+++ b/mock/tests/test_config_templates.py
@@ -1,5 +1,5 @@
 import pytest
-from mockbuild.text import TemplatedDictionary
+from templated_dictionary import TemplatedDictionary
 
 
 def test_transitive_expand():

--- a/mock/tests/test_package_manager.py
+++ b/mock/tests/test_package_manager.py
@@ -6,7 +6,7 @@ import pytest
 from unittest import mock
 from unittest.mock import MagicMock
 
-from mockbuild.text import TemplatedDictionary
+from templated_dictionary import TemplatedDictionary
 from mockbuild.config import load_defaults
 from mockbuild.buildroot import Buildroot
 from mockbuild.package_manager import _PackageManager, Dnf


### PR DESCRIPTION
I extracted this code to separate project https://github.com/xsuchy/templated-dictionary

This can be merged as soon as
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2020-6b516c40dc land in the stable.

If anyone is packaging mock for some distribution (other than EPEL, Fedora), please package this requirement before the next release of Mock.