### PR TITLE
mock: more quiet rpmbuild --noclean check

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -684,9 +684,10 @@ class Commands(object):
             return self.rpmbuild_noclean_option
 
         self.rpmbuild_noclean_option = ""
-        out, status = self.buildroot.doChroot(["rpmbuild", "--help"],
-                                              returnOutput=True)
-        if not status and "--noclean" in out:
+        out, _ = self.buildroot.doChroot("rpmbuild --help | grep -- --noclean",
+                                         returnOutput=True, shell=True,
+                                         raiseExc=False)
+        if "--noclean" in out:
             self.rpmbuild_noclean_option = "--noclean"
         return self.rpmbuild_noclean_option
 


### PR DESCRIPTION
The "DEBUG: " output might be annoying (printing every single command in the rpmbuild --help output), so let's minimize the stderr pollution with 'grep -- --noclean'.  This should be acceptable, note that this only appears in the --verbose stderr, and one needs to set "cleanup_on_success=False" explicitly.

Fixes: #999