### PR TITLE
Add docker check for containers with cgroupv2 

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -602,6 +602,11 @@ def running_in_docker():
             items = line.split(':')
             if 'docker' in items[2]:
                 return True
+    # For containers with cgroupv2
+    with open('/proc/self/mountinfo') as f:
+        for line in f:
+            if '/docker/containers/' in line:
+                return True
     return False
 
 

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -603,7 +603,7 @@ def running_in_docker():
             if 'docker' in items[2]:
                 return True
     # For containers with cgroupv2
-    with open('/proc/self/mountinfo') as f:
+    with open('/proc/self/mountinfo', encoding='utf8') as f:
         for line in f:
             if '/docker/containers/' in line:
                 return True


### PR DESCRIPTION
For containers with cgroupv2 we get /proc/self/cgroup: 
```
[root@66826257e096 noarch]# cat /proc/self/cgroup
0::/
```
So adding a check for /proc/self/mountinfo:
```
root@66826257e096 noarch]# cat /proc/self/mountinfo
.....
/docker/containers/66826257e096f3c9d04f17577dab7ef5d84078c88f18f646fd37050ec5b6b4f6/resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/vda1 rw
505 496 254:1 /docker/containers/66826257e096f3c9d04f17577dab7ef5d84078c88f18f646fd37050ec5b6b4f6/hostname /etc/hostname rw,relatime - ext4 /dev/vda1 rw
506 496 254:1 /docker/containers/66826257e096f3c9d04f17577dab7ef5d84078c88f18f646fd37050ec5b6b4f6/hosts /etc/hosts rw,relatime - ext4 /dev/vda1 rw
......
```

![image](https://user-images.githubusercontent.com/4771917/195162462-6bb48728-b457-4651-9bf5-b3e887c3e735.png)
