### PR TITLE
config: add CentOS Stream 9 "preview" configs

### DIFF
--- a/mock-core-configs/etc/mock/centos-stream-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-9-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/centos-stream-9.tpl')
+
+config_opts['root'] = 'centos-stream-9-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-9-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('templates/centos-stream-9.tpl')
+
+config_opts['root'] = 'centos-stream-9-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-9-s390x.cfg
@@ -1,0 +1,5 @@
+include('templates/centos-stream-9.tpl')
+
+config_opts['root'] = 'centos-stream-9-s390x'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/centos-stream-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-9-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/centos-stream-9.tpl')
+
+config_opts['root'] = 'centos-stream-9-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -1,0 +1,49 @@
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['dist'] = 'el9'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '9'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+
+# TODO: flip to 'stream9' tag once available
+config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9-development'
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=1
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+mdpolicy=group:primary
+best=1
+protected_packages=
+module_platform_id=platform:el9
+user_agent={{ user_agent }}
+
+[baseos-pre-release]
+name=CentOS Stream $releasever - BaseOS (pre-release)
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
+failovermethod=priority
+#gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=0
+skip_if_unavailable=False
+
+[appstream-pre-release]
+name=CentOS Stream $releasever - AppStream (pre-release)
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os/
+enabled=1
+#gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=0
+
+[crb-pre-release]
+name=CentOS Stream $releasever - CRB (pre-release)
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/CRB/$basearch/os/
+enabled=1
+#gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=0
+"""


### PR DESCRIPTION
The composes are not signed, and at the time of writing this patch
mirrors do not exist.  Neither centos:stream9 bootstrap image exists.

Relates: #719