### PR TITLE
Add Rocky Linux 9 Configuration and Modify Rocky Linux 8

### DIFF
--- a/mock-core-configs/etc/mock/chroot-aliases.cfg
+++ b/mock-core-configs/etc/mock/chroot-aliases.cfg
@@ -70,4 +70,11 @@ config_opts["no-config"]["epel-9"]["alternatives"] = {
             "https://rpm-software-management.github.io/mock/Feature-rhelchroots"
         ],
     },
+    "rocky+epel-9": {
+        "description": [
+            "Builds against Rocky Linux 9 repositories, "
+            "together with the official EPEL repositories.",
+            "Project page: https://rockylinux.org/"
+        ],
+    },
 }

--- a/mock-core-configs/etc/mock/rocky+epel-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-9-aarch64.cfg
@@ -1,0 +1,5 @@
+include('rocky-9-aarch64.cfg')
+include('templates/epel-9.tpl')
+
+config_opts['root'] = "rocky+epel-9-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 9 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-9-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('rocky-9-ppc64le.cfg')
+include('templates/epel-9.tpl')
+
+config_opts['root'] = "rocky+epel-9-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 9 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-9-s390x.cfg
@@ -1,0 +1,5 @@
+include('rocky-9-s390x.cfg')
+include('templates/epel-9.tpl')
+
+config_opts['root'] = "rocky+epel-9-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 9 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-9-x86_64.cfg
@@ -1,0 +1,5 @@
+include('rocky-9-x86_64.cfg')
+include('templates/epel-9.tpl')
+
+config_opts['root'] = "rocky+epel-9-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 9 + EPEL'

--- a/mock-core-configs/etc/mock/rocky-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky-9-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-9.tpl')
+
+config_opts['root'] = 'rocky-9-aarch64'
+config_opts['description'] = 'Rocky Linux 9'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rocky-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rocky-9-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-9.tpl')
+
+config_opts['root'] = 'rocky-9-ppc64le'
+config_opts['description'] = 'Rocky Linux 9'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rocky-9-s390x.cfg
+++ b/mock-core-configs/etc/mock/rocky-9-s390x.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-9.tpl')
+
+config_opts['root'] = 'rocky-9-s390x'
+config_opts['description'] = 'Rocky Linux 9'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/rocky-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky-9-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-9.tpl')
+
+config_opts['root'] = 'rocky-9-x86_64'
+config_opts['description'] = 'Rocky Linux 9'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -33,7 +33,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [appstream]
 name=Rocky Linux $releasever - AppStream
@@ -41,7 +41,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStre
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [powertools]
 name=Rocky Linux $releasever - PowerTools
@@ -49,7 +49,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTo
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [extras]
 name=Rocky Linux $releasever - Extras
@@ -57,7 +57,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/os/
 gpgcheck=1
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [ha]
 name=Rocky Linux $releasever - HighAvailability
@@ -65,7 +65,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAva
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [resilient-storage]
 name=Rocky Linux $releasever - ResilientStorage
@@ -73,7 +73,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Resilie
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [plus]
 name=Rocky Linux $releasever - Plus
@@ -81,7 +81,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=rockypl
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/plus/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [devel]
 name=Rocky Linux $releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
@@ -89,7 +89,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 # Debuginfo
 [baseos-debug]
@@ -98,7 +98,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [appstream-debug]
 name=Rocky Linux $releasever - AppStream - Debuginfo
@@ -106,7 +106,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStre
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [ha-debug]
 name=Rocky Linux $releasever - High Availability - Debuginfo
@@ -114,7 +114,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAva
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/$basearch/debug/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [powertools-debug]
 name=Rocky Linux $releasever - PowerTools - Debuginfo
@@ -122,7 +122,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTo
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/$basearch/debug/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [resilient-storage-debug]
 name=Rocky Linux $releasever - Resilient Storage - Debuginfo
@@ -130,7 +130,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Resilie
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/$basearch/debug/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [devel-debug]
 name=Rocky Linux $releasever - Devel - Debuginfo
@@ -138,7 +138,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=Devel-$
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/$basearch/debug/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 # Source Repos
 [baseos-source]
@@ -147,7 +147,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=BaseOS-$re
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/source/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [appstream-source]
 name=Rocky Linux $releasever - AppStream - Source
@@ -155,7 +155,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=AppStream-
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/source/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [ha-source]
 name=Rocky Linux $releasever - High Availability - Source
@@ -163,7 +163,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=HighAvaila
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/HighAvailability/source/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [powertools-source]
 name=Rocky Linux $releasever - PowerTools - Source
@@ -171,7 +171,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=PowerTools
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/PowerTools/source/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [resilient-storage-source]
 name=Rocky Linux $releasever - Resilient Storage - Source
@@ -179,7 +179,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=ResilientS
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/ResilientStorage/source/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 [devel-source]
 name=Rocky Linux $releasever - Devel - Source
@@ -187,7 +187,7 @@ mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=Devel-$rel
 #baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/Devel/source/tree
 gpgcheck=1
 enabled=0
-gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-rockyofficial
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
 
 """

--- a/mock-core-configs/etc/mock/templates/rocky-9.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-9.tpl
@@ -1,0 +1,255 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils redhat-release findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
+config_opts['dist'] = 'el9'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '9'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:9'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el9
+user_agent={{ user_agent }}
+
+
+[baseos]
+name=Rocky Linux $releasever - BaseOS
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[appstream]
+name=Rocky Linux $releasever - AppStream
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[crb]
+name=Rocky Linux $releasever - CRB
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[extras]
+name=Rocky Linux $releasever - Extras
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[devel]
+name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT ONLY DO NOT LEAVE ENABLED
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=devel-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[highavailability]
+name=Rocky Linux $releasever - High Availability
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[resilientstorage]
+name=Rocky Linux $releasever - Resilient Storage
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[nfv]
+name=Rocky Linux $releasever - NFV
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=NFV-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/NFV/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[rt]
+name=Rocky Linux $releasever - Realtime
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/RT/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[baseos-debug]
+name=Rocky Linux $releasever - BaseOS - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[baseos-source]
+name=Rocky Linux $releasever - BaseOS - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=BaseOS-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[appstream-debug]
+name=Rocky Linux $releasever - AppStream - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[appstream-source]
+name=Rocky Linux $releasever - AppStream - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=AppStream-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[crb-debug]
+name=Rocky Linux $releasever - CRB - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[crb-source]
+name=Rocky Linux $releasever - CRB - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=CRB-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[extras-debug]
+name=Rocky Linux $releasever - Extras Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[extras-source]
+name=Rocky Linux $releasever - Extras Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[highavailability-debug]
+name=Rocky Linux $releasever - High Availability - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[highavailability-source]
+name=Rocky Linux $releasever - High Availability - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=HighAvailability-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[resilientstorage-debug]
+name=Rocky Linux $releasever - Resilient Storage - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[resilientstorage-source]
+name=Rocky Linux $releasever - Resilient Storage - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=ResilientStorage-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[nfv-debug]
+name=Rocky Linux $releasever - NFV Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/NFV/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[nfv-source]
+name=Rocky Linux $releasever - NFV Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/NFV/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[rt-debug]
+name=Rocky Linux $releasever - Realtime Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/RT/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+[rt-source]
+name=Rocky Linux $releasever - Realtime Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/RT/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
+
+
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -18,7 +18,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.72
+Requires:   distribution-gpg-keys >= 1.73
 # specify minimal compatible version of mock
 Requires:   mock >= 2.5
 Requires:   mock-filesystem


### PR DESCRIPTION
Hello. This PR does the following:

* Add Rocky Linux 9 configuration for all supported architectures
* Add Rocky Linux 9 as an alternative for EPEL 9 builds
* Refresh key name for Rocky Linux 8 for consistency

This PR depends on xsuchy/distribution-gpg-keys#67