### PR TITLE
config: Add openSUSE Tumbleweed s390x config

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-tumbleweed-s390x.cfg
+++ b/mock-core-configs/etc/mock/opensuse-tumbleweed-s390x.cfg
@@ -1,0 +1,5 @@
+include('templates/opensuse-tumbleweed.tpl')
+
+config_opts['root'] = 'opensuse-tumbleweed-s390x'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -56,6 +56,9 @@ baseurl=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
 {% elif target_arch in ['aarch64'] %}
 baseurl=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/
 #metalink=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+{% elif target_arch in ['s390x'] %}
+baseurl=http://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/
+#metalink=http://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% endif %}
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1


### PR DESCRIPTION
openSUSE Tumbleweed has a IBM Z (s390x) port that mostly works now,
so we should have the ability to build for it.