### PR TITLE
[CR-910] Add documentation and examples of modularity enabled templates

### DIFF
--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -4,6 +4,8 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinux/almalinux:8'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/almalinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-9.tpl
@@ -4,6 +4,8 @@ config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinux/almalinux:9'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -7,6 +7,8 @@ config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream8'
 config_opts['dnf_vars'] = { 'stream': '8-stream',
                             'contentdir': 'centos',
                           }
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -6,6 +6,8 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'CentOS Stream 9'
 
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
@@ -5,6 +5,8 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'docker.io/library/oraclelinux:8'
 config_opts['description'] = 'Oracle Linux 8'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-8.tpl
@@ -12,6 +12,8 @@ config_opts['yum_install_command'] += ' subscription-manager'
 config_opts['root'] = 'rhel-8-{{ target_arch }}'
 
 config_opts['redhat_subscription_required'] = True
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rhel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-9.tpl
@@ -12,6 +12,8 @@ config_opts['yum_install_command'] += ' subscription-manager'
 config_opts['root'] = 'rhel-{{ releasever }}-{{ target_arch }}'
 
 config_opts['redhat_subscription_required'] = True
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -5,6 +5,8 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:8'
 config_opts['description'] = 'Rocky Linux 8'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]


### PR DESCRIPTION
See change request 910. Specific modularity channels need to be enabled for specific software bulds. Improve the documentation to reflect the availability of modularity for RHEL, and provide configuration examples in relevant templates.