### PR TITLE
config: Add EPEL suffixes to 'local' repo in EPEL configs

### DIFF
--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -15,13 +15,6 @@ enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel8&arch=$basearch
 skip_if_unavailable=False
 
-[local]
-name=local
-baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-build/latest/$basearch/
-cost=2000
-enabled=0
-skip_if_unavailable=False
-
 [epel-debuginfo]
 name=Extra Packages for Enterprise Linux $releasever - $basearch - Debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-8&arch=$basearch
@@ -49,6 +42,13 @@ skip_if_unavailable=False
 [epel-modular-source]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Source
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-source-8&arch=$basearch
+enabled=0
+skip_if_unavailable=False
+
+[local-epel]
+name=local-epel
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-build/latest/$basearch/
+cost=2000
 enabled=0
 skip_if_unavailable=False
 """

--- a/mock-core-configs/etc/mock/templates/epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-9.tpl
@@ -50,8 +50,8 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
-[local]
-name=local
+[local-epel]
+name=local-epel
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-build/latest/$basearch/
 cost=2000
 enabled=0

--- a/mock-core-configs/etc/mock/templates/epel-next-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-8.tpl
@@ -48,8 +48,8 @@ gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 skip_if_unavailable=False
 
-[local]
-name=local
+[local-epel-next]
+name=local-epel-next
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-next-build/latest/$basearch/
 cost=2000
 enabled=0

--- a/mock-core-configs/etc/mock/templates/epel-next-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-9.tpl
@@ -48,8 +48,8 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
-[local]
-name=local
+[local-epel-next]
+name=local-epel-next
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-next-build/latest/$basearch/
 cost=2000
 enabled=0


### PR DESCRIPTION
This ensures they are unique regardless of which base RHELish
distribution EPEL is combined with.