### PR TITLE
Align all the EPEL configs with the EPEL Steering Committee decision

### DIFF
--- a/mock-core-configs/etc/mock/centos+epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-7-aarch64.cfg
@@ -1,5 +1,6 @@
+include('templates/centos-7.tpl')
 include('templates/epel-7.tpl')
 
-config_opts['root'] = 'epel-7-aarch64'
+config_opts['root'] = 'centos+epel-7-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos+epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-7-ppc64le.cfg
@@ -1,5 +1,6 @@
+include('templates/centos-7.tpl')
 include('templates/epel-7.tpl')
 
-config_opts['root'] = 'epel-7-ppc64le'
+config_opts['root'] = 'centos+epel-7-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos+epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-7-x86_64.cfg
@@ -1,5 +1,6 @@
+include('templates/centos-7.tpl')
 include('templates/epel-7.tpl')
 
-config_opts['root'] = 'epel-7-x86_64'
+config_opts['root'] = 'centos+epel-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-8-aarch64.cfg
@@ -1,6 +1,6 @@
 include('templates/centos-8.tpl')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = 'epel-8-aarch64'
+config_opts['root'] = 'centos+epel-8-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos+epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-8-ppc64le.cfg
@@ -1,6 +1,6 @@
 include('templates/centos-8.tpl')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = 'epel-8-ppc64le'
+config_opts['root'] = 'centos+epel-8-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-8-x86_64.cfg
@@ -1,6 +1,6 @@
 include('templates/centos-8.tpl')
 include('templates/epel-8.tpl')
 
-config_opts['root'] = 'epel-8-x86_64'
+config_opts['root'] = 'centos+epel-8-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-aarch64.cfg
@@ -1,7 +1,6 @@
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
-include('templates/epel-next-9.tpl')
 
-config_opts['root'] = 'epel-next-9-aarch64'
+config_opts['root'] = 'centos-stream+epel-9-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
@@ -1,7 +1,6 @@
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
-include('templates/epel-next-9.tpl')
 
-config_opts['root'] = 'epel-next-9-ppc64le'
+config_opts['root'] = 'centos-stream+epel-9-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-s390x.cfg
@@ -1,7 +1,6 @@
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
-include('templates/epel-next-9.tpl')
 
-config_opts['root'] = 'epel-next-9-s390x'
+config_opts['root'] = 'centos-stream+epel-9-s390x'
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-x86_64.cfg
@@ -1,7 +1,6 @@
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
-include('templates/epel-next-9.tpl')
 
-config_opts['root'] = 'epel-next-9-x86_64'
+config_opts['root'] = 'centos-stream+epel-9-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-aarch64.cfg
@@ -2,6 +2,6 @@ include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')
 
-config_opts['root'] = 'epel-next-8-aarch64'
+config_opts['root'] = 'centos-stream+epel-next-8-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
@@ -2,6 +2,6 @@ include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')
 
-config_opts['root'] = 'epel-next-8-ppc64le'
+config_opts['root'] = 'centos-stream+epel-next-8-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-x86_64.cfg
@@ -2,6 +2,6 @@ include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')
 
-config_opts['root'] = 'epel-next-8-x86_64'
+config_opts['root'] = 'centos-stream+epel-next-8-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/epel-7.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-7.tpl
@@ -1,5 +1,3 @@
-include('templates/centos-7.tpl')
-
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 
 config_opts['yum.conf'] += """


### PR DESCRIPTION
The EPEL Steering Committee agreed to eliminate EPEL configs for exclusively distro+repo configs.

Additionally, fix EPEL 9 to have split configs for EPEL 9 and EPEL Next 9.