### PR TITLE
Provide 'epel-9' symlinks for 'fedpkg mockbuild'

### DIFF
--- a/mock-core-configs/etc/mock/epel-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-9-aarch64.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-9-aarch64.cfg

--- a/mock-core-configs/etc/mock/epel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-9-ppc64le.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-9-ppc64le.cfg

--- a/mock-core-configs/etc/mock/epel-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/epel-9-s390x.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-9-s390x.cfg

--- a/mock-core-configs/etc/mock/epel-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-9-x86_64.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-9-x86_64.cfg


### PR DESCRIPTION
Later this year, once there are other alternatives, we can get back to
the solution from #871.