### PR TITLE
Update Oraclelinux 7/8 configs and add Oraclelinux EPEL 7/8 configs

### DIFF
--- a/mock-core-configs/etc/mock/oraclelinux-epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-epel-7-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/oraclelinux-7.tpl')
+include('templates/oraclelinux-epel-7.tpl')
+
+config_opts['root'] = 'oraclelinux-7-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux-epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-epel-7-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/oraclelinux-7.tpl')
+include('templates/oraclelinux-epel-7.tpl')
+
+config_opts['root'] = 'oraclelinux-7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/oraclelinux-epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-epel-8-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/oraclelinux-8.tpl')
+include('templates/oraclelinux-epel-8.tpl')
+
+config_opts['root'] = 'oraclelinux-8-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux-epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-epel-8-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/oraclelinux-8.tpl')
+include('templates/oraclelinux-epel-8.tpl')
+
+config_opts['root'] = 'oraclelinux-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/oraclelinux-7.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-7.tpl
@@ -1,6 +1,6 @@
 # This list is taken from 'epel-7-x86_64' @buildsys-build group, minus the
 # 'epel-*' specific stuff.
-config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make oraclelinux-release patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
 
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'

--- a/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
@@ -1,4 +1,4 @@
-config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ redhat-rpm-config redhat-release oraclelinux-release which xz sed make bzip2 gzip gcc coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
 config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'

--- a/mock-core-configs/etc/mock/templates/oraclelinux-epel-7.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-epel-7.tpl
@@ -1,0 +1,11 @@
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
+
+config_opts['yum.conf'] += """
+
+[ol7_epel]
+name=Oracle Linux 7 EPEL ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL7/developer_EPEL/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1
+"""

--- a/mock-core-configs/etc/mock/templates/oraclelinux-epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-epel-8.tpl
@@ -1,0 +1,14 @@
+config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
+
+config_opts['dnf.conf'] += """
+
+# repos
+
+[ol8_epel]
+name=Oracle Linux 8 EPEL ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/EPEL/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+"""


### PR DESCRIPTION
There are currently no Oracle Linux EPEL configs.
Add oraclelinux-release to existing oraclelinux templates