### PR TITLE
config: add epel-9 chroot alias

### DIFF
--- a/mock-core-configs/etc/mock/chroot-aliases.cfg
+++ b/mock-core-configs/etc/mock/chroot-aliases.cfg
@@ -36,3 +36,14 @@ config_opts["no-config"]["epel-8"]["alternatives"] = {
         ],
     },
 }
+
+config_opts["no-config"]["epel-9"] = {}
+config_opts["no-config"]["epel-9"]["alternatives"] = {
+    "centos-stream+epel-9": {
+        "description": [
+            "Builds against CentOS Stream 9 repositories together "
+            "with the official EPEL 9 repositories.",
+            "Project page: https://www.centos.org/centos-stream/"
+        ],
+    },
+}


### PR DESCRIPTION
This is needed for the 'fedpkg mockbuild' inside 'epel9' branch (this
defaults to the 'mock -r epel-9-*' command.

Currently there's only CentOS Stream 9 + EPEL config for the 'epel-9'
variant.