### PR TITLE
mock: don't print coverage stats for RPM builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ matrix:
 
 install:
   - "pip install -r mock/requirements.txt"
+  - "pip install pytest-cov"
 
 script: PYTHON=python${TRAVIS_PYTHON_VERSION%%-dev} ./mock/run-tests.sh

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -88,7 +88,6 @@ BuildRequires: python%{python3_pkgversion}-distro
 BuildRequires: python%{python3_pkgversion}-jinja2
 BuildRequires: python%{python3_pkgversion}-pyroute2
 BuildRequires: python%{python3_pkgversion}-pytest
-BuildRequires: python%{python3_pkgversion}-pytest-cov
 BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-templated-dictionary
 %endif
@@ -216,7 +215,7 @@ pylint-3 py/mockbuild/ py/*.py py/mockbuild/plugins/* || :
 %endif
 
 %if %{with tests}
-./run-tests.sh
+./run-tests.sh --no-cov
 %endif
 
 

--- a/mock/requirements.txt
+++ b/mock/requirements.txt
@@ -1,6 +1,5 @@
 distro
 jinja2
 pyroute2
-pytest-cov
 requests
 templated-dictionary

--- a/mock/run-tests.sh
+++ b/mock/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /bin/bash
 
 script=$(readlink -f "$0")
 testdir=$(dirname "$script")/tests
@@ -20,4 +20,19 @@ debug "testdir:    $testdir"
 debug "PYTHON:     $PYTHON"
 debug "PYTHONPATH: $PYTHONPATH"
 
-"$PYTHON" -B -m pytest --cov-report term-missing --cov "$sourcedir" "$testdir" "$@"
+args=()
+cov=true
+for arg; do
+    case $arg in
+    --no-cov) cov=false ;;
+    *) args+=( "$arg" ) ;;
+    esac
+done
+
+cov_args=()
+if $cov; then
+    cov_args=( --cov-report term-missing --cov "$sourcedir" )
+fi
+
+set -x
+"$PYTHON" -B -m pytest "${cov_args[@]}" "$testdir" "${args[@]}"


### PR DESCRIPTION
This is breaking build on F34 (#2033331), but it also doesn't make any
sense to run coverage analysis for every RPM build.  By default, if run
locally, the ./run-tests.sh script still performs coverage analysis.