### PR TITLE
Add epel-next-8 configs

### DIFF
--- a/mock-core-configs/etc/mock/epel-next-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-next-8-aarch64.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-8.tpl')
+include('templates/epel-8.tpl')
+include('templates/epel-next-8.tpl')
+
+config_opts['root'] = 'epel-next-8-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/epel-next-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-next-8-ppc64le.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-8.tpl')
+include('templates/epel-8.tpl')
+include('templates/epel-next-8.tpl')
+
+config_opts['root'] = 'epel-next-8-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/epel-next-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-next-8-x86_64.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-8.tpl')
+include('templates/epel-8.tpl')
+include('templates/epel-next-8.tpl')
+
+config_opts['root'] = 'epel-next-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/epel-next-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-8.tpl
@@ -1,0 +1,59 @@
+config_opts['chroot_setup_cmd'] += " epel-next-release"
+
+config_opts['dnf.conf'] += """
+
+[epel-next]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-$releasever&arch=$basearch
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgcheck=1
+skip_if_unavailable=False
+
+[epel-next-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-debug-$releasever&arch=$basearch
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgcheck=1
+skip_if_unavailable=False
+
+[epel-next-source]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-source-$releasever&arch=$basearch
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgcheck=1
+skip_if_unavailable=False
+
+[epel-next-testing]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+skip_if_unavailable=False
+
+[epel-next-testing-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-debug-$releasever&arch=$basearch
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgcheck=1
+skip_if_unavailable=False
+
+[epel-next-testing-source]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-source-$releasever&arch=$basearch
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
+gpgcheck=1
+skip_if_unavailable=False
+
+[local]
+name=local
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-next-build/latest/$basearch/
+cost=2000
+enabled=0
+skip_if_unavailable=False
+"""


### PR DESCRIPTION
EPEL Next is a new repository that allows packagers to build against CentOS Stream instead of RHEL.  It is not an entire rebuild of EPEL and is intended to be used in conjunction with regular EPEL.  See the [wiki page](https://fedoraproject.org/wiki/EPEL_Next) for more details.