### PR TITLE
configs: Add Koji local repos to CentOS Stream configs

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -27,6 +27,13 @@ protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}
 
+[local]
+name=CentOS-Stream - Koji Local WARNING! FOR BUILDROOT USE ONLY!
+baseurl=https://koji.mbox.centos.org/kojifiles/repos/dist-c{{ releasever }}-stream-build/latest/$basearch/
+cost=2000
+enabled=0
+skip_if_unavailable=False
+
 [baseos]
 name=CentOS Stream $releasever - BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -24,6 +24,13 @@ protected_packages=
 module_platform_id=platform:el9
 user_agent={{ user_agent }}
 
+[local]
+name=CentOS Stream $releasever - Koji Local WARNING! FOR BUILDROOT USE ONLY!
+baseurl=https://kojihub.stream.centos.org/kojifiles/repos/c{{ releasever }}s-build/latest/$basearch/
+cost=2000
+enabled=0
+skip_if_unavailable=False
+
 [baseos]
 name=CentOS Stream $releasever - BaseOS
 #baseurl=http://mirror.stream.centos.org/$releasever-stream/BaseOS/$basearch/os/


### PR DESCRIPTION
This mimics the Koji local repo configured for Fedora configs and
allows people to emulate the build environment in CBS if needed.