### PR TITLE
config: Add AlmaLinux+EPEL configs

### DIFF
--- a/mock-core-configs/etc/mock/alma+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-8-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-8.tpl')
+include('templates/epel-8.tpl')
+
+config_opts['root'] = 'alma+epel-8-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/alma+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-8-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-8.tpl')
+include('templates/epel-8.tpl')
+
+config_opts['root'] = 'alma+epel-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)


### PR DESCRIPTION
This allows people to use AlmaLinux as the base OS for building packages
for Fedora EPEL.