### PR TITLE
config: Migrate EPEL 8 configuration to use AlmaLinux 8 as the base OS

### DIFF
--- a/mock-core-configs/etc/mock/epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-aarch64.cfg
@@ -1,4 +1,4 @@
-include('templates/centos-8.tpl')
+include('templates/almalinux-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'epel-8-aarch64'

--- a/mock-core-configs/etc/mock/epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-8-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('templates/centos-8.tpl')
+include('templates/almalinux-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'epel-8-ppc64le'

--- a/mock-core-configs/etc/mock/epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-8-x86_64.cfg
@@ -1,4 +1,4 @@
-include('templates/centos-8.tpl')
+include('templates/almalinux-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'epel-8-x86_64'

--- a/mock-core-configs/etc/mock/epelplayground-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epelplayground-8-aarch64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/centos-8.tpl')
+include('/etc/mock/templates/almalinux-8.tpl')
 include('/etc/mock/templates/epelplayground-8.tpl')
 
 config_opts['root'] = 'epelplayground-8-aarch64'

--- a/mock-core-configs/etc/mock/epelplayground-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epelplayground-8-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/centos-8.tpl')
+include('/etc/mock/templates/almalinux-8.tpl')
 include('/etc/mock/templates/epelplayground-8.tpl')
 
 config_opts['root'] = 'epelplayground-8-ppc64le'

--- a/mock-core-configs/etc/mock/epelplayground-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epelplayground-8-x86_64.cfg
@@ -1,4 +1,4 @@
-include('/etc/mock/templates/centos-8.tpl')
+include('/etc/mock/templates/almalinux-8.tpl')
 include('/etc/mock/templates/epelplayground-8.tpl')
 
 config_opts['root'] = 'epelplayground-8-x86_64'


### PR DESCRIPTION
CentOS Linux 8 support ends at the end of 2021, so we need to select
a new base OS for the default EPEL configuration.

AlmaLinux satisfies the requirements to replace CentOS Linux for the
EPEL configuration, namely that:

* Alma provides the exact same content as Red Hat Enterprise Linux 8
* Alma releases the same time as RHEL (Alma 8.5 was 2 days after RHEL 8.5)
* AlmaLinux has committed to supporting all RHEL architectures
* AlmaLinux is freely available with no entitlement encumbrances

This allows all users of Mock to (re)build EPEL packages to successfully
do so regardless of host Linux distribution Mock runs on.

Resolves: [rhbz#1965480](https://bugzilla.redhat.com/show_bug.cgi?id=1965480)