### PR TITLE
allow mock --install mock --install external:*

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -901,6 +901,7 @@ def run_command(options, args, config_opts, commands, buildroot, state):
             return 50
 
         commands.init()
+        commands.install_external(args)
         buildroot.install(*args)
 
     elif options.mode == 'update':


### PR DESCRIPTION
one commit which moves code to separate function and then second commit which calls it from `install()`