### PR TITLE
mock: don't set --cwd for --shell when we know it fails

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -357,7 +357,12 @@ class Commands(object):
             gid = 0
         cwd = options.cwd
         if not cwd:
-            cwd = self.config['chroothome']
+            # Hack!  We don't set the cwd here because we know that we work
+            # with old systemd-nspawn without --chdir option.  Still, users
+            # might use --chdir explicitly and such situation would still
+            # result in failure.  rhbz#1976702
+            if not util.USE_NSPAWN or util.check_nspawn_has_chdir_option():
+                cwd = self.config['chroothome']
 
         try:
             self.state.start("shell")

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -715,6 +715,14 @@ def _check_nspawn_resolv_conf():
     return '--resolv-conf' in systemd_nspawn_help_output()
 
 
+def check_nspawn_has_chdir_option():
+    """
+    Older systemd-nspawn versions don't have --chdir option, and sometimes we
+    need to know we work with such version.
+    """
+    return '--chdir' in systemd_nspawn_help_output()
+
+
 def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None,
                             cwd=None, interactive=False, shell=False):
     nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-M', uuid.uuid4().hex, '-D', chrootPath]


### PR DESCRIPTION
This is specific to EL7 environment, where the systemd-nspawn
implementation still doesn't support --chdir option.

Resolves: rhbz#1976702