### PR TITLE
mock: podman, explictily specify stdin as tar source

### DIFF
--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -66,7 +66,7 @@ class Podman:
         getLog().info("Copy content of container %s to %s", self.image, destination)
         cmd_podman = ["podman", "export", self.container_id]
         podman = subprocess.Popen(cmd_podman, stdout=subprocess.PIPE)
-        cmd_tar = [tar_cmd, "-xC", destination]
+        cmd_tar = [tar_cmd, "-xC", destination, "-f", "-"]
         tar = subprocess.Popen(cmd_tar, stdin=podman.stdout)
         tar.communicate()
         podman.communicate()


### PR DESCRIPTION
bsdtar reads for /dev/st0 by default. Update the tar_cmd to explicitly specify stdin so bsdtar will work to extract podman images.

Fixes #818