### PR TITLE
Adding support Oracle Linux 9 in mock

### DIFF
--- a/mock-core-configs/etc/mock/oraclelinux+epel-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-9-aarch64.cfg
@@ -1,0 +1,7 @@
+include('templates/oraclelinux-9.tpl')
+include('templates/epel-9.tpl')
+
+config_opts['root'] = 'oraclelinux+epel-9-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['description'] = 'Oracle Linux 9 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux+epel-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-9-x86_64.cfg
@@ -1,0 +1,7 @@
+include('templates/oraclelinux-9.tpl')
+include('templates/epel-9.tpl')
+
+config_opts['root'] = 'oraclelinux+epel-9-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['description'] = 'Oracle Linux 9 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-9-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-9.tpl')
+
+config_opts['root'] = 'oraclelinux-9-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-9-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-9.tpl')
+
+config_opts['root'] = 'oraclelinux-9-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/oraclelinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-9.tpl
@@ -1,0 +1,68 @@
+config_opts['chroot_setup_cmd'] = 'install tar redhat-rpm-config redhat-release oraclelinux-release which xz sed make bzip2 gzip coreutils unzip shadow-utils diffutils cpio bash gawk rpm-build info patch util-linux findutils grep glibc-minimal-langpack'
+config_opts['dist'] = 'el9'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '9'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'container-registry.oracle.com/os/oraclelinux:9'
+config_opts['description'] = 'Oracle Linux 9'
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el9
+user_agent={{ user_agent }}
+
+# repos
+
+[ol9_baseos_latest]
+name=Oracle Linux 9 BaseOS Latest ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol9
+gpgcheck=1
+enabled=1
+
+[ol9_appstream]
+name=Oracle Linux 9 Application Stream ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol9
+gpgcheck=1
+enabled=1
+
+[ol9_codeready_builder]
+name=Oracle Linux 9 CodeReady Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/codeready/builder/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol9
+gpgcheck=1
+enabled=1
+
+[ol9_distro_builder]
+name=Oracle Linux 9 Distro Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/distro/builder/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol9
+gpgcheck=1
+enabled=0
+
+{% if target_arch in ['x86_64'] %}
+[ol9_UEKR7]
+name=Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol9
+gpgcheck=1
+enabled=0
+{% endif %}
+
+"""

--- a/mock-core-configs/etc/mock/templates/oraclelinux-epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-epel-9.tpl
@@ -1,0 +1,14 @@
+config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
+
+config_opts['dnf.conf'] += """
+
+# repos
+
+[ol9_epel]
+name=Oracle Linux 9 EPEL ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol9
+gpgcheck=1
+enabled=1
+
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -18,7 +18,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.76
+Requires:   distribution-gpg-keys >= 1.77
 # specify minimal compatible version of mock
 Requires:   mock >= 2.5
 Requires:   mock-filesystem


### PR DESCRIPTION
Hello.
I would like to suggest pull request for adding support Oracle Linux 9 in mock. 
Could be merged if https://github.com/xsuchy/distribution-gpg-keys/pull/72 will be completed without any issues :)
Should fix request https://github.com/rpm-software-management/mock/issues/962