### PR TITLE
[CR-910] Discard unneccessary module_enable and module_install options for mock-core-configs

### DIFF
--- a/mock-core-configs/etc/mock/eol/templates/fedora-29.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/fedora-29.tpl
@@ -1,6 +1,4 @@
 config_opts['root'] = 'fedora-29-{{ target_arch }}'
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'fc29'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]

--- a/mock-core-configs/etc/mock/eol/templates/fedora-30.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/fedora-30.tpl
@@ -1,7 +1,4 @@
 config_opts['root'] = 'fedora-30-{{ target_arch }}'
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
-
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 
 config_opts['dist'] = 'fc30'  # only useful for --resultdir variable subst

--- a/mock-core-configs/etc/mock/eurolinux-8-aarch64.cfg
+++ b/mock-core-configs/etc/mock/eurolinux-8-aarch64.cfg
@@ -1,7 +1,5 @@
 include('templates/eurolinux-8.tpl')
 
-# To enable modules use:
-#config_opts['module_enable'] = ['swig', 'httpd', 'ruby']
 config_opts['root'] = 'eurolinux-8-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/eurolinux-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/eurolinux-8-x86_64.cfg
@@ -1,7 +1,5 @@
 include('templates/eurolinux-8.tpl')
 
-# To enable modules use:
-#config_opts['module_enable'] = ['swig', 'httpd', 'ruby']
 config_opts['root'] = 'eurolinux-8-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/eurolinux-9-aarch64.cfg
+++ b/mock-core-configs/etc/mock/eurolinux-9-aarch64.cfg
@@ -1,7 +1,5 @@
 include('templates/eurolinux-9.tpl')
 
-# To enable modules use:
-#config_opts['module_enable'] = ['swig', 'httpd', 'ruby']
 config_opts['root'] = 'eurolinux-9-aarch64'
 config_opts['target_arch'] = 'aarch64'
 config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/eurolinux-9-x86_64.cfg
+++ b/mock-core-configs/etc/mock/eurolinux-9-x86_64.cfg
@@ -1,7 +1,5 @@
 include('templates/eurolinux-9.tpl')
 
-# To enable modules use:
-#config_opts['module_enable'] = ['swig', 'httpd', 'ruby']
 config_opts['root'] = 'eurolinux-9-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/custom-1.tpl
+++ b/mock-core-configs/etc/mock/templates/custom-1.tpl
@@ -2,8 +2,6 @@ config_opts['chroot_setup_cmd'] = ''
 config_opts['chroot_additional_packages'] = ''
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['package_manager'] = 'dnf'
-config_opts['module_enable'] = []
-config_opts['module_install'] = []
 config_opts['description'] = 'Custom (no repository)'
 # DNF may not be available in this chroot
 config_opts['use_bootstrap'] = False

--- a/mock-core-configs/etc/mock/templates/fedora-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-branched.tpl
@@ -1,6 +1,4 @@
 config_opts['root'] = 'fedora-{{ releasever }}-{{ target_arch }}'
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 config_opts['description'] = 'Fedora {{ releasever }}'
 # fedora 31+ isn't mirrored, we need to run from koji

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -1,6 +1,4 @@
 config_opts['root'] = 'fedora-rawhide-{{ target_arch }}'
-# config_opts['module_enable'] = ['list', 'of', 'modules']
-# config_opts['module_install'] = ['module1/profile', 'module2/profile']
 
 # fedora 31+ isn't mirrored, we need to run from koji
 config_opts['mirrored'] = config_opts['target_arch'] != 'i686'


### PR DESCRIPTION
The documentation on using "modularity" for dnf is documented in docs/Feature-modularity.md  . The individual settings, commented out, are inconsistently listed and not in use.