### PR TITLE
Stop using the gtar symlink, use just tar

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -164,9 +164,16 @@
 # config_opts['createrepo_on_rpms'] = False
 # config_opts['createrepo_command'] = '/usr/bin/createrepo_c -d -q -x *.src.rpm'
 
-# You can configure which tar is used (for root cache and SCM plugin)
-# valid options are: "gnutar" or "bsdtar"
-# config_opts['tar'] = "gnutar"
+
+# What tar binary should be used by Mock.
+#config_opts['tar_binary'] = "/bin/tar"
+
+# You can configure what is the tar implementation stored on the
+# config_opts['tar_binary'] path.  Depending on this, Mock will use a different
+# set of command-line options for tar commands.  Valid options are "gnutar" or
+# "bsdtar" (used by root cache and SCM plugin, but also by core Mock for
+# unpacking Podman container file-systems with --use-bootstrap-image option).
+#config_opts['tar'] = "gnutar"
 
 # if you want mock to backup the contents of a result dir before clean
 # config_opts['backup_on_clean'] = False

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -179,12 +179,8 @@ class Buildroot(object):
             podman = Podman(self, self.bootstrap_image)
             podman.pull_image()
             podman.get_container_id()
-            if self.config["tar"] == "bsdtar":
-                __tar_cmd = "bsdtar"
-            else:
-                __tar_cmd = "gtar"
             podman.install_pkgmgmt_packages()
-            podman.cp(self.make_chroot_path(), __tar_cmd)
+            podman.cp(self.make_chroot_path(), self.config["tar_binary"])
             podman.remove()
 
         self._setup_dirs()

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -99,6 +99,7 @@ def setup_default_config_opts(unprivUid):
     config_opts['createrepo_on_rpms'] = False
     config_opts['createrepo_command'] = '/usr/bin/createrepo_c -d -q -x *.src.rpm'  # default command
 
+    config_opts['tar_binary'] = "/bin/tar"
     config_opts['tar'] = "gnutar"
 
     config_opts['backup_on_clean'] = False

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -134,7 +134,6 @@ def setup_default_config_opts(unprivUid):
             'age_check': True,
             'max_age_days': 15,
             'dir': "{{cache_topdir}}/{{root}}/root_cache/",
-            'tar': "gnutar",
             'compress_program': 'pigz',
             'decompress_program': None,
             'exclude_dirs': ["./proc", "./sys", "./dev", "./tmp/ccache", "./var/cache/yum", "./var/cache/dnf",

--- a/mock/py/mockbuild/plugins/root_cache.py
+++ b/mock/py/mockbuild/plugins/root_cache.py
@@ -39,8 +39,16 @@ class RootCache(object):
         if self.compressProgram == 'pigz' and not os.path.exists('/bin/pigz'):
             getLog().warning("specified 'pigz' as the root cache compress program but not available; using gzip")
             self.compressProgram = 'gzip'
-        # bsdtar use different decompress program
-        self.decompressProgram = self.root_cache_opts['decompress_program'] or self.compressProgram
+
+        self.decompressProgram = self.root_cache_opts.get('decompress_program')
+        if not self.decompressProgram:
+            if self.config['tar'] == 'bsdtar':
+                # Contrary to GNU tar, BSD tar doesn't automatically add the "-d"
+                # option to the compressing utility while decompressing.
+                self.decompressProgram = "{0} {1}".format(self.compressProgram, "-d")
+            else:
+                self.decompressProgram = self.compressProgram
+
         if self.compressProgram:
             self.compressArgs = ['--use-compress-program', self.compressProgram]
             self.rootCacheFile = self.rootCacheFile + self.root_cache_opts['extension']

--- a/mock/py/mockbuild/scm.py
+++ b/mock/py/mockbuild/scm.py
@@ -179,13 +179,11 @@ class scmWorker(object):
                 tarball = tardir + ".tar.gz"
             taropts = ""
 
-            if self.config["tar"] == "bsdtar":
-                __tar_cmd = "bsdtar"
-            else:
-                __tar_cmd = "gtar"
+            __tar_cmd = self.config["tar_binary"]
+
             # Always exclude vcs data from tarball unless told not to
-            if str(self.exclude_vcs).lower() == "true" and __tar_cmd == 'gtar':
-                proc = subprocess.Popen(['tar', '--help'], shell=False, stdout=subprocess.PIPE)
+            if str(self.exclude_vcs).lower() == "true" and self.config['tar'] == "gnutar":
+                proc = subprocess.Popen([__tar_cmd, '--help'], shell=False, stdout=subprocess.PIPE)
                 proc_result = proc.communicate()[0]
                 proc_result = proc_result.decode()
                 if "--exclude-vcs" in proc_result:


### PR DESCRIPTION
On GNU/Linux distributions, tar is just synonym for GNU tar.  At least
we currently don't know of any distribution that would break this rull.

Relates: #925