### PR TITLE
Fix `bootstrap_image` in mock-core-configs templates

### DIFF
--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el8.alma'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'docker.io/almalinux/almalinux:8'
+config_opts['bootstrap_image'] = 'docker.io/library/almalinux:8'
 
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el8.alma'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'docker.io/library/almalinux:8'
+config_opts['bootstrap_image'] = 'quay.io/almalinux/almalinux:8'
 
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
+++ b/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
@@ -4,7 +4,7 @@ config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['package_manager'] = 'yum'
 config_opts['releasever'] = '2'
 
-config_opts['bootstrap_image'] = 'amazonlinux:2'
+config_opts['bootstrap_image'] = 'docker.io/library/amazonlinux:2'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/mageia-7.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-7.tpl
@@ -5,7 +5,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
-config_opts['bootstrap_image'] = 'mageia:7'
+config_opts['bootstrap_image'] = docker.io/library/mageia:7'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/mageia-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-branched.tpl
@@ -5,7 +5,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgid}} -d {{chroothome}} {{chrootuser}}'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
-config_opts['bootstrap_image'] = 'mageia:{{ releasever }}'
+config_opts['bootstrap_image'] = 'docker.io/library/mageia:{{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]


### PR DESCRIPTION
- core-configs: Update almalinux-8.tpl bootstrap_image
- core-configs: Use fully qualified bootstrap_image name
