### PR TITLE
config: Fix description typo on AlmaLinux 8 for x86_64

### DIFF
--- a/mock-core-configs/etc/mock/almalinux-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-8-x86_64.cfg
@@ -1,6 +1,6 @@
 include('templates/almalinux-8.tpl')
 
 config_opts['root'] = 'almalinux-8-x86_64'
-config_opts['description'] = 'AlmaLinux 8 + EPEL'
+config_opts['description'] = 'AlmaLinux 8'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)


### PR DESCRIPTION
EPEL is not included in the baseline AlmaLinux configuration.