### PR TITLE
Add option ssl-extra-certs

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -500,5 +500,16 @@
 # different configuration, and copying the bundle helps.
 #config_opts['ssl_ca_bundle_path'] = None
 
+# Copy host's SSL certificates into a specified location inside the chroot if
+# mock needs access to repositories which require client certificate
+# authentication. Specify the full path to the public certificate on the host
+# and the destination directory in the chroot. Do the same for the private key.
+# The private key should not be password-protected if you want mock to run
+# unattended.
+#config_opts['ssl_extra_certs'] = None
+# Example:
+#config_opts['ssl_extra_certs'] = ['/etc/pki/tls/certs/client.crt', '/etc/pki/tls/certs/',
+#                                  '/etc/pki/tls/private/client_nopass.key.crt', '/etc/pki/tls/private/']
+
 # user_agent string to identify HTTP request to repositories
 # config_opts['user_agent'] = "Mock ({{ root }}; {{ target_arch }})"

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -106,6 +106,8 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
 
     config_opts['ssl_ca_bundle_path'] = None
 
+    config_opts['ssl_extra_certs'] = None
+
     # (global) plugins and plugin configs.
     # ordering constraings: tmpfs must be first.
     #    root_cache next.


### PR DESCRIPTION
As requested by @praiskup on the buildsys ML, here's my PR to add the ssl-extra-certs option. Reason: currently there are config options to add RHEL entitlement certificates and CA certificates in the chroot. What's missing is a similar option for regular (non-entitlement, non-CA) client/key certificates so mock can also access private (non-RHEL) repos from the chroot. On RHEL/Fedora hosts these certificates seem to live in /etc/pki/tls/certs and /etc/pki/tls/private. This patch allows you to specify both the client and key certificates with full path and the destination path in the chroot. Example:

config_opts['ssl_extra_certs'] = [
    '/etc/pki/tls/certs/client.crt', '/etc/pki/tls/certs/',
    '/etc/pki/tls/private/client_nopass.key.crt', '/etc/pki/tls/private/'
]

This PR adds the 3rd use case:
Works: Mock -> public repos like Fedora & CentOS
Works: Mock -> RHEL repos requiring an entitlement
Works: Mock + this PR -> public and private repos via cert & key in standard locations

Mailing list discussion: https://lists.fedoraproject.org/archives/list/buildsys@lists.fedoraproject.org/thread/5ZAACHTR7FVPYDIH4DWYYYGHNADNYOVE/