### PR TITLE
fix: missmatching gpg key and rpms in openEuler 20.03 LTS

### DIFF
--- a/mock-core-configs/etc/mock/templates/openeuler-20.03.tpl
+++ b/mock-core-configs/etc/mock/templates/openeuler-20.03.tpl
@@ -29,42 +29,42 @@ user_agent={{ user_agent }}
 
 [OS]
 name=OS
-baseurl=http://repo.openeuler.org/openEuler-20.03-LTS/OS/$basearch/
+baseurl=http://repo.openeuler.org/openEuler-20.03-LTS-SP3/OS/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/openeuler/RPM-GPG-KEY-openEuler
 
 [everything]
 name=everything
-baseurl=http://repo.openeuler.org/openEuler-20.03-LTS/everything/$basearch/
+baseurl=http://repo.openeuler.org/openEuler-20.03-LTS-SP3/everything/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/openeuler/RPM-GPG-KEY-openEuler
 
 [EPOL]
 name=EPOL
-baseurl=http://repo.openeuler.org/openEuler-20.03-LTS/EPOL/$basearch/
+baseurl=http://repo.openeuler.org/openEuler-20.03-LTS-SP3/EPOL/main/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/openeuler/RPM-GPG-KEY-openEuler
 
 [debuginfo]
 name=debuginfo
-baseurl=http://repo.openeuler.org/openEuler-20.03-LTS/debuginfo/$basearch/
+baseurl=http://repo.openeuler.org/openEuler-20.03-LTS-SP3/debuginfo/$basearch/
 enabled=0
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/openeuler/RPM-GPG-KEY-openEuler
 
 [source]
 name=source
-baseurl=http://repo.openeuler.org/openEuler-20.03-LTS/source/
+baseurl=http://repo.openeuler.org/openEuler-20.03-LTS-SP3/source/
 enabled=0
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/openeuler/RPM-GPG-KEY-openEuler
 
 [update]
 name=update
-baseurl=http://repo.openeuler.org/openEuler-20.03-LTS/update/$basearch/
+baseurl=http://repo.openeuler.org/openEuler-20.03-LTS-SP3/update/$basearch/
 enabled=1
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/openeuler/RPM-GPG-KEY-openEuler


### PR DESCRIPTION
The missmatching was cause by some packages in updates repo and was fixed after SP3 released, so we just change the mock's mirror to openEuler 20.03 LTS SP3

Signed-off-by: lichaoran <pkwarcraft@gmail.com>