### PR TITLE
argparse: handle old-style commands *before* ignoring "--"

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -397,13 +397,6 @@ def command_parse():
 
     (options, args) = parser.parse_known_args()
 
-    # Optparse.parse_args() eats '--' argument, while argparse doesn't.  Do it manually.
-    if args and args[0] == '--':
-        args = args[1:]
-
-    if options.scrub:
-        options.mode = 'clean'
-
     if options.mode == '__default__':
         # handle old-style commands
         if len(args) and args[0] in ('chroot', 'shell', 'rebuild', 'install',
@@ -412,6 +405,13 @@ def command_parse():
             args = args[1:]
         else:
             options.mode = 'rebuild'
+
+    # Optparse.parse_args() eats '--' argument, while argparse doesn't.  Do it manually.
+    if args and args[0] == '--':
+        args = args[1:]
+
+    if options.scrub:
+        options.mode = 'clean'
 
     # explicitly disallow multiple targets in --target argument
     if options.rpmbuild_arch:


### PR DESCRIPTION
If the attempt to eat "--" as the first unknown arg comes before
the handling of old-style commands, then it doesn't handle this:

mock -r something chroot -- commands

because the first unknown arg in that case is "chroot", not "--".
So we should do the old-style command handling first, *then*
check if the first unknown arg is "--" and eat it if so.

Fixes: https://bugzilla.redhat.com/2024620

Signed-off-by: Adam Williamson <awilliam@redhat.com>