### PR TITLE
Resolve the multiple "local" repo problems

### DIFF
--- a/mock-core-configs/etc/mock/centos-stream+epel-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-aarch64.cfg
@@ -1,3 +1,4 @@
+config_opts["koji_primary_repo"] = "epel"
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
@@ -1,3 +1,4 @@
+config_opts["koji_primary_repo"] = "epel"
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-s390x.cfg
@@ -1,3 +1,4 @@
+config_opts["koji_primary_repo"] = "epel"
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-x86_64.cfg
@@ -1,3 +1,4 @@
+config_opts["koji_primary_repo"] = "epel"
 include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-aarch64.cfg
@@ -1,3 +1,5 @@
+config_opts["koji_primary_repo"] = "epel-next"
+
 include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
@@ -1,3 +1,5 @@
+config_opts["koji_primary_repo"] = "epel-next"
+
 include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-x86_64.cfg
@@ -1,3 +1,5 @@
+config_opts["koji_primary_repo"] = "epel-next"
+
 include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -49,7 +49,7 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [devel]
-name=CentOS-$releasever - Devel WARNING! FOR BUILDROOT USE ONLY!
+name=CentOS-$releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=Devel&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/Devel/$basearch/os/
 gpgcheck=1

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -27,7 +27,11 @@ protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}
 
+{% if koji_primary_repo != None and koji_primary_repo != "centos-stream" %}
+[local-centos-stream]
+{% else %}
 [local]
+{% endif %}
 name=CentOS-Stream - Koji Local WARNING! FOR BUILDROOT USE ONLY!
 baseurl=https://koji.mbox.centos.org/kojifiles/repos/dist-c{{ releasever }}-stream-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -32,7 +32,7 @@ user_agent={{ user_agent }}
 {% else %}
 [local]
 {% endif %}
-name=CentOS-Stream - Koji Local WARNING! FOR BUILDROOT USE ONLY!
+name=CentOS Stream $releasever - Koji Local - BUILDROOT ONLY!
 baseurl=https://koji.mbox.centos.org/kojifiles/repos/dist-c{{ releasever }}-stream-build/latest/$basearch/
 cost=2000
 enabled=0
@@ -116,7 +116,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-Devel]
-name=CentOS-Stream - Devel WARNING! FOR BUILDROOT USE ONLY!
+name=CentOS-Stream - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
 baseurl=http://mirror.centos.org/centos/$releasever-stream/Devel/$basearch/os/
 gpgcheck=1
 enabled=0

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -29,7 +29,7 @@ user_agent={{ user_agent }}
 {% else %}
 [local]
 {% endif %}
-name=CentOS Stream $releasever - Koji Local WARNING! FOR BUILDROOT USE ONLY!
+name=CentOS Stream $releasever - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojihub.stream.centos.org/kojifiles/repos/c{{ releasever }}s-build/latest/$basearch/
 cost=2000
 enabled=0

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -24,7 +24,11 @@ protected_packages=
 module_platform_id=platform:el9
 user_agent={{ user_agent }}
 
+{% if koji_primary_repo != None and koji_primary_repo != "centos-stream" %}
+[local-centos-stream]
+{% else %}
 [local]
+{% endif %}
 name=CentOS Stream $releasever - Koji Local WARNING! FOR BUILDROOT USE ONLY!
 baseurl=https://kojihub.stream.centos.org/kojifiles/repos/c{{ releasever }}s-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -17,17 +17,6 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel8&arch=$
 failovermethod=priority
 skip_if_unavailable=False
 
-{% if koji_primary_repo != None and koji_primary_repo != "epel" %}
-[local-epel]
-{% else %}
-[local]
-{% endif %}
-name=local
-baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-build/latest/$basearch/
-cost=2000
-enabled=0
-skip_if_unavailable=False
-
 [epel-debuginfo]
 name=Extra Packages for Enterprise Linux $releasever - $basearch - Debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-8&arch=$basearch
@@ -60,6 +49,17 @@ skip_if_unavailable=False
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Source
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-source-8&arch=$basearch
 failovermethod=priority
+enabled=0
+skip_if_unavailable=False
+
+{% if koji_primary_repo != None and koji_primary_repo != "epel" %}
+[local-epel]
+{% else %}
+[local]
+{% endif %}
+name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-build/latest/$basearch/
+cost=2000
 enabled=0
 skip_if_unavailable=False
 """

--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -17,7 +17,11 @@ mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel8&arch=$
 failovermethod=priority
 skip_if_unavailable=False
 
+{% if koji_primary_repo != None and koji_primary_repo != "epel" %}
+[local-epel]
+{% else %}
 [local]
+{% endif %}
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-9.tpl
@@ -50,7 +50,11 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
+{% if koji_primary_repo != None and koji_primary_repo != "epel" %}
+[local-epel]
+{% else %}
 [local]
+{% endif %}
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-9.tpl
@@ -55,7 +55,7 @@ skip_if_unavailable=False
 {% else %}
 [local]
 {% endif %}
-name=local
+name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-build/latest/$basearch/
 cost=2000
 enabled=0

--- a/mock-core-configs/etc/mock/templates/epel-next-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-8.tpl
@@ -53,7 +53,7 @@ skip_if_unavailable=False
 {% else %}
 [local]
 {% endif %}
-name=local
+name=Extra Packages for Enterprise Linux $releasever - Next - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-next-build/latest/$basearch/
 cost=2000
 enabled=0

--- a/mock-core-configs/etc/mock/templates/epel-next-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-8.tpl
@@ -48,7 +48,11 @@ gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 skip_if_unavailable=False
 
+{% if koji_primary_repo != None and koji_primary_repo != "epel-next" %}
+[local-epel-next]
+{% else %}
 [local]
+{% endif %}
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-next-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/epel-next-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-9.tpl
@@ -48,7 +48,11 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
+{% if koji_primary_repo != None and koji_primary_repo != "epel-next" %}
+[local-epel-next]
+{% else %}
 [local]
+{% endif %}
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-next-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/epel-next-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-9.tpl
@@ -53,7 +53,7 @@ skip_if_unavailable=False
 {% else %}
 [local]
 {% endif %}
-name=local
+name=Extra Packages for Enterprise Linux $releasever - Next - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-next-build/latest/$basearch/
 cost=2000
 enabled=0

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -84,7 +84,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 [devel]
-name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT AND KOJI USE
+name=Rocky Linux $releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/os/
 gpgcheck=1
@@ -93,7 +93,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 # Debuginfo
 [baseos-debug]
-name=Rocky Linux $releasever - BaseOS - Source
+name=Rocky Linux $releasever - BaseOS - Debuginfo
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
 gpgcheck=1
@@ -101,7 +101,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 [appstream-debug]
-name=Rocky Linux $releasever - AppStream - Source
+name=Rocky Linux $releasever - AppStream - Debuginfo
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
 gpgcheck=1
@@ -109,7 +109,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 [ha-debug]
-name=Rocky Linux $releasever - High Availability - Source
+name=Rocky Linux $releasever - High Availability - Debuginfo
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/debug/tree
 gpgcheck=1
@@ -117,7 +117,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 [powertools-debug]
-name=Rocky Linux $releasever - PowerTools - Source
+name=Rocky Linux $releasever - PowerTools - Debuginfo
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/debug/tree
 gpgcheck=1
@@ -125,7 +125,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 [resilient-storage-debug]
-name=Rocky Linux $releasever - Resilient Storage - Source
+name=Rocky Linux $releasever - Resilient Storage - Debuginfo
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/debug/tree
 gpgcheck=1
@@ -133,7 +133,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
 
 [devel-debug]
-name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT AND KOJI USE
+name=Rocky Linux $releasever - Devel - Debuginfo
 mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$releasever-debug
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/debug/tree
 gpgcheck=1


### PR DESCRIPTION
Deterministically resolve which of the "local" repositories is
the primary one:

- 'centos-stream+epel' => local is EPEL buildroot
- 'centos-stream+epel-next' => local for EPEL Next buildroot
- 'centos-stream' => local is just CentOS Stream buildroot

The only requirement is to specify the 'koji_primary_repo' variable to
'epel', 'epel-next' or 'centos-stream'.

Users may still opt-in to use '--enablerepo "local*"' if they really
want to enable all the Koji buildroots.