### PR TITLE
compress_logs: compress also after repo failures

### DIFF
--- a/mock/py/mockbuild/plugins/compress_logs.py
+++ b/mock/py/mockbuild/plugins/compress_logs.py
@@ -20,7 +20,7 @@ class CompressLogsPlugin(object):
         self.state = buildroot.state
         self.conf = conf
         self.command = self.conf['command']
-        plugins.add_hook("postbuild", self._compress_logs)
+        plugins.add_hook("process_logs", self._compress_logs)
         getLog().info("compress_logs: initialized")
 
     @traceLog()

--- a/mock/py/mockbuild/rebuild.py
+++ b/mock/py/mockbuild/rebuild.py
@@ -27,6 +27,7 @@ def rebuild_generic(items, commands, buildroot, config_opts, cmd, post=None, cle
             log.info("Done(%s) Config(%s) %d minutes %d seconds",
                      item, config_opts['chroot_name'], elapsed // 60, elapsed % 60)
             log.info("Results and/or logs in: %s", buildroot.resultdir)
+            commands.plugins.call_hooks("process_logs")
 
         if config_opts["cleanup_on_success"]:
             log.info("Cleaning up build root ('cleanup_on_success=True')")
@@ -40,6 +41,7 @@ def rebuild_generic(items, commands, buildroot, config_opts, cmd, post=None, cle
         log.error("Exception(%s) Config(%s) %d minutes %d seconds",
                   item, buildroot.shared_root_name, elapsed // 60, elapsed % 60)
         log.info("Results and/or logs in: %s", buildroot.resultdir)
+        commands.plugins.call_hooks("process_logs")
         if config_opts["cleanup_on_failure"]:
             log.info("Cleaning up build root ('cleanup_on_failure=True')")
             commands.clean()


### PR DESCRIPTION
Before, errors like
    Errors during downloading metadata for repository 'local'
Ended up with non-compressed logs in resultdir.

We can not easily move the 'postbuild' hook call as others already
depend on that - so I'm proposing a new hook for log processing.

Original report:
https://pagure.io/copr/copr/issue/1648