### PR TITLE
mock: copy /usr/share/pki source CA certificates

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -303,13 +303,14 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
 
     @traceLog()
     def copy_certs(self):
-        cert_path = "/etc/pki/ca-trust"
-        pki_dir = self.buildroot.make_chroot_path(cert_path)
-        try:
-            copy_tree(cert_path, pki_dir)
-        except DistutilsFileError:
-            warning = "Couldn't copy certs from host, %s doesn't exist or is not readable"
-            self.buildroot.root_log.debug(warning, cert_path)
+        cert_paths = ["/etc/pki/ca-trust", "/usr/share/pki/ca-trust-source"]
+        for cert_path in cert_paths:
+            pki_dir = self.buildroot.make_chroot_path(cert_path)
+            try:
+                copy_tree(cert_path, pki_dir)
+            except DistutilsFileError:
+                warning = "Couldn't copy certs from host, %s doesn't exist or is not readable"
+                self.buildroot.root_log.debug(warning, cert_path)
 
         bundle_path = self.config['ssl_ca_bundle_path']
         if bundle_path:


### PR DESCRIPTION
Like commit dcdaf718 if a source CA is copied to /usr/share/pki on the
host update-ca-trust inside the chroot will remove these from the trust.
