### PR TITLE
move Requires of shadow-utils from mock-core-configs to mock-filesystem

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -32,7 +32,6 @@ Requires(post): system-release
 Requires(post): python3
 Requires(post): sed
 %endif
-Requires(pre):  shadow-utils
 %if 0%{?rhel} && 0%{?rhel} <= 7
 # to detect correct default.cfg
 Requires(post): python

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -136,6 +136,7 @@ of the buildroot.
 
 %package filesystem
 Summary:  Mock filesystem layout
+Requires(pre):  shadow-utils
 
 %description filesystem
 Filesystem layout and group for Mock.


### PR DESCRIPTION
This was forgotten when we created mock-filesystems
Credit goes to Orion P.
https://src.fedoraproject.org/rpms/mock/pull-request/10