### PR TITLE
Define _platform_multiplier macro

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -456,6 +456,11 @@
 
 ## Use this to force foreing architecture (requires qemu-user-static)
 # config_opts['forcearch'] = None
+#
+## Emulating architecture results in slower builds. Expose it to packagers
+## This is set to 1 normally. And to 10 when forcearch is in play.
+# config_opts['macros']['%_platform_multiplier'] = 1
+#
 # If you change chrootgid, you must also change "mock" to the correct group
 # name in this line of the mock PAM config:
 #   auth  sufficient pam_succeed_if.so user ingroup mock use_uid quiet

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -540,6 +540,7 @@ def check_arch_combination(target_arch, config_opts):
                  target_arch, host_arch)
         config_opts['forcearch'] = target_arch
 
+    config.multiply_platform_multiplier(config_opts)
     if config_opts['forcearch']:
         binary = '/usr/bin/qemu-x86_64-static'
         if not os.path.exists(binary):

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -258,6 +258,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['macros'] = {
         '%_topdir': '%s/build' % config_opts['chroothome'],
         '%_rpmfilename': '%%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm',
+        # This is actually set in check_arch_combination()
+        # '%_platform_multiplier': 1,
     }
     config_opts['hostname'] = None
     config_opts['module_enable'] = []
@@ -310,6 +312,13 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
 
     return config_opts
 
+
+def multiply_platform_multiplier(config_opts):
+    """ Define '%_platform_multiplier' macro based on forcearch.
+        But respect possible overrides in config.
+    """
+    if '%_platform_multiplier' not in config_opts["macros"]:
+        config_opts["macros"]["%_platform_multiplier"] = 10 if config_opts["forcearch"] else 1
 
 @traceLog()
 def set_config_opts_per_cmdline(config_opts, options, args):


### PR DESCRIPTION
This allows packagers to count with some delay on emulated architectures. Useful in %check section.

Resolves #697