### PR TITLE
minimize fork()ing during config loading

### DIFF
--- a/mock/py/mockbuild/exception.py
+++ b/mock/py/mockbuild/exception.py
@@ -11,17 +11,20 @@
 
 
 class Error(Exception):
-    "base class for our errors."
-    def __init__(self, msg, status=None):
-        Exception.__init__(self)
-        self.msg = msg
-        self.resultcode = 1
-        if status is not None:
-            self.resultcode = status
+    resultcode = 1
+
+    def __init__(self, *args):
+        """
+        A base class for our errors.  The exit code can be specified as
+        self.resultcode.  If multiple ARGS are specified, the second one is
+        used as the resultcode.
+        """
+        super().__init__(*args)
+        if len(args) > 1:
+            self.resultcode = args[1]
 
     def __str__(self):
-        return self.msg
-
+        return str(self.args[0])
 
 # result/exit codes
 # 0 = yay!
@@ -103,86 +106,75 @@ def get_class_by_code(exit_code):
 
 class BuildError(Error):
     "rpmbuild failed."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 10
 
 
 class commandTimeoutExpired(Error):
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 11
 
 class RootError(Error):
     "failed to set up chroot"
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 20
 
 
 class LvmError(Error):
     "LVM manipulation failed."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 25
 
 
 class YumError(RootError):
     "yum failed."
-    def __init__(self, msg):
-        RootError.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 30
 
 
 class ExternalDepsError(RootError):
     "Unknown external dependency."
-    def __init__(self, msg):
-        RootError.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 31
 
 class PkgError(Error):
     "error with the srpm given to us."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 40
 
 
 class BuildRootLocked(Error):
     "build root in use by another process."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 60
 
 
 class LvmLocked(Error):
     "LVM thinpool is locked."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 65
 
 
 class BadCmdline(Error):
     "user gave bad/inconsistent command line."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 5
 
 
 class InvalidArchitecture(Error):
     "invalid host/target architecture specified."
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 6
 
 
@@ -193,34 +185,30 @@ Could not create output directory for built rpms. The directory specified was:
 
 Try using the --resultdir= option to select another location. Recommended location is --resultdir=~/mock/.
 """
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 70
 
 
 class UnshareFailed(Error):
     "call to C library unshare(2) syscall failed"
 
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 80
 
 
 class StateError(Error):
     "unbalanced call to state functions"
 
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 110
 
 
 class ConfigError(Error):
     "invalid configuration"
 
-    def __init__(self, msg):
-        Error.__init__(self, msg)
-        self.msg = msg
+    def __init__(self, *args):
+        super().__init__(*args)
         self.resultcode = 3

--- a/mock/tests/test_package_manager.py
+++ b/mock/tests/test_package_manager.py
@@ -7,7 +7,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from templated_dictionary import TemplatedDictionary
-from mockbuild.config import load_defaults
+from mockbuild.config import setup_default_config_opts
 from mockbuild.constants import PKGPYTHONDIR
 from mockbuild.buildroot import Buildroot
 from mockbuild.package_manager import _PackageManager, Dnf
@@ -23,7 +23,7 @@ class TestPackageManager:
         plugindir = os.path.realpath(plugindir)
         PKGPYTHONDIR = plugindir
 
-        self.config_opts = load_defaults(None)
+        self.config_opts = setup_default_config_opts()
         self.config_opts['root'] = 'distro-version-arch'
         self.config_opts['basedir'] = self.workdir
         self.config_opts["resultdir"] = "{{basedir}}/{{root}}/result"


### PR DESCRIPTION
This PR should eventually

- fix https://bugzilla.redhat.com/show_bug.cgi?id=2080735
- make the --list-configs much faster
- make the configuration easier to read
- make the configuration logic easier for security enhancement (see below)

I wish we could invent a new way of Mock configuration in the future, which doesn't require `exec()` call.  I'd suggest using `yaml` for this, and for the time being (one or two major releases) allow both variants).
