### PR TITLE
Disable the Devel repo in Rocky Linux config by default

### DIFF
--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -29,7 +29,7 @@ user_agent={{ user_agent }}
 [baseos]
 name=Rocky Linux $releasever - BaseOS
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/BaseOS/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -37,7 +37,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [appstream]
 name=Rocky Linux $releasever - AppStream
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/AppStream/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -45,7 +45,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [powertools]
 name=Rocky Linux $releasever - PowerTools
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/PowerTools/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -53,7 +53,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [extras]
 name=Rocky Linux $releasever - Extras
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/extras/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -61,7 +61,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [ha]
 name=Rocky Linux $releasever - HighAvailability
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -69,7 +69,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [resilient-storage]
 name=Rocky Linux $releasever - ResilientStorage
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -77,7 +77,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [plus]
 name=Rocky Linux $releasever - Plus
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=rockyplus-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/plus/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/plus/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -85,7 +85,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [devel]
 name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT AND KOJI USE
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/Devel/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -94,7 +94,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [baseos-debug]
 name=Rocky Linux $releasever - BaseOS - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/BaseOS/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -102,7 +102,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [appstream-debug]
 name=Rocky Linux $releasever - AppStream - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/AppStream/$basearch/os/
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -110,7 +110,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [ha-debug]
 name=Rocky Linux $releasever - High Availability - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever-debug
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/$basearch/debug/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/debug/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -118,7 +118,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [powertools-debug]
 name=Rocky Linux $releasever - PowerTools - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever-debug
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/PowerTools/$basearch/debug/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/debug/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -126,7 +126,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [resilient-storage-debug]
 name=Rocky Linux $releasever - Resilient Storage - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever-debug
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/$basearch/debug/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/debug/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -134,7 +134,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [devel-debug]
 name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT AND KOJI USE
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever-debug
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/Devel/$basearch/debug/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/debug/tree
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -143,7 +143,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [baseos-source]
 name=Rocky Linux $releasever - BaseOS - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=BaseOS-$releasever-source
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/BaseOS/source/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/source/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -151,7 +151,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [appstream-source]
 name=Rocky Linux $releasever - AppStream - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=AppStream-$releasever-source
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/AppStream/source/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/source/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -159,7 +159,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [ha-source]
 name=Rocky Linux $releasever - High Availability - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=HighAvailability-$releasever-source
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/source/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/source/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -167,7 +167,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [powertools-source]
 name=Rocky Linux $releasever - PowerTools - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=PowerTools-$releasever-source
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/PowerTools/source/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/source/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -175,7 +175,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [resilient-storage-source]
 name=Rocky Linux $releasever - Resilient Storage - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=ResilientStorage-$releasever-source
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/source/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/source/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
@@ -183,7 +183,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 [devel-source]
 name=Rocky Linux $releasever - Devel - Source
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=Devel-$releasever-source
-#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/Devel/source/tree
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/source/tree
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -87,7 +87,7 @@ name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT AND KOJI USE
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/os/
 gpgcheck=1
-enabled=1
+enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 # Debuginfo


### PR DESCRIPTION
Having this enabled makes it too easy for people to accidentally
build packages that depend on content in here at runtime. That
makes it possible for people to make packages that will not be
compatible with RHEL and derivatives.

Disable this repo by default. If people need this, they can enable
it in the Mock command-line as-needed. At least then they acknowledge
what they're doing and know the consequences.

Additionally, fix the URL for the commented out "baseurl" lines, so
that they're valid.

Fixes #756 