### PR TITLE
Use host_arch to select appropriate qemu-user-static binary

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -557,7 +557,7 @@ def check_arch_combination(target_arch, config_opts):
 
     config.multiply_platform_multiplier(config_opts)
     if config_opts['forcearch']:
-        binary = '/usr/bin/qemu-x86_64-static'
+        binary = '/usr/bin/qemu-' + host_arch + '-static'
         if not os.path.exists(binary):
             # qemu-user-static is required, but seems to be missing
             if util.is_host_rh_family():


### PR DESCRIPTION
Currently mock is hardcoded to use `qemu-x86_64-static`, which is
only valid on x86_64.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>