### PR TITLE
Update to AlmaLinux Quay.io repo

### DIFF
--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el8.alma'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'quay.io/almalinux/almalinux:8'
+config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:8'
 
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/almalinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-9.tpl
@@ -3,7 +3,7 @@ config_opts['dist'] = 'el9.alma'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['bootstrap_image'] = 'quay.io/almalinux/almalinux:9'
+config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:9'
 
 
 config_opts['dnf.conf'] = """


### PR DESCRIPTION
A new organization named `almalinuxorg` created since `almalinux` admin account is locked-down and not able to create new branches for publishing

Signed-off-by: Bala Raman <srbala@gmail.com>