### PR TITLE
Reduce packages installed in epel chroots

### DIFF
--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -1,4 +1,4 @@
-config_opts['chroot_setup_cmd'] += " epel-release epel-rpm-macros fedpkg-minimal"
+config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
 
 config_opts['dnf.conf'] += """
 

--- a/mock-core-configs/etc/mock/templates/epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-9.tpl
@@ -1,4 +1,4 @@
-config_opts['chroot_setup_cmd'] += " epel-release epel-rpm-macros fedpkg-minimal"
+config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
 
 # epel9-next is launching before epel9.  This file will not have repo
 # definitions until after the epel9 launch.

--- a/mock-core-configs/etc/mock/templates/epel-next-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-8.tpl
@@ -1,5 +1,3 @@
-config_opts['chroot_setup_cmd'] += " epel-next-release"
-
 config_opts['dnf.conf'] += """
 
 [epel-next]

--- a/mock-core-configs/etc/mock/templates/epel-next-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-9.tpl
@@ -1,5 +1,3 @@
-config_opts['chroot_setup_cmd'] += " epel-next-release"
-
 config_opts['dnf.conf'] += """
 
 [epel-next]


### PR DESCRIPTION
The repo definitions are provided by mock-core-configs and the gpg keys are provided by distribution-gpg-keys, so epel-release/epel-next-release are not needed.  fedpkg-minimal is needed in koji for obtaining sources from dist-git and the lookaside cache, but koji installs that via the srpm-build group.

https://pagure.io/releng/issue/10369

Related #790