### PR TITLE
Add Oracle Linux configuration

### DIFF
--- a/mock-core-configs/etc/mock/oraclelinux-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-7-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-7.tpl')
+
+config_opts['root'] = 'oraclelinux-7-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-7-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-7.tpl')
+
+config_opts['root'] = 'oraclelinux-7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/oraclelinux-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-8-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-8.tpl')
+
+config_opts['root'] = 'oraclelinux-8-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-8-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-8.tpl')
+
+config_opts['root'] = 'oraclelinux-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/oraclelinux-7.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-7.tpl
@@ -1,0 +1,66 @@
+# This list is taken from 'epel-7-x86_64' @buildsys-build group, minus the
+# 'epel-*' specific stuff.
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '7'
+config_opts['bootstrap_image'] = 'docker.io/library/oraclelinux:7'
+config_opts['package_manager'] = 'yum'
+
+config_opts['yum_install_command'] += " --disablerepo=ol7_software_collections"
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+protected_packages=
+user_agent={{ user_agent }}
+
+# repos
+
+[ol7_latest]
+name=Oracle Linux $releasever Latest ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/latest/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol7
+gpgcheck=1
+enabled=1
+skip_if_unavailable=False
+
+[ol7_optional_latest]
+name=Oracle Linux $releasever Optional Latest ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol7
+gpgcheck=1
+enabled=1
+skip_if_unavailable=False
+
+[ol7_software_collections]
+name=Software Collection Library packages for Oracle Linux 7 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol7
+gpgcheck=1
+enabled=1
+includepkgs=devtoolset*
+skip_if_unavailable=False
+
+{% for uekver in range(3,7) %}
+[ol7_UEKR{{ uekver }}]
+name=Latest Unbreakable Enterprise Kernel Release {{ uekver }} for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/UEKR{{ uekver }}/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol7
+gpgcheck=1
+enabled=0
+{% endfor %}
+
+"""

--- a/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
@@ -1,0 +1,67 @@
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '8'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'docker.io/library/oraclelinux:8'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+protected_packages=
+module_platform_id=platform:el8
+user_agent={{ user_agent }}
+
+# repos
+
+[ol8_baseos_latest]
+name=Oracle Linux 8 BaseOS Latest ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_appstream]
+name=Oracle Linux 8 Application Stream ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/appstream/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_codeready_builder]
+name=Oracle Linux 8 CodeReady Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/codeready/builder/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_distro_builder]
+name=Oracle Linux 8 Distro Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/distro/builder/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+{% if target_arch in ['x86_64'] %}
+[ol8_UEKR6]
+name=Latest Unbreakable Enterprise Kernel Release 6 for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+{% endif %}
+
+"""


### PR DESCRIPTION
This PR adds configuration for building with Oracle Linux.

@Djelibeybi I was unable to find a `-latest` equivalent for the UEK repos to add to this. Is there a possibility of having one of those so that I can add optional UEK repo configuration into here? That would make it tremendously easier for people building kernel modules against UEK.