### PR TITLE
[CR-910] Update Fedora-modularity.md with new modularity commands

### DIFF
--- a/docs/Feature-modularity.md
+++ b/docs/Feature-modularity.md
@@ -4,15 +4,38 @@ title: Feature modularity support
 ---
 ## Modularity support
 
-* There is a support for Fedora Modularity. You can add to config:
+There is support for Fedora and RHEL Modularity. This requires `dnf`, not merely
+`yum`. It is available for RHEL >= 8 and its clones, and built into
+all supported releases of Fedora. 
+
+The new modularity format was added with release 2.4 and uses
+`module_setup_commands`. Each command can be specified multiple times,
+and mock respects the order of the commands when executing them.
+
+* Artificial example:
+   * Disable any potentially enabled postgresql module stream.
+   * Enable _specific_ postgresql and ruby module streams.
+   * Install the development nodejs profile and (4) disable it immediately.
+
+```
+config_opts['module_setup_commands'] = [
+    ('disable', 'postgresql'),
+    ('enable',  'postgresql:12, ruby:2.6'),
+    ('install', 'nodejs:13/development'),
+    ('disable', 'nodejs'),
+    ]
+```
+
+The obsolete, less flexible, but still available  modularity syntax was added in Mock 1.4.2.
 
 ```
 config_opts['module_enable'] = ['list', 'of', 'modules']
 config_opts['module_install'] = ['module1/profile', 'module2/profile']
 ```
 
-This will call `dnf module enable list of modules` and `dnf module install module1/profile module2/profile` during the init phase. If you want to use this feature you have to have DNF which support modularity (Fedora 28+).
+This would call these steps during the init phase.
+* `dnf module enable list of modules`
+* `dnf module install module1/profile module2/profile`
 
-You can find more in this comprehensive blogpost - [Modularity Features in Mock](http://frostyx.cz/posts/modularity-features-in-mock).
-
-This has been added in Mock 1.4.2.
+You can find more about this obsolete format in this comprehensive blogpost.
+* [Modularity Features in Mock](http://frostyx.cz/posts/modularity-features-in-mock).


### PR DESCRIPTION
The new `module_setup_commands` was documented only in the release notes. Feature-modularity.md is a better place to document the option, especially while deprecating the obsolete option.