### PR TITLE
config: Use MirrorCache instead of MirrorBrain to improve reliability

### DIFF
--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.3.tpl
@@ -50,8 +50,8 @@ user_agent={{ user_agent }}
 
 [opensuse-leap-oss]
 name=openSUSE Leap $releasever - {{ target_arch }} - OSS
-baseurl=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/
-#metalink=http://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+#metalink=https://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
         file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports
@@ -60,24 +60,24 @@ gpgcheck=1
 
 [opensuse-leap-oss-update]
 name=openSUSE Leap $releasever - {{ target_arch }} - OSS - Updates
-baseurl=http://download.opensuse.org/update/leap/$releasever/oss/
-#metalink=http://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/update/leap/$releasever/oss/
+#metalink=https://download.opensuse.org/update/leap/$releasever/oss/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1
 
 [opensuse-leap-sle-update]
 name=openSUSE Leap $releasever - {{ target_arch }} - Updates from SUSE Linux Enterprise
-baseurl=http://download.opensuse.org/update/leap/$releasever/sle/
-#metalink=http://download.opensuse.org/update/leap/$releasever/sle/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/update/leap/$releasever/sle/
+#metalink=https://download.opensuse.org/update/leap/$releasever/sle/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/suse/RPM-GPG-KEY-SuSE-SLE-15
 gpgcheck=1
 
 [opensuse-leap-sle-backports-update]
 name=openSUSE Leap $releasever - {{ target_arch }} - Updates from Backports for SUSE Linux Enterprise
-baseurl=http://download.opensuse.org/update/leap/$releasever/backports/
-#metalink=http://download.opensuse.org/update/leap/$releasever/backports/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/update/leap/$releasever/backports/
+#metalink=https://download.opensuse.org/update/leap/$releasever/backports/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports
 gpgcheck=1

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -49,17 +49,17 @@ user_agent={{ user_agent }}
 [opensuse-tumbleweed-oss]
 name=openSUSE Tumbleweed - {{ target_arch }} - OSS
 {% if target_arch in ['x86_64', 'i586'] %}
-baseurl=http://download.opensuse.org/tumbleweed/repo/oss/
-#metalink=http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/tumbleweed/repo/oss/
+#metalink=https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% elif target_arch in ['ppc64le', 'ppc64'] %}
-baseurl=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
-#metalink=http://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/
+#metalink=https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% elif target_arch in ['aarch64'] %}
-baseurl=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/
-#metalink=http://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/
+#metalink=https://download.opensuse.org/ports/aarch64/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% elif target_arch in ['s390x'] %}
-baseurl=http://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/
-#metalink=http://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/repodata/repomd.xml.metalink
+baseurl=https://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/
+#metalink=https://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/repodata/repomd.xml.metalink
 {% endif %}
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE
 gpgcheck=1


### PR DESCRIPTION
openSUSE has a new system called MirrorCache that offers an improved
mirror service experience for openSUSE users.