### PR TITLE
Add AlmaLinux and Alma+EPEL 8 configs for POWER (ppc64le)

### DIFF
--- a/mock-core-configs/etc/mock/alma+epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-8-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-8.tpl')
+include('templates/epel-8.tpl')
+
+config_opts['root'] = 'alma+epel-8-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/almalinux-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/almalinux-8-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('templates/almalinux-8.tpl')
+
+config_opts['root'] = 'almalinux-8-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)


### PR DESCRIPTION
AlmaLinux now offers AlmaLinux 8 for POWER systems: https://almalinux.org/blog/almalinux-for-powerpc-85-stable-now-available/