### PR TITLE
Update Fedora/CentOS/RHEL bootstrap images and add openSUSE Tumbleweed image

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -4,7 +4,7 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils f
 
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
-config_opts['bootstrap_image'] = 'centos:7'
+config_opts['bootstrap_image'] = 'registry.centos.org/centos:7'
 config_opts['package_manager'] = 'yum'
 
 config_opts['yum_install_command'] += "{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %} --disablerepo=centos-sclo*{% endif %}"

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'centos:8'
+config_opts['bootstrap_image'] = 'registry.centos.org/centos:8'
 
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/centos-stream.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'centos:8'
+config_opts['bootstrap_image'] = 'registry.centos.org/centos:8'
 config_opts['dnf_vars'] = { 'stream': '8-stream',
                             'contentdir': 'centos',
                           }

--- a/mock-core-configs/etc/mock/templates/fedora-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-branched.tpl
@@ -10,7 +10,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 config_opts['dist'] = 'fc{{ releasever }}'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['package_manager'] = 'dnf'
-config_opts['bootstrap_image'] = 'fedora:{{ releasever }}'
+config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -11,7 +11,7 @@ config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '34'
 config_opts['package_manager'] = 'dnf'
-config_opts['bootstrap_image'] = 'fedora:rawhide'
+config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -5,6 +5,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '0'
 config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VERSION_ID")'
 config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'registry.opensuse.org/opensuse/tumbleweed-dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
 
 # Due to the nature of the OpenSUSE mirroring system, we can not use

--- a/mock-core-configs/etc/mock/templates/rhel-7.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-7.tpl
@@ -2,7 +2,7 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils f
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7Server'
 config_opts['package_manager'] = 'yum'
-config_opts['bootstrap_image'] = 'ubi7/ubi'
+config_opts['bootstrap_image'] = 'registry.access.redhat.com/ubi7/ubi'
 
 config_opts['dnf_install_command'] += ' subscription-manager'
 config_opts['yum_install_command'] += ' subscription-manager'

--- a/mock-core-configs/etc/mock/templates/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-8.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
-config_opts['bootstrap_image'] = 'ubi8/ubi'
+config_opts['bootstrap_image'] = 'registry.access.redhat.com/ubi8/ubi'
 
 config_opts['dnf_install_command'] += ' subscription-manager'
 config_opts['yum_install_command'] += ' subscription-manager'


### PR DESCRIPTION
This pull request updates Fedora, CentOS, and RHEL configs to use fully qualified paths for fetching images for setting up the bootstrap environment. Additionally, we now configure a bootstrap image for openSUSE Tumbleweed since a usable image exists now.