### PR TITLE
Explicitly convert macro values to str in scm plugin

### DIFF
--- a/mock/py/mockbuild/scm.py
+++ b/mock/py/mockbuild/scm.py
@@ -150,7 +150,7 @@ class scmWorker(object):
         # Add passed RPM macros before parsing spec file
         for macro, expression in list(self.macros.items()):
             # pylint: disable=no-member
-            rpm.addMacro(macro.lstrip('%'), expression)
+            rpm.addMacro(macro.lstrip('%'), str(expression))
 
         # Dig out some basic information from the spec file
         self.sources = []


### PR DESCRIPTION
rpm.addMacro will only take strings for macro values. A recent change has caused an int to appear in the macros, which is causing the scm plugin to fail.

I believe the regression first appeared after #730. An alternative solution might be to modify that change to store the macro as an string instead of an integer.

This is the error I'm seeing on CentOS 8 with mock-2.11-1.el8:

<details>

```
ERROR: AddMacro() argument 2 must be str, not None
Traceback (most recent call last):
  File "/dev/fd/4", line 1060, in <module>
    exitStatus = main()
  File "/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/dev/fd/4", line 826, in main
    result = run_command(options, args, config_opts, commands, buildroot, state)
  File "/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/dev/fd/4", line 849, in run_command
    (options.sources, options.spec) = scmWorker.prepare_sources()
  File "/usr/lib/python3.6/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.6/site-packages/mockbuild/scm.py", line 153, in prepare_sources
    rpm.addMacro(macro.lstrip('%'), expression)
TypeError: AddMacro() argument 2 must be str, not None
```

</details>