### PR TITLE
Add eurolinux-8 x86_64 and i686 buildroots

### DIFF
--- a/mock-core-configs/etc/mock/eurolinux-8-i686.cfg
+++ b/mock-core-configs/etc/mock/eurolinux-8-i686.cfg
@@ -1,0 +1,5 @@
+include('templates/eurolinux-8.tpl')
+
+config_opts['root'] = 'eurolinux-8-i686'
+config_opts['target_arch'] = 'i686'
+config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')

--- a/mock-core-configs/etc/mock/eurolinux-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/eurolinux-8-x86_64.cfg
@@ -1,0 +1,7 @@
+include('templates/eurolinux-8.tpl')
+
+# To enable modules use:
+#config_opts['module_enable'] = ['swig', 'httpd', 'ruby']
+config_opts['root'] = 'eurolinux-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/eurolinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/eurolinux-8.tpl
@@ -1,0 +1,51 @@
+# EuroLinux open buildroots
+# Note: perl modules are broken by design
+
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '8'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=0
+protected_packages=
+module_platform_id=platform:el8
+
+
+[baseos-all]
+name=EuroLinux 8 BaseOS All
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/8/$basearch/certify-BaseOS/all
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/eurolinux/RPM-GPG-KEY-eurolinux8
+
+[appstream-all]
+name=EuroLinux 8 AppStream All
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/8/$basearch/certify-AppStream/all
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/eurolinux/RPM-GPG-KEY-eurolinux8
+
+[powertools-all]
+name=EuroLinux 8 PowerTools All
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/8/$basearch/certify-PowerTools/all
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/eurolinux/RPM-GPG-KEY-eurolinux8
+
+"""


### PR DESCRIPTION
Hi,

I want to add EuroLinux 8 mocks. EuroLinux build roots are entire repos with all build artefacts (including lots of normally removed `-devel` packages).

I tested the following changes by building mock-core-configs with tito (--test is required) and running two builds of htop. One for x86_64 and a second one for i686.