### PR TITLE
Disable versionlock DNF plugin by default

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -421,7 +421,7 @@
 # config_opts['files']['path/name/no/leading/slash'] = "put file contents here."
 # config_opts['chrootuid'] = os.getuid()
 # config_opts['releasever'] = '20'
-# config_opts['dnf_disable_plugins'] = ['local', 'spacewalk']
+# config_opts['dnf_disable_plugins'] = ['local', 'spacewalk', 'versionlock']
 # config_opts['yum_common_opts'] = []
 # config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
 # config_opts['yum_builddep_opts'] = []

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -304,7 +304,7 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['microdnf_common_opts'] = []
     config_opts['rpm_command'] = '/bin/rpm'
     config_opts['rpmbuild_command'] = '/usr/bin/rpmbuild'
-    config_opts['dnf_disable_plugins'] = ['local', 'spacewalk']
+    config_opts['dnf_disable_plugins'] = ['local', 'spacewalk', 'versionlock']
     config_opts['user_agent'] = "Mock ({{ root }}; {{ target_arch }})"
     config_opts['opstimeout'] = 0
 


### PR DESCRIPTION
The system-wide versionlock from DNF does not make any sense to use for
mock builds.

Signed-off-by: Igor Raits <igor.raits@gmail.com>