### PR TITLE
Do not expose the EPEL Koji repo when we are on EPEL Next

### DIFF
--- a/mock-core-configs/etc/mock/templates/epel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-8.tpl
@@ -73,14 +73,12 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
-{% if koji_primary_repo != None and koji_primary_repo != "epel" %}
-[local-epel]
-{% else %}
+{% if koji_primary_repo == "epel" %}
 [local]
-{% endif %}
 name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-build/latest/$basearch/
 cost=2000
 enabled=0
 skip_if_unavailable=False
+{% endif %}
 """

--- a/mock-core-configs/etc/mock/templates/epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-9.tpl
@@ -49,14 +49,12 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
-{% if koji_primary_repo != None and koji_primary_repo != "epel" %}
-[local-epel]
-{% else %}
+{% if koji_primary_repo == "epel" %}
 [local]
-{% endif %}
 name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-build/latest/$basearch/
 cost=2000
 enabled=0
 skip_if_unavailable=False
+{% endif %}
 """

--- a/mock-core-configs/etc/mock/templates/epel-next-8.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-8.tpl
@@ -48,11 +48,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 skip_if_unavailable=False
 
-{% if koji_primary_repo != None and koji_primary_repo != "epel-next" %}
-[local-epel-next]
-{% else %}
 [local]
-{% endif %}
 name=Extra Packages for Enterprise Linux $releasever - Next - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel8-next-build/latest/$basearch/
 cost=2000

--- a/mock-core-configs/etc/mock/templates/epel-next-9.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-next-9.tpl
@@ -48,11 +48,7 @@ gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 skip_if_unavailable=False
 
-{% if koji_primary_repo != None and koji_primary_repo != "epel-next" %}
-[local-epel-next]
-{% else %}
 [local]
-{% endif %}
 name=Extra Packages for Enterprise Linux $releasever - Next - Koji Local - BUILDROOT ONLY!
 baseurl=https://kojipkgs.fedoraproject.org/repos/epel$releasever-next-build/latest/$basearch/
 cost=2000


### PR DESCRIPTION
The EPEL Next Koji repo inherits from the EPEL Koji repo.

The EPEL Koji repo has RHEL packages,
not CentOS Stream packages,
they give errors 403:

    $ mock -r centos-stream+epel-next-9-x86_64 --remove libgcrypt
    ...
    $ mock -r centos-stream+epel-next-9-x86_64 --enablerepo='local*' --install libgcrypt
    [MIRROR] libgcrypt-1.10.0-4.el9_0.x86_64.rpm: Status code: 403 for https://infrastructure.fedoraproject.org/repo/rhel/rhel9/x86_64/rhel-9-for-x86_64-baseos-rpms/Packages/l/libgcrypt-1.10.0-4.el9_0.x86_64.rpm (IP: ...)