### PR TITLE
Cr 910 Add modularity options, commented, to RHEL templates

### DIFF
--- a/mock-core-configs/etc/mock/eol/templates/centos-8.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/centos-8.tpl
@@ -4,7 +4,8 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:8'
-
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/eol/templates/epelplayground-8.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/epelplayground-8.tpl
@@ -26,4 +26,3 @@ enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-8
 gpgcheck=1
 """
-

--- a/mock-core-configs/etc/mock/eol/templates/fedora-29.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/fedora-29.tpl
@@ -1,12 +1,12 @@
 config_opts['root'] = 'fedora-29-{{ target_arch }}'
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'fc29'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '29'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'fedora:29'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/eol/templates/fedora-30.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/fedora-30.tpl
@@ -1,14 +1,12 @@
 config_opts['root'] = 'fedora-30-{{ target_arch }}'
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
-
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
-
 config_opts['dist'] = 'fc30'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '30'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'fedora:30'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -4,7 +4,8 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:8'
-
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -27,7 +27,6 @@ protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}
 
-
 [baseos]
 name=AlmaLinux $releasever - BaseOS
 mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos

--- a/mock-core-configs/etc/mock/templates/almalinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-9.tpl
@@ -4,7 +4,8 @@ config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:9'
-
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/almalinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-9.tpl
@@ -27,7 +27,6 @@ protected_packages=
 module_platform_id=platform:el9
 user_agent={{ user_agent }}
 
-
 [baseos]
 name=AlmaLinux $releasever - BaseOS
 mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -7,6 +7,8 @@ config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream8'
 config_opts['dnf_vars'] = { 'stream': '8-stream',
                             'contentdir': 'centos',
                           }
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-9.tpl
@@ -6,6 +6,8 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'CentOS Stream 9'
 
 config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream9'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/circlelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/circlelinux-8.tpl
@@ -5,7 +5,6 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'docker.io/circlelinuxos/circlelinux:8'
 
-
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1
@@ -25,7 +24,6 @@ install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el8
 user_agent={{ user_agent }}
-
 
 [baseos]
 name=Circle Linux $releasever - BaseOS

--- a/mock-core-configs/etc/mock/templates/eurolinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/eurolinux-8.tpl
@@ -26,7 +26,6 @@ best=0
 protected_packages=
 module_platform_id=platform:el8
 
-
 [baseos-all]
 name=EuroLinux 8 BaseOS All
 baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/8/$basearch/certify-BaseOS/all/

--- a/mock-core-configs/etc/mock/templates/eurolinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/eurolinux-9.tpl
@@ -25,7 +25,6 @@ best=0
 protected_packages=
 module_platform_id=platform:el9
 
-
 [baseos-all]
 name=EuroLinux 9 BaseOS All
 baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/9/$basearch/BaseOS/all/

--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -77,7 +77,6 @@ gpgcheck=1
 gpgkey={{ rawhide_gpg_keys() }}
 skip_if_unavailable=False
 
-
 [eln-appstream]
 name=Fedora - ELN AppStream - Developmental packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/$basearch/os/
@@ -111,7 +110,6 @@ gpgcheck=1
 gpgkey={{ rawhide_gpg_keys() }}
 skip_if_unavailable=False
 
-
 [eln-crb]
 name=Fedora - ELN CodeReady Linux Builders - Build packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
@@ -144,8 +142,6 @@ type=rpm
 gpgcheck=1
 gpgkey={{ rawhide_gpg_keys() }}
 skip_if_unavailable=False
-
-
 
 [eln-extras]
 name=Fedora - ELN Extras - Developmental packages for the next Enterprise Linux release
@@ -184,8 +180,6 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
 
-
-
 [eln-ha]
 name=Fedora - ELN HighAvailability - Developmental packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/$basearch/os/
@@ -222,8 +216,6 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
-
-
 
 [eln-rs]
 name=Fedora - ELN ResilientStorage - Developmental packages for the next Enterprise Linux release
@@ -262,8 +254,6 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
 
-
-
 [eln-rt]
 name=Fedora - ELN RT - Developmental packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/RT/$basearch/os/
@@ -300,8 +290,6 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
-
-
 
 [eln-nfv]
 name=Fedora - ELN NFV - Developmental packages for the next Enterprise Linux release
@@ -340,8 +328,6 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
 
-
-
 [eln-sap]
 name=Fedora - ELN SAP - Developmental packages for the next Enterprise Linux release
 baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAP/$basearch/os/
@@ -378,8 +364,6 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
-
-
 
 [eln-saphana]
 name=Fedora - ELN SAPHANA - Developmental packages for the next Enterprise Linux release

--- a/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-8.tpl
@@ -5,6 +5,8 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'docker.io/library/oraclelinux:8'
 config_opts['description'] = 'Oracle Linux 8'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/oraclelinux-epel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-epel-9.tpl
@@ -1,9 +1,7 @@
 config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
 
 config_opts['dnf.conf'] += """
-
 # repos
-
 [ol9_epel]
 name=Oracle Linux 9 EPEL ($basearch)
 baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/developer/EPEL/$basearch

--- a/mock-core-configs/etc/mock/templates/rhel-7.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-7.tpl
@@ -43,7 +43,6 @@ sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 skip_if_unavailable=False
 
-
 [rhel-optional]
 name = Red Hat Enterprise Linux - Optional
 {% if target_arch == 'aarch64' %}

--- a/mock-core-configs/etc/mock/templates/rhel-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-8.tpl
@@ -12,6 +12,8 @@ config_opts['yum_install_command'] += ' subscription-manager'
 config_opts['root'] = 'rhel-8-{{ target_arch }}'
 
 config_opts['redhat_subscription_required'] = True
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rhel-9.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-9.tpl
@@ -12,6 +12,8 @@ config_opts['yum_install_command'] += ' subscription-manager'
 config_opts['root'] = 'rhel-{{ releasever }}-{{ target_arch }}'
 
 config_opts['redhat_subscription_required'] = True
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -5,6 +5,8 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:8'
 config_opts['description'] = 'Rocky Linux 8'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/rocky-8.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-8.tpl
@@ -191,5 +191,4 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-8
 
-
 """

--- a/mock-core-configs/etc/mock/templates/rocky-9.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-9.tpl
@@ -5,7 +5,6 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:9'
 
-
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1
@@ -25,7 +24,6 @@ install_weak_deps=0
 protected_packages=
 module_platform_id=platform:el9
 user_agent={{ user_agent }}
-
 
 [baseos]
 name=Rocky Linux $releasever - BaseOS
@@ -250,6 +248,5 @@ gpgcheck=1
 enabled=0
 metadata_expire=6h
 gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-9
-
 
 """

--- a/mock-core-configs/etc/mock/templates/rocky-9.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-9.tpl
@@ -4,6 +4,8 @@ config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:9'
+# config_opts['module_enable'] = ['list', 'of', 'modules']
+# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['dnf.conf'] = """
 [main]


### PR DESCRIPTION
RHEL 8 and later support "modularity". As difficult as it's been, let's at least list the needed options to activate it for RHEL based operating systems, rather than simply enabling it by default.