### PR TITLE
implement --list-chroots command

### DIFF
--- a/mock-core-configs/etc/mock/alma+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-8-aarch64.cfg
@@ -2,5 +2,6 @@ include('templates/almalinux-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'alma+epel-8-aarch64'
+config_opts['description'] = 'AlmaLinux 8 + EPEL'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/alma+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-8-x86_64.cfg
@@ -2,5 +2,6 @@ include('templates/almalinux-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'alma+epel-8-x86_64'
+config_opts['description'] = 'AlmaLinux 8 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/almalinux-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-8-aarch64.cfg
@@ -1,5 +1,6 @@
 include('templates/almalinux-8.tpl')
 
 config_opts['root'] = 'almalinux-8-aarch64'
+config_opts['description'] = 'AlmaLinux 8 + EPEL'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/almalinux-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-8-x86_64.cfg
@@ -1,5 +1,6 @@
 include('templates/almalinux-8.tpl')
 
 config_opts['root'] = 'almalinux-8-x86_64'
+config_opts['description'] = 'AlmaLinux 8 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos+epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-7-ppc64le.cfg
@@ -2,5 +2,6 @@ include('templates/centos-7.tpl')
 include('templates/epel-7.tpl')
 
 config_opts['root'] = 'centos+epel-7-ppc64le'
+config_opts['description'] = 'CentOS 7 + EPEL'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos+epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos+epel-7-x86_64.cfg
@@ -2,5 +2,6 @@ include('templates/centos-7.tpl')
 include('templates/epel-7.tpl')
 
 config_opts['root'] = 'centos+epel-7-x86_64'
+config_opts['description'] = 'CentOS 7 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-8-aarch64.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'centos-stream+epel-8-aarch64'
+config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-8-ppc64le.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'centos-stream+epel-8-ppc64le'
+config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-8-x86_64.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'centos-stream+epel-8-x86_64'
+config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-aarch64.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-9-aarch64'
+config_opts['description'] = 'CentOS Stream 9 + EPEL'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-9-ppc64le'
+config_opts['description'] = 'CentOS Stream 9 + EPEL'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-s390x.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-9-s390x'
+config_opts['description'] = 'CentOS Stream 9 + EPEL'
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-x86_64.cfg
@@ -3,5 +3,6 @@ include('templates/centos-stream-9.tpl')
 include('templates/epel-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-9-x86_64'
+config_opts['description'] = 'CentOS Stream 9 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-aarch64.cfg
@@ -5,5 +5,6 @@ include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-8-aarch64'
+config_opts['description'] = 'CentOS Stream 8 + EPEL Next'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
@@ -5,5 +5,6 @@ include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-8-ppc64le'
+config_opts['description'] = 'CentOS Stream 8 + EPEL Next'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-x86_64.cfg
@@ -5,5 +5,6 @@ include('templates/epel-8.tpl')
 include('templates/epel-next-8.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-8-x86_64'
+config_opts['description'] = 'CentOS Stream 8 + EPEL Next'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-9-aarch64.cfg
@@ -4,5 +4,6 @@ include('templates/epel-9.tpl')
 include('templates/epel-next-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-9-aarch64'
+config_opts['description'] = 'CentOS Stream 9 + EPEL Next'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-9-ppc64le.cfg
@@ -4,5 +4,6 @@ include('templates/epel-9.tpl')
 include('templates/epel-next-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-9-ppc64le'
+config_opts['description'] = 'CentOS Stream 9 + EPEL Next'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-9-s390x.cfg
@@ -4,5 +4,6 @@ include('templates/epel-9.tpl')
 include('templates/epel-next-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-9-s390x'
+config_opts['description'] = 'CentOS Stream 9 + EPEL Next'
 config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-9-x86_64.cfg
@@ -4,5 +4,6 @@ include('templates/epel-9.tpl')
 include('templates/epel-next-9.tpl')
 
 config_opts['root'] = 'centos-stream+epel-next-9-x86_64'
+config_opts['description'] = 'CentOS Stream 9 + EPEL Next'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-8-aarch64.cfg
@@ -1,5 +1,6 @@
 include('templates/centos-stream-8.tpl')
 
 config_opts['root'] = 'centos-stream-8-aarch64'
+config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-8-ppc64le.cfg
@@ -1,5 +1,6 @@
 include('templates/centos-stream-8.tpl')
 
 config_opts['root'] = 'centos-stream-8-ppc64le'
+config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-8-x86_64.cfg
@@ -1,5 +1,6 @@
 include('templates/centos-stream-8.tpl')
 
 config_opts['root'] = 'centos-stream-8-x86_64'
+config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/fedora-eln-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-eln-aarch64.cfg
@@ -2,3 +2,4 @@ config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)
 
 include('templates/fedora-eln.tpl')
+config_opts['description'] = 'Fedora ELN'

--- a/mock-core-configs/etc/mock/fedora-eln-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-eln-i386.cfg
@@ -2,3 +2,4 @@ config_opts['target_arch'] = 'i686'
 config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
 
 include('templates/fedora-eln.tpl')
+config_opts['description'] = 'Fedora ELN'

--- a/mock-core-configs/etc/mock/fedora-eln-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-eln-ppc64le.cfg
@@ -2,3 +2,4 @@ config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
 
 include('templates/fedora-eln.tpl')
+config_opts['description'] = 'Fedora ELN'

--- a/mock-core-configs/etc/mock/fedora-eln-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-eln-s390x.cfg
@@ -2,3 +2,4 @@ config_opts['target_arch'] = 's390x'
 config_opts['legal_host_arches'] = ('s390x',)
 
 include('templates/fedora-eln.tpl')
+config_opts['description'] = 'Fedora ELN'

--- a/mock-core-configs/etc/mock/fedora-eln-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-eln-x86_64.cfg
@@ -2,3 +2,4 @@ config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
 
 include('templates/fedora-eln.tpl')
+config_opts['description'] = 'Fedora ELN'

--- a/mock-core-configs/etc/mock/opensuse-leap-15.2-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.2-aarch64.cfg
@@ -9,6 +9,7 @@ config_opts['releasever'] = '15.2'
 config_opts['macros']['%dist'] = '.suse.lp152'
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
+config_opts['description'] = 'openSUSE Leap {{ releasever }}'
 
 # Due to the nature of the OpenSUSE mirroring system, we can not use
 # metalinks easily and also we can not rely on the fact that baseurl's

--- a/mock-core-configs/etc/mock/opensuse-leap-15.2-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-15.2-x86_64.cfg
@@ -9,6 +9,7 @@ config_opts['releasever'] = '15.2'
 config_opts['macros']['%dist'] = '.suse.lp152'
 config_opts['package_manager'] = 'dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
+config_opts['description'] = 'openSUSE Leap {{ releasever }}'
 
 # Due to the nature of the OpenSUSE mirroring system, we can not use
 # metalinks easily and also we can not rely on the fact that baseurl's

--- a/mock-core-configs/etc/mock/oraclelinux+epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-7-aarch64.cfg
@@ -4,3 +4,4 @@ include('templates/epel-7.tpl')
 config_opts['root'] = 'oraclelinux+epel-7-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['description'] = 'Oracle Linux 7 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux+epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-7-x86_64.cfg
@@ -4,3 +4,4 @@ include('templates/epel-7.tpl')
 config_opts['root'] = 'oraclelinux+epel-7-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['description'] = 'Oracle Linux 7 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-8-aarch64.cfg
@@ -4,3 +4,4 @@ include('templates/epel-8.tpl')
 config_opts['root'] = 'oraclelinux+epel-8-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['description'] = 'Oracle Linux 8 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-8-x86_64.cfg
@@ -4,3 +4,4 @@ include('templates/epel-8.tpl')
 config_opts['root'] = 'oraclelinux+epel-8-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['description'] = 'Oracle Linux 8 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-8-aarch64.cfg
@@ -2,3 +2,4 @@ include('rhel-8-aarch64.cfg')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhel+epel-8-{{ target_arch }}"
+config_opts['description'] = 'RHEL 8 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-8-ppc64le.cfg
@@ -2,3 +2,4 @@ include('rhel-8-ppc64le.cfg')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhel+epel-8-{{ target_arch }}"
+config_opts['description'] = 'RHEL 8 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-8-s390x.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-8-s390x.cfg
@@ -2,3 +2,4 @@ include('rhel-8-s390x.cfg')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhel+epel-8-{{ target_arch }}"
+config_opts['description'] = 'RHEL 8 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-8-x86_64.cfg
@@ -2,3 +2,4 @@ include('rhel-8-x86_64.cfg')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = "rhel+epel-8-{{ target_arch }}"
+config_opts['description'] = 'RHEL 8 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-8-aarch64.cfg
@@ -2,5 +2,6 @@ include('templates/rocky-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'rocky+epel-8-aarch64'
+config_opts['description'] = 'Rocky Linux 8 + EPEL'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rocky+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-8-x86_64.cfg
@@ -2,5 +2,6 @@ include('templates/rocky-8.tpl')
 include('templates/epel-8.tpl')
 
 config_opts['root'] = 'rocky+epel-8-x86_64'
+config_opts['description'] = 'Rocky Linux 8 + EPEL'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
+++ b/mock-core-configs/etc/mock/templates/amazonlinux-2.tpl
@@ -3,6 +3,7 @@ config_opts['dist'] = 'amzn2' # only useful for --resultdir variable subst
 config_opts['plugin_conf']['ccache_enable'] = False
 config_opts['package_manager'] = 'yum'
 config_opts['releasever'] = '2'
+config_opts['description'] = 'Amazon Linux 2'
 
 config_opts['bootstrap_image'] = 'docker.io/library/amazonlinux:2'
 

--- a/mock-core-configs/etc/mock/templates/centos-7.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-7.tpl
@@ -6,6 +6,7 @@ config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:7'
 config_opts['package_manager'] = 'yum'
+config_opts['description'] = 'CentOS 7'
 
 config_opts['yum_install_command'] += "{% if target_arch in ['x86_64', 'ppc64le', 'aarch64'] %} --disablerepo=centos-sclo*{% endif %}"
 

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -3,6 +3,7 @@ config_opts['dist'] = 'el9'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['description'] = 'CentOS Stream 9'
 
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9'
 

--- a/mock-core-configs/etc/mock/templates/custom-1.tpl
+++ b/mock-core-configs/etc/mock/templates/custom-1.tpl
@@ -4,6 +4,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['package_manager'] = 'dnf'
 config_opts['module_enable'] = []
 config_opts['module_install'] = []
+config_opts['description'] = 'Custom (no repository)'
 # DNF may not be available in this chroot
 config_opts['use_bootstrap'] = False
 

--- a/mock-core-configs/etc/mock/templates/eurolinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/eurolinux-8.tpl
@@ -6,7 +6,7 @@ config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-
+config_opts['description'] = 'EuroLinux 8'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-branched.tpl
@@ -2,6 +2,7 @@ config_opts['root'] = 'fedora-{{ releasever }}-{{ target_arch }}'
 # config_opts['module_enable'] = ['list', 'of', 'modules']
 # config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
+config_opts['description'] = 'Fedora {{ releasever }}'
 # fedora 31+ isn't mirrored, we need to run from koji
 config_opts['mirrored'] = config_opts['target_arch'] != 'i686'
 

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -12,6 +12,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '37'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
+config_opts['description'] = 'Fedora Rawhide'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/mageia-7.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-7.tpl
@@ -6,6 +6,7 @@ config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'docker.io/library/mageia:7'
+config_opts['description'] = 'Mageia 7'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/mageia-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-branched.tpl
@@ -6,6 +6,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'docker.io/library/mageia:{{ releasever }}'
+config_opts['description'] = 'Mageia {{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/mageia-cauldron.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-cauldron.tpl
@@ -7,6 +7,7 @@ config_opts['releasever'] = '9'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'mageia:cauldron'
+config_opts['description'] = 'Mageia Cauldron'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/navy-8.tpl
+++ b/mock-core-configs/etc/mock/templates/navy-8.tpl
@@ -3,6 +3,7 @@ config_opts['dist'] = 'el8'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['description'] = 'Navy Linux {{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/openmandriva-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/openmandriva-branched.tpl
@@ -4,6 +4,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgid}} -d {{chroothome}} {{chrootuser}}'
 config_opts['macros']['%cross_compiling'] = '0' # Mock should generally be considered native builds
 config_opts['package_manager'] = 'dnf'
+config_opts['description'] = 'OpenMandriva {{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/openmandriva-cooker.tpl
+++ b/mock-core-configs/etc/mock/templates/openmandriva-cooker.tpl
@@ -5,6 +5,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '5.0'
 config_opts['macros']['%cross_compiling'] = '0' # Mock should generally be considered native builds
 config_opts['package_manager'] = 'dnf'
+config_opts['description'] = 'OpenMandriva Cooker {{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/openmandriva-rolling.tpl
+++ b/mock-core-configs/etc/mock/templates/openmandriva-rolling.tpl
@@ -5,6 +5,7 @@ config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgi
 config_opts['releasever'] = '5.0'
 config_opts['macros']['%cross_compiling'] = '0' # Mock should generally be considered native builds
 config_opts['package_manager'] = 'dnf'
+config_opts['description'] = 'OpenMandriva Rolling'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
@@ -7,6 +7,7 @@ config_opts['macros']['%dist'] = '.suse.lp153'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'registry.opensuse.org/opensuse/leap-dnf:15.3'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
+config_opts['description'] = 'openSUSE Leap {{ releasever }}'
 
 # Due to the nature of the OpenSUSE mirroring system, we can not use
 # metalinks easily and also we can not rely on the fact that baseurl's

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -7,6 +7,7 @@ config_opts['macros']['%dist'] = '.suse.tw%(sh -c ". /etc/os-release; echo \$VER
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'registry.opensuse.org/opensuse/tumbleweed-dnf'
 config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
+config_opts['description'] = 'openSUSE Tumbleweed'
 
 # Due to the nature of the OpenSUSE mirroring system, we can not use
 # metalinks easily and also we can not rely on the fact that baseurl's

--- a/mock-core-configs/etc/mock/templates/oraclelinux-7.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-7.tpl
@@ -6,6 +6,7 @@ config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
 config_opts['bootstrap_image'] = 'docker.io/library/oraclelinux:7'
 config_opts['package_manager'] = 'yum'
+config_opts['description'] = 'Oracle Linux 7'
 
 config_opts['yum_install_command'] += " --disablerepo=ol7_software_collections"
 

--- a/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
@@ -4,7 +4,7 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'docker.io/library/oraclelinux:8'
-
+config_opts['description'] = 'Oracle Linux 8'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rhel-7.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-7.tpl
@@ -3,6 +3,7 @@ config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7Server'
 config_opts['package_manager'] = 'yum'
 config_opts['bootstrap_image'] = 'registry.access.redhat.com/ubi7/ubi'
+config_opts['description'] = 'RHEL 7'
 
 config_opts['dnf_install_command'] += ' subscription-manager'
 config_opts['yum_install_command'] += ' subscription-manager'

--- a/mock-core-configs/etc/mock/templates/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-8.tpl
@@ -4,6 +4,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'registry.access.redhat.com/ubi8/ubi'
+config_opts['description'] = 'RHEL 8'
 
 config_opts['dnf_install_command'] += ' subscription-manager'
 config_opts['yum_install_command'] += ' subscription-manager'

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -4,7 +4,7 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:8'
-
+config_opts['description'] = 'Rocky Linux 8'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -137,6 +137,9 @@ Do a yum install PACKAGE inside the chroot. No 'clean' is performed.
 \fB\-\-installdeps\fP
 Find out deps for SRPM or RPM, and do a yum install to put them in the chroot. No 'clean' is performed
 .TP
+\fB\-\-list-chroots\fP
+List all available chroots names and their description - both system-wide and user ones.
+.TP
 \fB\-l\fR, \fB\-\-list\-snapshots\fP
 List all existing snapshots of the chroot belonging to the current configuration.
 Current base snapshot is marked with an asterisk (\fB*\fR)

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -165,6 +165,9 @@ def command_parse():
     parser.add_option("-i", "--install", action="store_const", const="install",
                       dest="mode",
                       help="install packages using package manager")
+    parser.add_option("--list-chroots", action="store_const", const="listchroots",
+                      dest="mode",
+                      help="List all chroot's configs")
     parser.add_option("--update", action="store_const", const="update",
                       dest="mode",
                       help="update installed packages using package manager")
@@ -586,6 +589,12 @@ def do_debugconfig(config_opts, uidManager, expand=False):
             print("config_opts['{}'] = {}".format(key, pformat(value)))
     config_opts['__jinja_expand'] = jinja_expand
 
+
+@traceLog()
+def do_listchroots(config_opts, uidManager):
+    config.list_configs(config_opts, uidManager, __VERSION__, PKGPYTHONDIR)
+
+
 @traceLog()
 def rootcheck():
     "verify mock was started correctly (either by sudo or consolehelper)"
@@ -964,6 +973,9 @@ def run_command(options, args, config_opts, commands, buildroot, state):
 
     elif options.mode == 'debugconfigexpand':
         do_debugconfig(config_opts, buildroot.uid_manager, True)
+
+    elif options.mode == 'listchroots':
+        do_listchroots(config_opts, buildroot.uid_manager)
 
     elif options.mode == 'orphanskill':
         util.orphansKill(buildroot.make_chroot_path())


### PR DESCRIPTION
This prints list of chroots available on system. Including users ones.
If the chroot has ["description"] then it is printed beside the chroot
name.

Notes:
- I clear atexit functions during parsing config. Otherwise during
  sys.exit() in the fork the exit function in syslinux plugin is called
  (and it prints error)
- I temporary disable logging before parsing the configs. Otherwise it
  prints "INFO: reading config ..." before reading the config, which
  would clutter the output.

And I still have to edit man page and bash completation.