### PR TITLE
Productionize CentOS Stream 9 build configuration

### DIFF
--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -21,6 +21,7 @@ syslog_device=
 metadata_expire=0
 mdpolicy=group:primary
 best=1
+install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -21,6 +21,7 @@ syslog_device=
 metadata_expire=0
 mdpolicy=group:primary
 best=1
+install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -22,6 +22,7 @@ syslog_ident=mock
 syslog_device=
 mdpolicy=group:primary
 best=1
+install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -1,4 +1,4 @@
-config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['chroot_setup_cmd'] = 'install tar redhat-rpm-config redhat-release which xz sed make bzip2 gzip coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep glibc-minimal-langpack'
 config_opts['dist'] = 'el9'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
@@ -19,29 +19,30 @@ gpgcheck=1
 assumeyes=1
 syslog_ident=mock
 syslog_device=
-mdpolicy=group:primary
 best=1
 install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el9
 user_agent={{ user_agent }}
 
-[baseos-pre-release]
-name=CentOS Stream $releasever - BaseOS (pre-release)
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
-failovermethod=priority
+[baseos]
+name=CentOS Stream $releasever - BaseOS
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-$releasever-stream&arch=$basearch
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 skip_if_unavailable=False
 
-[appstream-pre-release]
-name=CentOS Stream $releasever - AppStream (pre-release)
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os/
+[appstream]
+name=CentOS Stream $releasever - AppStream
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-$releasever-stream&arch=$basearch
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[crb-pre-release]
-name=CentOS Stream $releasever - CRB (pre-release)
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/CRB/$basearch/os/
+[crb]
+name=CentOS Stream $releasever - CRB
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/CRB/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$releasever-stream&arch=$basearch
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 """

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -21,6 +21,7 @@ syslog_ident=mock
 syslog_device=
 mdpolicy=group:primary
 best=1
+install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el9
 user_agent={{ user_agent }}

--- a/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
@@ -21,6 +21,7 @@ syslog_device=
 metadata_expire=0
 mdpolicy=group:primary
 best=1
+install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -21,6 +21,7 @@ syslog_device=
 metadata_expire=0
 mdpolicy=group:primary
 best=1
+install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}


### PR DESCRIPTION
This pull request makes the necessary adjustments to productionize the CentOS Stream 9 configuration. CentOS Stream 9 is now on the mirror network, so we're using the new metalinks from MirrorManager. Additionally, I've fixed an issue where weak dependencies were being installed in the build environments and synchronized the chroot setup package set with the one in Koji.