### PR TITLE
config: keep failovermethod=priority for a while

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -29,6 +29,7 @@ user_agent={{ user_agent }}
 [baseos]
 name=CentOS-$releasever - Base
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -38,6 +38,7 @@ skip_if_unavailable=False
 name=CentOS Stream $releasever - BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
+failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False

--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -5,6 +5,7 @@ config_opts['dnf.conf'] += """
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearch
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=$basearch
+failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 skip_if_unavailable=False
@@ -13,6 +14,7 @@ skip_if_unavailable=False
 name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch
 enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel8&arch=$basearch
+failovermethod=priority
 skip_if_unavailable=False
 
 [local]
@@ -25,30 +27,35 @@ skip_if_unavailable=False
 [epel-debuginfo]
 name=Extra Packages for Enterprise Linux $releasever - $basearch - Debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-8&arch=$basearch
+failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-source]
 name=Extra Packages for Enterprise Linux $releasever - $basearch - Source
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-8&arch=$basearch
+failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-modular]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-8&arch=$basearch
+failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-modular-debuginfo]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-debug-8&arch=$basearch
+failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-modular-source]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Source
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-source-8&arch=$basearch
+failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 """


### PR DESCRIPTION
We still support EL7 in the release process.  We can remove this once we
have 'mock-2' branch separated from 'main' (for the purpose of EL7
mock/mock-core-configs maintenance).

This causes ugly warnings on modern fedora systems, but these are just
warnings which are going to disappear soon:
https://github.com/rpm-software-management/libdnf/pull/1276

This reverts commit d4b504c1c1d026f99f9e84852ec7543ce615d1bb.
Relates: #807