### PR TITLE
log.info print Config with config.chroot_name variable instead buildr…

### DIFF
--- a/mock/py/mockbuild/rebuild.py
+++ b/mock/py/mockbuild/rebuild.py
@@ -18,7 +18,7 @@ def rebuild_generic(items, commands, buildroot, config_opts, cmd, post=None, cle
     start = time.time()
     try:
         for item in items:
-            log.info("Start(%s)  Config(%s)", item, buildroot.shared_root_name)
+            log.info("Start(%s)  Config(%s)", item, buildroot.config['chroot_name'])
             if clean:
                 commands.clean()
             commands.init(prebuild=not config_opts.get('short_circuit'))


### PR DESCRIPTION
…oot.shared_root_name

Because config.chroot_name is the real name of mock --root buildroot.shared_root_name is just the mock build directory

for example for: mock -r epel+rpmfusion_free-7-x86_64 config.chroot_name is epel+rpmfusion_free-7-x86_64 and buildroot.shared_root_name is centos+epel-7-x86_64