### PR TITLE
Added option --debug-config-expanded

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -120,6 +120,9 @@ See also \fB\-\-shell\fR.
 \fB\-\-debug-config\fP
 Print all options in config_opts.
 .TP
+\fB\-\-debug-config-expanded\fP
+Prints all options in config_opts with jinja template values already expanded.
+.TP
 \fB\-\-dnf\-cmd\fP
 Execute following arguments with DNF with installroot set to the chroot path. DNF must be installed on the system.
 It will use the binary which is specified in 'dnf_command' option in site-defaults.cfg config, which by default is /usr/bin/dnf.

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -141,6 +141,9 @@ def command_parse():
     parser.add_option("--debug-config", action="store_const", const="debugconfig",
                       dest="mode",
                       help="Prints all options in config_opts")
+    parser.add_option("--debug-config-expanded", action="store_const", const="debugconfigexpand",
+                      dest="mode",
+                      help="Prints all options in config_opts with jinja template values already expanded")
     parser.add_option("--shell", action="store_const",
                       const="shell", dest="mode",
                       help="run the specified command interactively within the chroot."
@@ -556,11 +559,11 @@ def check_arch_combination(target_arch, config_opts):
             time.sleep(5)
 
 @traceLog()
-def do_debugconfig(config_opts, uidManager):
+def do_debugconfig(config_opts, uidManager, expand=False):
     jinja_expand = config_opts['__jinja_expand']
     defaults = config.load_defaults(uidManager, __VERSION__, PKGPYTHONDIR)
-    defaults['__jinja_expand'] = False
-    config_opts['__jinja_expand'] = False
+    defaults['__jinja_expand'] = expand
+    config_opts['__jinja_expand'] = expand
     for key in sorted(config_opts):
         if key == '__jinja_expand':
             value = jinja_expand
@@ -946,6 +949,9 @@ def run_command(options, args, config_opts, commands, buildroot, state):
 
     elif options.mode == 'debugconfig':
         do_debugconfig(config_opts, buildroot.uid_manager)
+
+    elif options.mode == 'debugconfigexpand':
+        do_debugconfig(config_opts, buildroot.uid_manager, True)
 
     elif options.mode == 'orphanskill':
         util.orphansKill(buildroot.make_chroot_path())


### PR DESCRIPTION
#mock -r fedora-rawhide-x86_64 --debug-config-expanded   shows the real result

instead  
`'gpgkey={{ rawhide_gpg_keys() }}\n' `

shows 

```
'gpgkey=file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-primary '
'file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-35-primary '
'file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-34-primary\n'
```