### PR TITLE
Standardize oraclelinux+epel configs

### DIFF
--- a/mock-core-configs/etc/mock/oraclelinux+epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-7-aarch64.cfg
@@ -1,6 +1,6 @@
 include('templates/oraclelinux-7.tpl')
-include('templates/oraclelinux-epel-7.tpl')
+include('templates/epel-7.tpl')
 
-config_opts['root'] = 'oraclelinux-7-aarch64'
+config_opts['root'] = 'oraclelinux+epel-7-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux+epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-7-x86_64.cfg
@@ -1,6 +1,6 @@
 include('templates/oraclelinux-7.tpl')
-include('templates/oraclelinux-epel-7.tpl')
+include('templates/epel-7.tpl')
 
-config_opts['root'] = 'oraclelinux-7-x86_64'
+config_opts['root'] = 'oraclelinux+epel-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/oraclelinux+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-8-aarch64.cfg
@@ -1,6 +1,6 @@
 include('templates/oraclelinux-8.tpl')
-include('templates/oraclelinux-epel-8.tpl')
+include('templates/epel-8.tpl')
 
-config_opts['root'] = 'oraclelinux-8-aarch64'
+config_opts['root'] = 'oraclelinux+epel-8-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-8-x86_64.cfg
@@ -1,6 +1,6 @@
 include('templates/oraclelinux-8.tpl')
-include('templates/oraclelinux-epel-8.tpl')
+include('templates/epel-8.tpl')
 
-config_opts['root'] = 'oraclelinux-8-x86_64'
+config_opts['root'] = 'oraclelinux+epel-8-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)


### PR DESCRIPTION
* Rename files from `oraclelinux-epel-*` to `oraclelinux+epel-*`
* Use corresponding root name in config_opts
* Use the real EPEL