### PR TITLE
config: Add GPG keys and RPM repositories for openSUSE Leap 15.3

### DIFF
--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
@@ -53,6 +53,8 @@ baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
 #metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+        file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports
+        file:///usr/share/distribution-gpg-keys/suse/RPM-GPG-KEY-SuSE-SLE-15
 gpgcheck=1
 
 [opensuse-leap-oss-update]
@@ -61,6 +63,22 @@ baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
 #metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
+gpgcheck=1
+
+[opensuse-leap-sle-update]
+name=openSUSE Leap $releasever - {{ target_arch }} - Updates from SUSE Linux Enterprise
+baseurl=http://download.opensuse.org/update/leap/$releasever/sle/
+#metalink=http://download.opensuse.org/update/leap/$releasever/sle/repodata/repomd.xml.metalink
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-SuSE-SLE-15
+gpgcheck=1
+
+[opensuse-leap-sle-backports-update]
+name=openSUSE Leap $releasever - {{ target_arch }} - Updates from Backports for SUSE Linux Enterprise
+baseurl=http://download.opensuse.org/update/leap/$releasever/backports/
+#metalink=http://download.opensuse.org/update/leap/$releasever/backports/repodata/repomd.xml.metalink
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports
 gpgcheck=1
 
 """

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -18,7 +18,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.48
+Requires:   distribution-gpg-keys >= 1.54
 # specify minimal compatible version of mock
 Requires:   mock >= 2.5
 Requires:   mock-filesystem


### PR DESCRIPTION
openSUSE Leap 15.3 has multiple GPG keys and requires multiple
repositories to construct its updates.

This requires a version of distribution-gpg-keys that includes
the extra GPG keys.

Reference: https://bugzilla.opensuse.org/1186593

Requires: https://github.com/xsuchy/distribution-gpg-keys/pull/45
Requires: https://github.com/xsuchy/distribution-gpg-keys/pull/46

Fixes: #731 