### PR TITLE
Install external deps into build chroot, not bootstrap

### DIFF
--- a/mock/py/mockbuild/external.py
+++ b/mock/py/mockbuild/external.py
@@ -48,7 +48,11 @@ class ExternalDeps(object):
     def install_external_deps_pypi(self, deps):
         """ deps is list of python modules. Without the prefix. """
         self.bootstrap_buildroot.install_as_root('/usr/bin/pip3', 'python3-setuptools')
-        command = ['pip3', "install", "--root", self.buildroot.make_chroot_path()] + deps
+        command = [
+            'pip3', "install",
+            "--root", self.buildroot.make_chroot_path(),
+            "--prefix", "/usr",
+        ] + deps
         try:
             self.uid_manager.becomeUser(0, 0)
             self.buildroot.doOutChroot(command, shell=False, printOutput=True)

--- a/mock/py/mockbuild/external.py
+++ b/mock/py/mockbuild/external.py
@@ -51,7 +51,7 @@ class ExternalDeps(object):
         command = ['pip3', "install", "--root", self.buildroot.make_chroot_path()] + deps
         try:
             self.uid_manager.becomeUser(0, 0)
-            self.bootstrap_buildroot.doOutChroot(command, shell=False, printOutput=True)
+            self.buildroot.doOutChroot(command, shell=False, printOutput=True)
         except:  # pylint: disable=bare-except
             raise ExternalDepsError('Pip3 install failed')
         finally:
@@ -65,7 +65,7 @@ class ExternalDeps(object):
         command = ['cargo', "install", "--root", self.buildroot.make_chroot_path()] + deps
         try:
             self.uid_manager.becomeUser(0, 0)
-            self.bootstrap_buildroot.doOutChroot(command, shell=False, printOutput=True)
+            self.buildroot.doOutChroot(command, shell=False, printOutput=True)
         except:  # pylint: disable=bare-except
             raise ExternalDepsError('Cargo install failed')
         finally:


### PR DESCRIPTION
Precisely, we want to use the 'pip' or 'cargo' command from the
bootstrap chroot to install dependencies into the build chroot.

Relates: #761