### PR TITLE
Config: Add rocky+epel confs + Disable devel-debug

### DIFF
--- a/mock-core-configs/etc/mock/rocky+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-8-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-8.tpl')
+include('templates/epel-8.tpl')
+
+config_opts['root'] = 'rocky+epel-8-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rocky+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-8-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-8.tpl')
+include('templates/epel-8.tpl')
+
+config_opts['root'] = 'rocky+epel-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -137,7 +137,7 @@ name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT AND KOJI USE
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/debug/tree
 gpgcheck=1
-enabled=1
+enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 # Source Repos


### PR DESCRIPTION
The following configs were added to enable Rocky 8 x86_64 and aarch64 and EPEL builds:

* rocky+epel-8-x86_64
* rocky+epel-8-aarch64

The following templates were modified to disable devel-debug (which should only be enabled if a user requests as such):

* rocky-8.tpl

---

Please let me know if there is anything incorrect with the naming or the configurations in this PR. Thank you!