### PR TITLE
move setup_uid_manager to mockbuild.uid module 

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -129,8 +129,8 @@ for file in py/mock.py py/mock-parse-buildlog.py; do
 done
 
 %build
-for i in py/mock.py py/mock-parse-buildlog.py; do
-    perl -p -i -e 's|^__VERSION__\s*=.*|__VERSION__="%{version}"|' $i
+for i in py/mockbuild/constants.py py/mock-parse-buildlog.py; do
+    perl -p -i -e 's|^VERSION\s*=.*|VERSION="%{version}"|' $i
     perl -p -i -e 's|^SYSCONFDIR\s*=.*|SYSCONFDIR="%{_sysconfdir}"|' $i
     perl -p -i -e 's|^PYTHONDIR\s*=.*|PYTHONDIR="%{python_sitelib}"|' $i
     perl -p -i -e 's|^PKGPYTHONDIR\s*=.*|PKGPYTHONDIR="%{python_sitelib}/mockbuild"|' $i

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -649,8 +649,7 @@ def main():
     #   setuid wrapper has real uid = unpriv,  effective uid = 0
     #   sudo sets real/effective = 0, and sets env vars
     #   setuid wrapper clears environment, so there wont be any conflict between these two
-    mockgid = grp.getgrnam('mock').gr_gid
-    uidManager = mockbuild.uid.setup_uid_manager(mockgid)
+    uidManager = mockbuild.uid.setup_uid_manager()
 
     # go unpriv only when root to make --help etc work for non-mock users
     if os.geteuid() == 0:
@@ -673,10 +672,7 @@ def main():
     util.subscription_redhat_init(config_opts)
 
     # allow a different mock group to be specified
-    if config_opts['chrootgid'] != mockgid:
-        uidManager.restorePrivs()
-        os.setgroups((mockgid, config_opts['chrootgid']))
-        uidManager.dropPrivsTemp()
+    uidManager.fix_different_chrootgid(config_opts)
 
     # verify that our unprivileged uid is in the mock group
     groupcheck(uidManager.unprivGid, config_opts['chrootgid'])

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -63,16 +63,9 @@ import copy
 from functools import partial
 from mockbuild import config
 from mockbuild import util
+from mockbuild.constants import MOCKCONFDIR, PKGPYTHONDIR, PYTHONDIR, SYSCONFDIR, VERSION
 from mockbuild.file_downloader import FileDownloader
 from mockbuild.mounts import BindMountPoint, FileSystemMountPoint
-
-# all of the variables below are substituted by the build system
-__VERSION__ = "unreleased_version"
-SYSCONFDIR = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "..", "etc")
-PYTHONDIR = os.path.dirname(os.path.realpath(sys.argv[0]))
-PKGPYTHONDIR = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "mockbuild")
-MOCKCONFDIR = os.path.join(SYSCONFDIR, "mock")
-# end build system subs
 
 # import all mockbuild.* modules after this.
 sys.path.insert(0, PYTHONDIR)
@@ -118,7 +111,7 @@ def command_parse():
     plugins = config.PLUGIN_LIST
     parser = argparse.ArgumentParser(usage=__doc__)
 
-    parser.add_argument('--version', action='version', version=__VERSION__)
+    parser.add_argument('--version', action='version', version=VERSION)
 
     # hack from optparse=>argparse migration time, use add_argument if possible
     parser.add_option = parser.add_argument
@@ -553,7 +546,7 @@ def check_arch_combination(target_arch, config_opts):
 @traceLog()
 def do_debugconfig(config_opts, uidManager, expand=False):
     jinja_expand = config_opts['__jinja_expand']
-    defaults = config.load_defaults(uidManager, __VERSION__, PKGPYTHONDIR)
+    defaults = config.load_defaults(uidManager, VERSION, PKGPYTHONDIR)
     defaults['__jinja_expand'] = expand
     config_opts['__jinja_expand'] = expand
     for key in sorted(config_opts):
@@ -569,7 +562,7 @@ def do_debugconfig(config_opts, uidManager, expand=False):
 
 @traceLog()
 def do_listchroots(config_opts, uidManager):
-    config.list_configs(config_opts, uidManager, __VERSION__, PKGPYTHONDIR)
+    config.list_configs(config_opts, uidManager, VERSION, PKGPYTHONDIR)
 
 
 @traceLog()
@@ -664,7 +657,7 @@ def main():
     if options.configdir:
         config_path = options.configdir
 
-    config_opts = config.load_config(config_path, options.chroot, uidManager, __VERSION__, PKGPYTHONDIR)
+    config_opts = config.load_config(config_path, options.chroot, uidManager, VERSION, PKGPYTHONDIR)
 
     # cmdline options override config options
     config.set_config_opts_per_cmdline(config_opts, options, args)
@@ -693,7 +686,7 @@ def main():
     # do whatever we're here to do
     py_version = '{0}.{1}.{2}'.format(*sys.version_info[:3])
     log.info("mock.py version %s starting (python version = %s%s)...",
-             __VERSION__, py_version,
+             VERSION, py_version,
              "" if not _MOCK_NVR else ", NVR = " + _MOCK_NVR)
     state = State()
     plugins = Plugins(config_opts, state)

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -22,16 +22,16 @@ import sys
 from templated_dictionary import TemplatedDictionary
 from . import exception
 from . import text
+from .constants import MOCKCONFDIR, PKGPYTHONDIR, VERSION
 from .file_util import is_in_dir
 from .trace_decorator import getLog, traceLog
-from .uid import getresuid
+from .uid import getresuid, setup_uid_manager
 from .util import set_use_nspawn, setup_operations_timeout
 
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
                'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor']
-
 
 def nspawn_supported():
     """Detect some situations where the systemd-nspawn chroot code won't work"""
@@ -780,6 +780,17 @@ def list_configs(config_opts, uidManager, version, pkg_python_dir):
         for config_filename in sorted(user_config_files):
             print_description(config_opts['config_path'], config_filename, uidManager, version, pkg_python_dir)
         log.disabled = False
+
+
+@traceLog()
+def simple_load_config(name, config_path=None, pkg_python_dir=None):
+    """ wrapper around load_config() intended by use 3rd party SW """
+    uidManager = setup_uid_manager()
+    if config_path is None:
+        config_path = MOCKCONFDIR
+    if pkg_python_dir is None:
+        pkg_python_dir = PKGPYTHONDIR
+    return load_config(config_path, name, uidManager, VERSION, pkg_python_dir)
 
 
 @traceLog()

--- a/mock/py/mockbuild/constants.py
+++ b/mock/py/mockbuild/constants.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+
+import os.path
+import sys
+
+# all of the variables below are substituted by the build system
+VERSION = "unreleased_version"
+SYSCONFDIR = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "..", "etc")
+PYTHONDIR = os.path.dirname(os.path.realpath(sys.argv[0]))
+PKGPYTHONDIR = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "mockbuild")
+MOCKCONFDIR = os.path.join(SYSCONFDIR, "mock")
+# end build system subs


### PR DESCRIPTION
Two commits:
 * one moves  setup_uid_manager() to mockbuild.uid module 
 * second simplifies it

The motivation is that fedora-review calls load_config without uidManager param
  https://pagure.io/FedoraReview/blob/master/f/src/FedoraReview/mock.py#_180
which fatally fails because recent changes require the uidManager there and it cannot be None.
When we merge this, I will prepare PR for fedora-review and we should synchronize release.