### PR TITLE
remove epel-7-ppc64

### DIFF
--- a/mock-core-configs/etc/mock/epel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/epel-7-ppc64.cfg
@@ -1,5 +1,0 @@
-include('templates/epel-7.tpl')
-
-config_opts['root'] = 'epel-7-ppc64'
-config_opts['target_arch'] = 'ppc64'
-config_opts['legal_host_arches'] = ('ppc64',)


### PR DESCRIPTION
This is left over from 4658fe74593593f61064acde3455b63cccb50a28
We do no not have good replacement for this, but that can be resolved later.