### PR TITLE
mock: re-introduce Error.msg attribute

### DIFF
--- a/mock/py/mockbuild/exception.py
+++ b/mock/py/mockbuild/exception.py
@@ -20,11 +20,12 @@ class Error(Exception):
         used as the resultcode.
         """
         super().__init__(*args)
+        self.msg = args[0]
         if len(args) > 1:
             self.resultcode = args[1]
 
     def __str__(self):
-        return str(self.args[0])
+        return self.msg
 
 # result/exit codes
 # 0 = yay!


### PR DESCRIPTION
The exceptions are expected to have that attribute, see c6cfaa3be. Some of our code also relies on that attribute.

Complements: ca069b44ed5954c40fd504ce2adb95eabc9dd660