### PR TITLE
Fix bootstrapping of newer Fedora on EL7

### DIFF
--- a/mock-core-configs/etc/host-overrides/README
+++ b/mock-core-configs/etc/host-overrides/README
@@ -1,9 +1,0 @@
-directories in this folder should be named:
-  rhel-%{rhel}
-  fedora-%{fedora}
-  ...
-and are in SPEC files appended to config. E.g
-  host-override/fedora-%{fedora}/fedora-31-x86_64.cfg
-is appended to
-  mock/fedora-31-x86_64.cfg
-if we are building for fedora-%{fedora}

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-aarch64.cfg
@@ -1,1 +1,0 @@
-config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-armhfp.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-i386.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-ppc64le.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-s390x.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-31-x86_64.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-aarch64.cfg
@@ -1,1 +1,0 @@
-config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-armhfp.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-i386.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-ppc64le.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-s390x.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-32-x86_64.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-aarch64.cfg
@@ -1,1 +1,0 @@
-config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-armhfp.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-i386.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-ppc64le.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-s390x.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-7/fedora-rawhide-x86_64.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-aarch64.cfg
@@ -1,1 +1,0 @@
-config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-armhfp.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-i386.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-ppc64le.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-s390x.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-31-x86_64.cfg
@@ -1,1 +1,0 @@
-fedora-31-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-aarch64.cfg
@@ -1,1 +1,0 @@
-config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-armhfp.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-i386.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-ppc64le.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-s390x.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-32-x86_64.cfg
@@ -1,1 +1,0 @@
-fedora-32-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-aarch64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-aarch64.cfg
@@ -1,1 +1,0 @@
-config_opts['use_bootstrap_image'] = True

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-armhfp.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-armhfp.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-i386.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-i386.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-ppc64le.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-ppc64le.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-s390x.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-s390x.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-x86_64.cfg
+++ b/mock-core-configs/etc/host-overrides/rhel-8/fedora-rawhide-x86_64.cfg
@@ -1,1 +1,0 @@
-fedora-rawhide-aarch64.cfg


### PR DESCRIPTION
We forgot to add Fedora 33 host override when adding other Fedora 33
configs.  This is something which would definitely repeat in future, so
I'm rather using a script that will do this hack for us automatically in
the future.

While I'm on it I'm removing rhel-8 override without replacement because
in the meantime the RPM in EL8 got the libzstd support.

Resolves: rhbz#1914750