### PR TITLE
Pass env to podman run

### DIFF
--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -26,7 +26,7 @@ class Podman:
     def get_container_id(self):
         """ start a container and detach immediately """
         cmd = ["podman", "run", "--quiet", "-i", "--detach", self.image, "/bin/bash"]
-        container_id = util.do(cmd, returnOutput=True)
+        container_id = util.do(cmd, returnOutput=True, env=self.buildroot.env)
         self.container_id = container_id.strip()
         return self.container_id
 


### PR DESCRIPTION
Fixes #831

Without env vars passed to the podman run command, outbound proxy doesn't work while creating the root dir