### PR TITLE
config: Rename epel-7-ppc64 to centos+epel-7-ppc64

### DIFF
--- a/mock-core-configs/etc/mock/centos+epel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-7-ppc64.cfg
@@ -1,5 +1,6 @@
+include('templates/centos-7.tpl')
 include('templates/epel-7.tpl')
 
-config_opts['root'] = 'epel-7-ppc64'
+config_opts['root'] = 'centos+epel-7-ppc64'
 config_opts['target_arch'] = 'ppc64'
 config_opts['legal_host_arches'] = ('ppc64',)


### PR DESCRIPTION
This was missed with the others.

Fixes: 1a1932d32607215aab694a9a655dc9bcee1434b8