### PR TITLE
config: Fix GPG key path for SLE updates in openSUSE Leap 15.3

### DIFF
--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
@@ -70,7 +70,7 @@ name=openSUSE Leap $releasever - {{ target_arch }} - Updates from SUSE Linux Ent
 baseurl=http://download.opensuse.org/update/leap/$releasever/sle/
 #metalink=http://download.opensuse.org/update/leap/$releasever/sle/repodata/repomd.xml.metalink
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-SuSE-SLE-15
+gpgkey=file:///usr/share/distribution-gpg-keys/suse/RPM-GPG-KEY-SuSE-SLE-15
 gpgcheck=1
 
 [opensuse-leap-sle-backports-update]


### PR DESCRIPTION
The GPG key path used the /opensuse/ directory for the key installed
in the /suse/ directory incorrectly.