### PR TITLE
config: Fix dist value for openSUSE Leap 15.4

### DIFF
--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.4.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.4.tpl
@@ -1,5 +1,5 @@
 config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
-config_opts['dist'] = 'suse.lp153'  # only useful for --resultdir variable subst
+config_opts['dist'] = 'suse.lp154'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['useradd'] = '/usr/sbin/useradd -o -m -u {{chrootuid}} -g {{chrootgid}} -d {{chroothome}} {{chrootuser}}'
 config_opts['releasever'] = '15.4'


### PR DESCRIPTION
One small bit leftover from Leap 15.3 -> 15.4 adaptation

Fixes: 0d4dca7afdd63a575bbd4ec76ac0712d498542d4