### PR TITLE
Set extended variables for yum

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -565,6 +565,7 @@ class Buildroot(object):
                 'etc/dnf/vars',
                 'etc/yum.repos.d',
                 'etc/yum',
+                'etc/yum/vars',
                 'proc',
                 'sys']
         dirs += self.config['extra_chroot_dirs']

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -50,7 +50,8 @@ def nspawn_supported():
 @traceLog()
 def setup_default_config_opts(unprivUid, version, pkgpythondir):
     "sets up default configuration."
-    config_opts = TemplatedDictionary(alias_spec={'dnf.conf': ['yum.conf']})
+    config_opts = TemplatedDictionary(alias_spec={'dnf.conf': ['yum.conf'],
+                                                  'dnf_vars': ['yum_vars']})
     config_opts['config_paths'] = []
     config_opts['version'] = version
     config_opts['basedir'] = '/var/lib/mock'  # root name is automatically added to this
@@ -247,7 +248,6 @@ def setup_default_config_opts(unprivUid, version, pkgpythondir):
     config_opts['target_arch'] = 'i386'
     config_opts['releasever'] = None
     config_opts['rpmbuild_arch'] = None  # <-- None means set automatically from target_arch
-    config_opts['dnf_vars'] = {}
     config_opts['yum_builddep_opts'] = []
     config_opts['yum_common_opts'] = []
     config_opts['update_before_build'] = True


### PR DESCRIPTION
yum supports extended variables, even in RHEL 6. If either `yum_vars` or `dnf_vars` are set in the mock configuration, then set extended variables for the appropriate package manager. These are used in URLs for CentOS. (This change precedes #844.)