### PR TITLE
do not allocate tty for podman

### DIFF
--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -25,7 +25,7 @@ class Podman:
     @traceLog()
     def get_container_id(self):
         """ start a container and detach immediately """
-        cmd = ["podman", "run", "-it", "--detach", self.image, "/bin/bash"]
+        cmd = ["podman", "run", "--quiet", "-i", "--detach", self.image, "/bin/bash"]
         container_id = util.do(cmd, returnOutput=True)
         self.container_id = container_id.strip()
         return self.container_id


### PR DESCRIPTION
Also use quiet mode which print just the container id.

Addressing:
Error: no container with name or ID "time=\"2021-04-15T06:18:24+02:00\" level=warning msg=\"The input device is not a TTY. The --tty and --interactive flags might not work properly\"\n0c65b4d7174ac4dc2308366b4ea0f9dc36c7533b090a98cf4d30510ae4b646cf" found: no such container

Fixes: #720