### PR TITLE
configs: fix rawhide config after branching

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -9,7 +9,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 
 config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['releasever'] = '34'
+config_opts['releasever'] = '35'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
 


### PR DESCRIPTION
We forgot to bump releasever in afbadca68a4d4bf304feebc98 and it is
needed because all f35 packages are being re-signed with F35 keys we are
not referencing, errors:

Public key for openssl-libs-1.1.1i-3.fc35.x86_64.rpm is not installed. Failing package is: openssl-libs-1:1.1.1i-3.fc35.x86_64
 GPG Keys are configured as: file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-34-primary, file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-34-primary, file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-33-primary
Error: GPG check FAILED