### PR TITLE
lvm_root: fix copy/paste error in a warning message

### DIFF
--- a/mock/py/mockbuild/plugins/lvm_root.py
+++ b/mock/py/mockbuild/plugins/lvm_root.py
@@ -281,7 +281,7 @@ class LvmPlugin(object):
         if size_metadata and size_metadata > 75:
             self.buildroot.root_log.warning(
                 "LVM Thin pool metadata are nearly filled up ({0}%). You may experience weird errors. "
-                "Consider growing up your thin pool.".format(size_data))
+                "Consider growing up your thin pool.".format(size_metadata))
         if size_data and size_data > 75:
             self.buildroot.root_log.warning(
                 "LVM Thin pool is nearly filled up ({0}%). You may experience weird errors. "


### PR DESCRIPTION
... detected by Coverity:
```
Error: COPY_PASTE_ERROR (CWE-398):
mock-2.12/py/mockbuild/plugins/lvm_root.py:288: original: ""LVM Thin pool is nearly filled up ({0}%). You may experience weird errors. Consider growing up your thin pool.".format(size_data)" looks like the original copy.
mock-2.12/py/mockbuild/plugins/lvm_root.py:284: copy_paste_error: "size_data" in ""LVM Thin pool metadata are nearly filled up ({0}%). You may experience weird errors. Consider growing up your thin pool.".format(size_data)" looks like a copy-paste error.
mock-2.12/py/mockbuild/plugins/lvm_root.py:284: remediation: Should it say "size_metadata" instead?
```