### PR TITLE
config: Finalize CentOS Stream 9 configuration

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -4,8 +4,7 @@ config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 
-# TODO: flip to 'stream9' tag once available
-config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9-development'
+config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9'
 
 config_opts['dnf.conf'] = """
 [main]
@@ -15,7 +14,7 @@ reposdir=/dev/null
 logfile=/var/log/yum.log
 retries=20
 obsoletes=1
-gpgcheck=1
+gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=
@@ -27,22 +26,61 @@ user_agent={{ user_agent }}
 
 [baseos]
 name=CentOS Stream $releasever - BaseOS
-#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os/
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/BaseOS/$basearch/os/
 metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-$releasever-stream&arch=$basearch
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=1
 skip_if_unavailable=False
 
 [appstream]
 name=CentOS Stream $releasever - AppStream
-#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os/
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/AppStream/$basearch/os/
 metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-$releasever-stream&arch=$basearch
-enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=1
+skip_if_unavailable=False
 
 [crb]
 name=CentOS Stream $releasever - CRB
-#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/CRB/$basearch/os/
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/CRB/$basearch/os/
 metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$releasever-stream&arch=$basearch
-enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=1
+skip_if_unavailable=False
+
+[highavailability]
+name=CentOS Stream $releasever - HighAvailability
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/HighAvailability/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-highavailability-$releasever-stream&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=0
+
+[nfv]
+name=CentOS Stream $releasever - NFV
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/NFV/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-nfv-$releasever-stream&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=0
+
+[rt]
+name=CentOS Stream $releasever - RT
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/RT/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-rt-$releasever-stream&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=0
+
+[resilientstorage]
+name=CentOS Stream $releasever - ResilientStorage
+#baseurl=http://mirror.stream.centos.org/$releasever-stream/ResilientStorage/$basearch/os/
+metalink=https://mirrors.centos.org/metalink?repo=centos-resilientstorage-$releasever-stream&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgcheck=1
+enabled=0
+
 """


### PR DESCRIPTION
The final production container image is now available, and all the
final URLs for example baseurls are in place too.

Also, `gpgcheck=1` at the main section breaks mockchain, so switch
to `gpgcheck=0` and set `gpgcheck=1` for each repo.

Finally, Add disabled repos for all the addon repositories so
users can consume those easily enough, since they're part of the
base CentOS Stream 9 offering.