### PR TITLE
Fix broken --enablerepo option

### DIFF
--- a/mock/integration-tests/runconfigs.sh
+++ b/mock/integration-tests/runconfigs.sh
@@ -41,6 +41,13 @@ for i in $configs; do
     amazonlinux*) continue;;
     esac
 
+    # For branched Fedoras, try also updates-testing.
+    enablerepo=
+    case $i in
+    fedora-eln*|fedora-rawhide*) ;;
+    fedora*) enablerepo=" --enablerepo updates-testing " ;;
+    esac
+
     name=$(basename $i .cfg)
     header "testing config $name.cfg with tmpfs plugin"
     runcmd "$MOCKCMD -r $name --enable-plugin=tmpfs --rebuild $srpm "
@@ -52,7 +59,7 @@ for i in $configs; do
     fi
     sudo python ${TESTDIR}/dropcache.py
     header "testing config $name.cfg *without* tmpfs plugin"
-    runcmd "$MOCKCMD -r $name --disable-plugin=tmpfs --rebuild $srpm "
+    runcmd "$MOCKCMD -r $name --disable-plugin=tmpfs --rebuild $srpm $enablerepo"
     if [ $? != 0 ]; then
 	echo "FAILED: $i"
 	fails=$(($fails+1))

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -110,7 +110,7 @@ class RepoCallback(argparse.Action):
         if not hasattr(namespace, self.dest):
             setattr(namespace, self.dest, [])
         options = getattr(namespace, self.dest)
-        options += [(option_string, value)]
+        options.extend((option_string, value))
 
 
 def command_parse():


### PR DESCRIPTION
Mock expects that the args.enable_disable_repos variable is set to list
of strings (dnf commandline options), not a list of pairs.

Complements: 9bdc2f1020047b9a14d72d4dc6a6aebd6dc6288a
Original-report: https://bodhi.fedoraproject.org/updates/FEDORA-2021-c0fa68d0a1