### PR TITLE
config: Validate GPG signatures for CentOS Stream 9

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -29,21 +29,18 @@ user_agent={{ user_agent }}
 name=CentOS Stream $releasever - BaseOS (pre-release)
 baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
 failovermethod=priority
-#gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-gpgcheck=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 skip_if_unavailable=False
 
 [appstream-pre-release]
 name=CentOS Stream $releasever - AppStream (pre-release)
 baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os/
 enabled=1
-#gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-gpgcheck=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [crb-pre-release]
 name=CentOS Stream $releasever - CRB (pre-release)
 baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/CRB/$basearch/os/
 enabled=1
-#gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-gpgcheck=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 """


### PR DESCRIPTION
CentOS Stream 9 packages are now signed on each compose. However,
we're still in a pre-release state where CentOS Stream 9 is not yet
on the mirror network.