### PR TITLE
Add epel9-next configs

### DIFF
--- a/mock-core-configs/etc/mock/epel-next-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-next-9-aarch64.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-9.tpl')
+include('templates/epel-9.tpl')
+include('templates/epel-next-9.tpl')
+
+config_opts['root'] = 'epel-next-9-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/epel-next-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-next-9-ppc64le.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-9.tpl')
+include('templates/epel-9.tpl')
+include('templates/epel-next-9.tpl')
+
+config_opts['root'] = 'epel-next-9-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/epel-next-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/epel-next-9-s390x.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-9.tpl')
+include('templates/epel-9.tpl')
+include('templates/epel-next-9.tpl')
+
+config_opts['root'] = 'epel-next-9-s390x'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/epel-next-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-next-9-x86_64.cfg
@@ -1,0 +1,7 @@
+include('templates/centos-stream-9.tpl')
+include('templates/epel-9.tpl')
+include('templates/epel-next-9.tpl')
+
+config_opts['root'] = 'epel-next-9-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-9.tpl
@@ -1,0 +1,4 @@
+config_opts['chroot_setup_cmd'] += " epel-release epel-rpm-macros fedpkg-minimal"
+
+# epel9-next is launching before epel9.  This file will not have repo
+# definitions until after the epel9 launch.

--- a/mock-core-configs/etc/mock/templates/epel-next-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-9.tpl
@@ -1,0 +1,59 @@
+config_opts['chroot_setup_cmd'] += " epel-next-release"
+
+config_opts['dnf.conf'] += """
+
+[epel-next]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-$releasever&arch=$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-source]
+name=Extra Packages for Enterprise Linux $releasever - Next - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-next-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-testing]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-testing-debuginfo]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch - Debug
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-debug-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[epel-next-testing-source]
+name=Extra Packages for Enterprise Linux $releasever - Next - Testing - $basearch - Source
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-next-source-$releasever&arch=$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
+skip_if_unavailable=False
+
+[local]
+name=local
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-next-build/latest/$basearch/
+cost=2000
+enabled=0
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -18,7 +18,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.55
+Requires:   distribution-gpg-keys >= 1.59
 # specify minimal compatible version of mock
 Requires:   mock >= 2.5
 Requires:   mock-filesystem


### PR DESCRIPTION
Similar to epel8-next, epel9-next will eventually work in conjunction with epel9.  However, we are launching epel9-next before epel9, so initially there will be no epel9 repo defintions.

Related https://github.com/xsuchy/distribution-gpg-keys/pull/51