### PR TITLE
Remove failovermethod=priority from c8s and epel8 templates

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -42,7 +42,6 @@ skip_if_unavailable=False
 name=CentOS Stream $releasever - BaseOS
 mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
-failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False

--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -5,7 +5,6 @@ config_opts['dnf.conf'] += """
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearch
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=$basearch
-failovermethod=priority
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 skip_if_unavailable=False
@@ -14,41 +13,35 @@ skip_if_unavailable=False
 name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch
 enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel8&arch=$basearch
-failovermethod=priority
 skip_if_unavailable=False
 
 [epel-debuginfo]
 name=Extra Packages for Enterprise Linux $releasever - $basearch - Debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-8&arch=$basearch
-failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-source]
 name=Extra Packages for Enterprise Linux $releasever - $basearch - Source
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-8&arch=$basearch
-failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-modular]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-8&arch=$basearch
-failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-modular-debuginfo]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Debug
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-debug-8&arch=$basearch
-failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 
 [epel-modular-source]
 name=Extra Packages for Enterprise Linux Modular $releasever - $basearch - Source
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-modular-source-8&arch=$basearch
-failovermethod=priority
 enabled=0
 skip_if_unavailable=False
 


### PR DESCRIPTION
These were removed in DNF, and now cause warnings when populating the
mock chroot:

```
Invalid configuration value: failovermethod=priority in /var/lib/mock/epel-8-x86_64-zstd/root/etc/dnf/dnf.conf; Configuration: OptionBinding with id "failovermethod" does not exist
```

The C8S and EPEL repo definitions no longer set this key.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>