### PR TITLE
Add some documentation for enabling modules on the CLI

### DIFF
--- a/docs/Feature-modularity.md
+++ b/docs/Feature-modularity.md
@@ -26,6 +26,11 @@ config_opts['module_setup_commands'] = [
     ]
 ```
 
+Modules can also be specified on the command line using:
+```
+--config-opts=module_setup_commands.module_install=postgresql:13
+```
+
 The obsolete, less flexible, but still available  modularity syntax was added in Mock 1.4.2.
 
 ```


### PR DESCRIPTION
I had trouble getting modules working in mock, but after a lot of experimentation I found that this worked for me and thought it would help others to have it documented.

My use case: https://github.com/ManageIQ/manageiq-rpm_build/pull/341