### PR TITLE
mock: stuff in /var/{lib,cache}/mock doesn't need SGID

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -237,7 +237,7 @@ pylint-3 py/mockbuild/ py/*.py py/mockbuild/plugins/* || :
 %{_datadir}/cheat/mock
 
 # cache & build dirs
-%defattr(0775, root, mock, 02775)
+%defattr(0775, root, mock, 0775)
 %dir %{_localstatedir}/cache/mock
 %dir %{_localstatedir}/lib/mock
 

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -164,7 +164,7 @@ class Buildroot(object):
         file_util.mkdirIfAbsent(self.basedir)
         mockgid = grp.getgrnam('mock').gr_gid
         os.chown(self.basedir, os.getuid(), mockgid)
-        os.chmod(self.basedir, 0o2775)
+        os.chmod(self.basedir, 0o775)
         file_util.mkdirIfAbsent(self.make_chroot_path())
         self.plugins.call_hooks('mount_root')
         # intentionally we do not call bootstrap hook here - it does not have sense


### PR DESCRIPTION
We should only need the g+rw permissions so mock can write to those directories.  But we shouldn't need to re-chown everything to 'mock' chroot.  I tried to search through the history, and haven't found a real need for this.  According my testing, everything continues working.

Relates: #977