### PR TITLE
core-configs: Fix CentOS templates

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -51,7 +51,6 @@ skip_if_unavailable=False
 
 [updates]
 name=CentOS-$releasever - Updates
-enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/updates/$basearch/
 failovermethod=priority
@@ -85,9 +84,11 @@ enabled=0
 name=CentOS-$releasever - Plus
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/centosplus/$basearch/
+failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
        {{- centos_7_arch_gpg_key }}
 gpgcheck=1
+skip_if_unavailable=False
 enabled=0
 
 {% if target_arch == 'x86_64' %}
@@ -95,6 +96,7 @@ enabled=0
 name=CentOS-$releasever - SCLo sclo
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-sclo&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/sclo/$basearch/sclo/
+failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*
@@ -106,6 +108,7 @@ skip_if_unavailable=False
 name=CentOS-$releasever - SCLo rh
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-rh&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/sclo/$basearch/rh/
+failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*

--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -30,12 +30,13 @@ best=1
 protected_packages=
 user_agent={{ user_agent }}
 
-{% set centos_7_gpg_keys = 'file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7' %}
+{% set centos_7_arch_gpg_key -%}
 {% if target_arch in ['ppc64le', 'ppc64'] %}
-{%   set centos_7_gpg_keys = centos_7_gpg_keys + ',file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-' + target_arch %}
-{% elif target_arch in ['aarch64'] %}
-{%   set centos_7_gpg_keys = centos_7_gpg_keys + ',file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7-aarch64' %}
-{% endif %}
+       file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-AltArch-7-{{ target_arch }}
+{%- elif target_arch == 'aarch64' %}
+       file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7-aarch64
+{%- endif -%}
+{% endset -%}
 
 # repos
 [base]
@@ -43,7 +44,8 @@ name=CentOS-$releasever - Base
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/os/$basearch/
 failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+       {{- centos_7_arch_gpg_key }}
 gpgcheck=1
 skip_if_unavailable=False
 
@@ -53,7 +55,8 @@ enabled=1
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/updates/$basearch/
 failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+       {{- centos_7_arch_gpg_key }}
 gpgcheck=1
 skip_if_unavailable=False
 
@@ -62,7 +65,8 @@ name=CentOS-$releasever - Extras
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/extras/$basearch/
 failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+       {{- centos_7_arch_gpg_key }}
 gpgcheck=1
 skip_if_unavailable=False
 
@@ -71,7 +75,8 @@ name=CentOS-$releasever - fasttrack
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/fasttrack/$basearch/
 failovermethod=priority
-gpgkey={{ centos_7_gpg_keys }}
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+       {{- centos_7_arch_gpg_key }}
 gpgcheck=1
 skip_if_unavailable=False
 enabled=0
@@ -80,7 +85,8 @@ enabled=0
 name=CentOS-$releasever - Plus
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/centosplus/$basearch/
-gpgkey={{ centos_7_gpg_keys }}
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+       {{- centos_7_arch_gpg_key }}
 gpgcheck=1
 enabled=0
 

--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -6,6 +6,9 @@ config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:7'
 config_opts['package_manager'] = 'yum'
+config_opts['yum_vars'] = { 'contentdir': "{% if target_arch in ['x86_64'] -%} centos {%- else -%} altarch {%- endif %}",
+                            'infra': 'stock',
+                          }
 
 config_opts['yum_install_command'] += "{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %} --disablerepo=centos-sclo*{% endif %}"
 
@@ -37,7 +40,8 @@ user_agent={{ user_agent }}
 # repos
 [base]
 name=CentOS-$releasever - Base
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/os/$basearch/
 failovermethod=priority
 gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
@@ -46,7 +50,8 @@ skip_if_unavailable=False
 [updates]
 name=CentOS-$releasever - Updates
 enabled=1
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/updates/$basearch/
 failovermethod=priority
 gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
@@ -54,8 +59,8 @@ skip_if_unavailable=False
 
 [extras]
 name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/extras/$basearch/
 failovermethod=priority
 gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
@@ -63,7 +68,8 @@ skip_if_unavailable=False
 
 [fasttrack]
 name=CentOS-$releasever - fasttrack
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/fasttrack/$basearch/
 failovermethod=priority
 gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
@@ -72,8 +78,8 @@ enabled=0
 
 [centosplus]
 name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/centosplus/$basearch/
 gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
 enabled=0
@@ -81,7 +87,8 @@ enabled=0
 {% if target_arch == 'x86_64' %}
 [centos-sclo-sclo]
 name=CentOS-$releasever - SCLo sclo
-baseurl=http://mirror.centos.org/centos/7/sclo/$basearch/sclo/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-sclo&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/sclo/$basearch/sclo/
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*
@@ -91,7 +98,8 @@ skip_if_unavailable=False
 {% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %}
 [centos-sclo-rh]
 name=CentOS-$releasever - SCLo rh
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=sclo-rh
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-rh&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/sclo/$basearch/rh/
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
 includepkgs=devtoolset*

--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -1,6 +1,7 @@
 # This list is taken from 'epel-7-x86_64' @buildsys-build group, minus the
 # 'epel-*' specific stuff.
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['chroot_additional_packages'] = 'scl-utils-build'
 
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
@@ -91,7 +92,7 @@ gpgcheck=1
 skip_if_unavailable=False
 enabled=0
 
-{% if target_arch == 'x86_64' %}
+{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %}
 [centos-sclo-sclo]
 name=CentOS-$releasever - SCLo sclo
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-sclo&infra=$infra
@@ -99,11 +100,8 @@ mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
-includepkgs=devtoolset*
 skip_if_unavailable=False
-{% endif %}
 
-{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %}
 [centos-sclo-rh]
 name=CentOS-$releasever - SCLo rh
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-rh&infra=$infra
@@ -111,7 +109,6 @@ mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-SCLo
 gpgcheck=1
-includepkgs=devtoolset*
 skip_if_unavailable=False
 {% endif %}
 """

--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -92,6 +92,55 @@ gpgcheck=1
 skip_if_unavailable=False
 enabled=0
 
+[cr]
+name=CentOS-$releasever - cr
+baseurl=http://mirror.centos.org/$contentdir/$releasever/cr/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+       {{- centos_7_arch_gpg_key }}
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
+[base-debuginfo]
+name=CentOS-$releasever - Debuginfo
+baseurl=http://debuginfo.centos.org/$releasever/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Debug-7
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
+[base-source]
+name=CentOS-$releasever - Base Sources
+baseurl=http://vault.centos.org/centos/$releasever/os/Source/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
+[updates-source]
+name=CentOS-$releasever - Updates Sources
+baseurl=http://vault.centos.org/centos/$releasever/updates/Source/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
+[extras-source]
+name=CentOS-$releasever - Extras Sources
+baseurl=http://vault.centos.org/centos/$releasever/extras/Source/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
+[centosplus-source]
+name=CentOS-$releasever - Plus Sources
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/Source/
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+skip_if_unavailable=False
+enabled=0
+
 {% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %}
 [centos-sclo-sclo]
 name=CentOS-$releasever - SCLo sclo

--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -61,7 +61,7 @@ gpgkey={{ centos_7_gpg_keys }}
 gpgcheck=1
 skip_if_unavailable=False
 
-[fastrack]
+[fasttrack]
 name=CentOS-$releasever - fasttrack
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack
 failovermethod=priority

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -27,7 +27,7 @@ module_platform_id=platform:el8
 user_agent={{ user_agent }}
 
 [baseos]
-name=CentOS-$releasever - Base
+name=CentOS Linux $releasever - BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -35,21 +35,21 @@ gpgcheck=1
 skip_if_unavailable=False
 
 [appstream]
-name=CentOS-$releasever - AppStream
+name=CentOS Linux $releasever - AppStream
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/AppStream/$basearch/os/
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools]
-name=CentOS-$releasever - PowerTools
+name=CentOS Linux $releasever - PowerTools
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/PowerTools/$basearch/os/
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [devel]
-name=CentOS-$releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
+name=CentOS Linux $releasever - Devel WARNING! FOR BUILDROOT USE ONLY!
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=Devel&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/Devel/$basearch/os/
 gpgcheck=1
@@ -57,7 +57,7 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [plus]
-name=CentOS-$releasever - Plus
+name=CentOS Linux $releasever - Plus
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=centosplus&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/os/
 gpgcheck=1
@@ -65,21 +65,21 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [cr]
-name=CentOS-$releasever - cr
+name=CentOS Linux $releasever - ContinuousRelease
 baseurl=http://mirror.centos.org/centos/8/cr/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [debuginfo]
-name=CentOS-$releasever - Debuginfo
+name=CentOS Linux $releasever - Debuginfo
 baseurl=http://debuginfo.centos.org/8/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras]
-name=CentOS-$releasever - Extras
+name=CentOS Linux $releasever - Extras
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/os/
 gpgcheck=1
@@ -87,7 +87,7 @@ enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [fasttrack]
-name=CentOS-$releasever - fasttrack
+name=CentOS Linux $releasever - FastTrack
 mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=fasttrack&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/fasttrack/$basearch/os/
 gpgcheck=1
@@ -95,35 +95,35 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [baseos-source]
-name=CentOS-$releasever - BaseOS Sources
+name=CentOS Linux $releasever - BaseOS - Source
 baseurl=http://vault.centos.org/centos/8/BaseOS/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [appstream-source]
-name=CentOS-$releasever - AppStream Sources
+name=CentOS Linux $releasever - AppStream - Source
 baseurl=http://vault.centos.org/centos/8/AppStream/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools-source]
-name=CentOS-$releasever - PowerTools Sources
+name=CentOS Linux $releasever - PowerTools - Source
 baseurl=http://vault.centos.org/centos/8/PowerTools/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras-source]
-name=CentOS-$releasever - Extras Sources
+name=CentOS Linux $releasever - Extras - Source
 baseurl=http://vault.centos.org/centos/8/extras/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[splus-source]
-name=CentOS-$releasever - Plus Sources
+[plus-source]
+name=CentOS Linux $releasever - Plus - Source
 baseurl=http://vault.centos.org/centos/8/centosplus/Source/
 gpgcheck=1
 enabled=0

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -33,16 +33,16 @@ user_agent={{ user_agent }}
 name=CentOS Linux $releasever - BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/
-failovermethod=priority
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
-skip_if_unavailable=False
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [appstream]
 name=CentOS Linux $releasever - AppStream
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/
 gpgcheck=1
+enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools]
@@ -50,6 +50,7 @@ name=CentOS Linux $releasever - PowerTools
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/
 gpgcheck=1
+enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [devel]

--- a/mock-core-configs/etc/mock/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-8.tpl
@@ -4,6 +4,9 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:8'
+config_opts['dnf_vars'] = { 'contentdir': "{% if target_arch in ['x86_64'] -%} centos {%- else -%} altarch {%- endif %}",
+                            'infra': 'stock',
+                          }
 
 
 config_opts['dnf.conf'] = """
@@ -28,7 +31,8 @@ user_agent={{ user_agent }}
 
 [baseos]
 name=CentOS Linux $releasever - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=BaseOS&infra=$infra
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
@@ -36,15 +40,15 @@ skip_if_unavailable=False
 
 [appstream]
 name=CentOS Linux $releasever - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=AppStream&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/AppStream/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools]
 name=CentOS Linux $releasever - PowerTools
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=PowerTools&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/PowerTools/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/PowerTools/$basearch/os/
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
@@ -58,73 +62,73 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [plus]
 name=CentOS Linux $releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=centosplus&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/centosplus/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [cr]
 name=CentOS Linux $releasever - ContinuousRelease
-baseurl=http://mirror.centos.org/centos/8/cr/$basearch/os/
+baseurl=http://mirror.centos.org/$contentdir/$releasever/cr/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [debuginfo]
 name=CentOS Linux $releasever - Debuginfo
-baseurl=http://debuginfo.centos.org/8/$basearch/
+baseurl=http://debuginfo.centos.org/$releasever/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras]
 name=CentOS Linux $releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [fasttrack]
 name=CentOS Linux $releasever - FastTrack
-mirrorlist=http://mirrorlist.centos.org/?release=8&arch=$basearch&repo=fasttrack&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/fasttrack/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/fasttrack/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [baseos-source]
 name=CentOS Linux $releasever - BaseOS - Source
-baseurl=http://vault.centos.org/centos/8/BaseOS/Source/
+baseurl=http://vault.centos.org/centos/$releasever/BaseOS/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [appstream-source]
 name=CentOS Linux $releasever - AppStream - Source
-baseurl=http://vault.centos.org/centos/8/AppStream/Source/
+baseurl=http://vault.centos.org/centos/$releasever/AppStream/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools-source]
 name=CentOS Linux $releasever - PowerTools - Source
-baseurl=http://vault.centos.org/centos/8/PowerTools/Source/
+baseurl=http://vault.centos.org/centos/$releasever/PowerTools/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras-source]
 name=CentOS Linux $releasever - Extras - Source
-baseurl=http://vault.centos.org/centos/8/extras/Source/
+baseurl=http://vault.centos.org/centos/$releasever/extras/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [plus-source]
 name=CentOS Linux $releasever - Plus - Source
-baseurl=http://vault.centos.org/centos/8/centosplus/Source/
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -94,29 +94,29 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[Stream-BaseOS-source]
-name=CentOS-Stream - BaseOS Sources
+[baseos-source]
+name=CentOS Stream $releasever - BaseOS - Source
 baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[Stream-AppStream-source]
-name=CentOS-Stream - AppStream Sources
+[appstream-source]
+name=CentOS Stream $releasever - AppStream - Source
 baseurl=http://vault.centos.org/centos/$releasever-stream/AppStream/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[Stream-PowerTools-source]
-name=CentOS-Stream - PowerTools Sources
+[powertools-source]
+name=CentOS Stream $releasever - PowerTools - Source
 baseurl=http://vault.centos.org/centos/$releasever-stream/PowerTools/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[Stream-extras-source]
-name=CentOS-Stream - Extras Sources
+[extras-source]
+name=CentOS Stream $releasever - Extras - Source
 baseurl=http://vault.centos.org/centos/$releasever-stream/extras/Source/
 gpgcheck=1
 enabled=0

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -6,6 +6,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream8'
 config_opts['dnf_vars'] = { 'stream': '8-stream',
                             'contentdir': 'centos',
+                            'infra': 'stock',
                           }
 
 config_opts['dnf.conf'] = """
@@ -33,15 +34,15 @@ user_agent={{ user_agent }}
 [local]
 {% endif %}
 name=CentOS Stream $releasever - Koji Local - BUILDROOT ONLY!
-baseurl=https://koji.mbox.centos.org/kojifiles/repos/dist-c{{ releasever }}-stream-build/latest/$basearch/
+baseurl=https://koji.mbox.centos.org/kojifiles/repos/dist-c$stream-build/latest/$basearch/
 cost=2000
 enabled=0
 skip_if_unavailable=False
 
 [baseos]
 name=CentOS Stream $releasever - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/BaseOS/$basearch/os/
 failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
@@ -49,75 +50,75 @@ skip_if_unavailable=False
 
 [appstream]
 name=CentOS Stream $releasever - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=AppStream&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [debuginfo]
 name=CentOS Stream $releasever - Debuginfo
-baseurl=http://debuginfo.centos.org/$releasever-stream/$basearch/
+baseurl=http://debuginfo.centos.org/$stream/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras]
 name=CentOS Stream $releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/extras/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools]
 name=CentOS Stream $releasever - PowerTools
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=PowerTools&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [rt]
 name=CentOS Stream $releasever - RealTime
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=RT&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/RT/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=RT&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/RT/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [ha]
 name=CentOS Stream $releasever - HighAvailability
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=HighAvailability&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=HighAvailability&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [baseos-source]
 name=CentOS Stream $releasever - BaseOS - Source
-baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/Source/
+baseurl=http://vault.centos.org/$contentdir/$stream/BaseOS/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [appstream-source]
 name=CentOS Stream $releasever - AppStream - Source
-baseurl=http://vault.centos.org/centos/$releasever-stream/AppStream/Source/
+baseurl=http://vault.centos.org/$contentdir/$stream/AppStream/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools-source]
 name=CentOS Stream $releasever - PowerTools - Source
-baseurl=http://vault.centos.org/centos/$releasever-stream/PowerTools/Source/
+baseurl=http://vault.centos.org/$contentdir/$stream/PowerTools/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [extras-source]
 name=CentOS Stream $releasever - Extras - Source
-baseurl=http://vault.centos.org/centos/$releasever-stream/extras/Source/
+baseurl=http://vault.centos.org/$contentdir/$stream/extras/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -94,6 +94,14 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
+[resilientstorage]
+name=CentOS Stream $releasever - ResilientStorage
+mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=ResilientStorage&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$stream/ResilientStorage/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
 [baseos-source]
 name=CentOS Stream $releasever - BaseOS - Source
 baseurl=http://vault.centos.org/$contentdir/$stream/BaseOS/Source/
@@ -118,6 +126,27 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [extras-source]
 name=CentOS Stream $releasever - Extras - Source
 baseurl=http://vault.centos.org/$contentdir/$stream/extras/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[ha-source]
+name=CentOS Stream $releasever - HighAvailability - Source
+baseurl=http://vault.centos.org/$contentdir/$stream/HighAvailability/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[rt-source]
+name=CentOS Stream $releasever - RT - Source
+baseurl=http://vault.centos.org/$contentdir/$stream/RT/Source/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[resilientstorage-source]
+name=CentOS Stream $releasever - ResilientStorage - Source
+baseurl=http://vault.centos.org/$contentdir/$stream/ResilientStorage/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -62,27 +62,6 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[Stream-centosplus]
-name=CentOS-Stream - Plus
-baseurl=http://mirror.centos.org/centos/$releasever-stream/centosplus/$basearch/os/
-gpgcheck=1
-enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-
-[cr]
-name=CentOS-$releasever - cr
-baseurl=http://mirror.centos.org/centos/$releasever/cr/$basearch/os/
-gpgcheck=1
-enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-
-[Stream-base-debuginfo]
-name=CentOS-Stream - Debuginfo
-baseurl=http://debuginfo.centos.org/$releasever-stream/$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-
 [extras]
 name=CentOS Stream $releasever - Extras
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
@@ -115,13 +94,6 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[Stream-Devel]
-name=CentOS-Stream - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
-baseurl=http://mirror.centos.org/centos/$releasever-stream/Devel/$basearch/os/
-gpgcheck=1
-enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-
 [Stream-BaseOS-source]
 name=CentOS-Stream - BaseOS Sources
 baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/Source/
@@ -146,13 +118,6 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [Stream-extras-source]
 name=CentOS-Stream - Extras Sources
 baseurl=http://vault.centos.org/centos/$releasever-stream/extras/Source/
-gpgcheck=1
-enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-
-[Stream-centosplus-source]
-name=CentOS-Stream - Plus Sources
-baseurl=http://vault.centos.org/centos/$releasever-stream/centosplus/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -43,10 +43,9 @@ skip_if_unavailable=False
 name=CentOS Stream $releasever - BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=$stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/$contentdir/$stream/BaseOS/$basearch/os/
-failovermethod=priority
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
-skip_if_unavailable=False
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [appstream]
 name=CentOS Stream $releasever - AppStream


### PR DESCRIPTION
This fixes differences between the CentOS templates in mock, and the actual repository configurations for CentOS, which results in build issues depending on the repositories and/or architectures.