### PR TITLE
mock: drop the redundant qemu-user-static warning

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -532,14 +532,17 @@ def check_arch_combination(target_arch, config_opts):
         binary = f'/usr/bin/qemu-{config_opts["qemu_user_static_mapping"][config_opts["forcearch"]]}-static'
         if not os.path.exists(binary):
             # qemu-user-static is required, but seems to be missing
-            log.warning("missing %s mock will likely fail ...", binary)
             if util.is_host_rh_family():
                 # fail asap on RH systems
-                raise RuntimeError('the --forcearch feature requires the '
-                                   'qemu-user-static.rpm package to be installed')
-            # on other systems we are not sure where the qemu-user-static
-            # binaries are installed.  Notify the user verbosely, but do our
-            # best and continue!
+                raise RuntimeError(
+                    f'The --forcearch feature requires the {binary} '
+                    'file to be installed (typically qemu-user-static* package)')
+
+            # On non-RH systems we are not sure where the qemu-<ARCH>-static
+            # binaries reside - therefore we can't even check whether they are
+            # installed.  Therefore we don't raise an exception; we at least
+            # notify the user verbosely, cross our fingers, and continue.
+            log.warning("missing %s mock will likely fail ...", binary)
             time.sleep(5)
 
 @traceLog()


### PR DESCRIPTION
In case we are on a RHEL-like distro, we will raise a self-explanatory RuntimeException anyway.

Complements: #998