### PR TITLE
mock: local repositories to use gpgcheck=0

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -965,6 +965,7 @@ baseurl={baseurl}
 enabled=1
 skip_if_unavailable=0
 metadata_expire=0
+gpgcheck=0
 cost=1
 best=1
 """.format(repoid=repoid, baseurl=baseurl)


### PR DESCRIPTION
The locally generated repositories are not signed by mock, at least not
now.  This was breaking e.g. 'mock --chain' command for centos-stream-9
where we had 'gpgcheck=1' set on global [main] level (thus even for the
local_build_repo).

See-also: #781