### PR TITLE
config: Update CentOS Stream 9 Extras repo to use correct key

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -98,7 +98,7 @@ enabled=0
 name=CentOS Stream $releasever - Extras packages
 #baseurl=http://mirror.stream.centos.org/SIGs/$releasever-stream/extras/$basearch/extras-common/
 metalink=https://mirrors.centos.org/metalink?repo=centos-extras-sig-extras-common-$releasever-stream&arch=$basearch
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Extras
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
 gpgcheck=1
 enabled=1
 skip_if_unavailable=False

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -18,7 +18,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.64
+Requires:   distribution-gpg-keys >= 1.66
 # specify minimal compatible version of mock
 Requires:   mock >= 2.5
 Requires:   mock-filesystem


### PR DESCRIPTION
The key was regenerated to drop the SHA1 algorithm.

Requires: https://github.com/xsuchy/distribution-gpg-keys/pull/59

See: https://bugzilla.redhat.com/show_bug.cgi?id=2059424