### PR TITLE
mock-core-configs: add configs for the CentOS Hyperscale SIG

### DIFF
--- a/mock-core-configs/etc/mock/centos-stream-hyperscale-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-hyperscale-8-x86_64.cfg
@@ -1,0 +1,17 @@
+include('templates/centos-stream-8.tpl')
+
+config_opts['root'] = 'centos-stream-hyperscale-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+config_opts['chroot_setup_cmd'] += " centos-release-hyperscale"
+
+config_opts['dnf.conf'] += """
+
+[Stream-hyperscale]
+name=CentOS-Stream - Hyperscale
+baseurl=http://mirror.centos.org/centos/8-stream/hyperscale/$basearch/packages-main/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-HyperScale
+"""

--- a/mock-core-configs/etc/mock/centos-stream-hyperscale-experimental-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-hyperscale-experimental-8-x86_64.cfg
@@ -1,0 +1,17 @@
+include('templates/centos-stream-8.tpl')
+
+config_opts['root'] = 'centos-stream-hyperscale-experimental-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+config_opts['chroot_setup_cmd'] += " centos-release-hyperscale-experimental"
+
+config_opts['dnf.conf'] += """
+
+[Stream-hyperscale-experimental]
+name=CentOS-Stream - Hyperscale Experimental
+baseurl=http://mirror.centos.org/centos/8-stream/hyperscale/$basearch/packages-experimental/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-HyperScale
+"""


### PR DESCRIPTION
Add mock configs for building packages against the Hyperscale SIG repos in CentOS Stream. The GPG key was previously added in https://github.com/xsuchy/distribution-gpg-keys/pull/44