### PR TITLE
podman.py: don't let podman warnings taint container id

### DIFF
--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -30,7 +30,7 @@ class Podman:
             seccomp_disable_opts = []
         cmd = ["podman", "run"] + seccomp_disable_opts + \
               ["--quiet", "-i", "--detach", self.image, "/bin/bash"]
-        container_id = util.do(cmd, returnOutput=True, env=self.buildroot.env)
+        container_id = util.do(cmd, returnOutput=True, returnStderr=False, env=self.buildroot.env)
         self.container_id = container_id.strip()
         return self.container_id
 


### PR DESCRIPTION
In nested podman containers, it's possible there are (harmless) warnings
printed by podman during the exec call [1]. These are getting caught by
Podman.get_container_id and tainting the container id generated. Add the
parameter returnStderr=False to the util.do call to mask these warnings
on stderr and stop them from tainting the container id.

[1]
...
Storing signatures
dfcd4643609a8042c3d7d53fd36110b7ce8b059b63cf984e1dc024be806f2686
Error: no container with name or ID "time=\"2022-08-08T09:40:15Z\"
level=warning msg=\"Ignoring global metacopy option, not supported with
booted kernel\"\ntime=\"2022-08-08T09:40:15Z\" level=warning
msg=\"Failed to add conmon to cgroupfs sandbox cgroup: error creating
cgroup path /libpod_parent/conmon: write
/sys/fs/cgroup/cgroup.subtree_control: device or resource
busy\"\n5b3cffe1482b6e1c76ed04c1b3a0d7d6e7e783966ba069333cd9832f4a79ec43"
found: no such container
ERROR: Command failed:
 # podman exec time="2022-08-08T09:40:15Z" level=warning msg="Ignoring
global metacopy option, not supported with booted kernel"
time="2022-08-08T09:40:15Z" level=warning msg="Failed to add conmon to
cgroupfs sandbox cgroup: error creating cgroup path
/libpod_parent/conmon: write /sys/fs/cgroup/cgroup.subtree_control:
device or resource busy"