### PR TITLE
config: epel move: CentOS+EPEL => RHEL+EPEL

### DIFF
--- a/mock-core-configs/etc/mock/epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-aarch64.cfg
@@ -1,6 +1,4 @@
-include('templates/centos-8.tpl')
+include('rhel-8-aarch64.cfg')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = 'epel-8-aarch64'
-config_opts['target_arch'] = 'aarch64'
-config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['root'] = "epel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/epel-8-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-ppc64.cfg
@@ -1,4 +1,4 @@
 include('rhel-8-ppc64.cfg')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = "rhelepel-8-{{ target_arch }}"
+config_opts['root'] = "epel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-8-ppc64le.cfg
@@ -1,6 +1,4 @@
-include('templates/centos-8.tpl')
+include('rhel-8-ppc64le.cfg')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = 'epel-8-ppc64le'
-config_opts['target_arch'] = 'ppc64le'
-config_opts['legal_host_arches'] = ('ppc64le',)
+config_opts['root'] = "epel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-x86_64.cfg
@@ -1,6 +1,4 @@
-include('templates/centos-8.tpl')
+include('rhel-8-x86_64.cfg')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = 'epel-8-x86_64'
-config_opts['target_arch'] = 'x86_64'
-config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['root'] = "epel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/rhel-8-ppc64.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-ppc64.cfg
@@ -1,0 +1,4 @@
+include('templates/rhel-8.tpl')
+
+config_opts['target_arch'] = 'ppc64'
+config_opts['legal_host_arches'] = ('ppc64',)

--- a/mock-core-configs/etc/mock/rhelepel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-aarch64.cfg
@@ -1,4 +1,0 @@
-include('rhel-8-aarch64.cfg')
-include('templates/epel-8.tpl')
-
-config_opts['root'] = "rhelepel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/rhelepel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-ppc64le.cfg
@@ -1,4 +1,0 @@
-include('rhel-8-ppc64le.cfg')
-include('templates/epel-8.tpl')
-
-config_opts['root'] = "rhelepel-8-{{ target_arch }}"

--- a/mock-core-configs/etc/mock/rhelepel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhelepel-8-x86_64.cfg
@@ -1,4 +1,0 @@
-include('rhel-8-x86_64.cfg')
-include('templates/epel-8.tpl')
-
-config_opts['root'] = "rhelepel-8-{{ target_arch }}"


### PR DESCRIPTION
CentOS 8 support ends at the end of Y2021, and we need to move on
WRT our default EPEL configuration.

The official EPEL packages are built (in Fedora Koji) against RHEL
repositories + EPEL repositories, so we try to mimic this here to be as
close to Koji as possible.

The obvious consequence here is that, from now on, users will need a Red
Hat subscription to build against epel-8-* chroots and newer (but the
free developer subscription is enough):

  https://rpm-software-management.github.io/mock/Feature-rhelchroots

Another problem is that Mock's forcearch (emulated) compilation isn't
working ATM: https://bugzilla.redhat.com/show_bug.cgi?id=1912847

Relates: https://bugzilla.redhat.com/show_bug.cgi?id=1965480