### PR TITLE
Branch Fedora 38

### DIFF
--- a/mock-core-configs/etc/mock/fedora-38-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-38-aarch64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-aarch64.cfg
+config_opts['releasever'] = '38'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-38-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-38-i386.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-i386.cfg
+config_opts['releasever'] = '38'
+config_opts['target_arch'] = 'i686'
+config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-38-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-38-ppc64le.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-ppc64le.cfg
+config_opts['releasever'] = '38'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-38-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-38-s390x.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-s390x.cfg
+config_opts['releasever'] = '38'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-38-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-38-x86_64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-x86_64.cfg
+config_opts['releasever'] = '38'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-39-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-39-aarch64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/mock/fedora-39-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-39-i386.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-i386.cfg

--- a/mock-core-configs/etc/mock/fedora-39-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-39-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-ppc64le.cfg

--- a/mock-core-configs/etc/mock/fedora-39-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-39-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-s390x.cfg

--- a/mock-core-configs/etc/mock/fedora-39-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-39-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-x86_64.cfg

--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -1,5 +1,5 @@
 config_opts['releasever'] = 'eln'
-config_opts['eln_rawhide_releasever'] = '38'
+config_opts['eln_rawhide_releasever'] = '39'
 
 config_opts['root'] = 'fedora-eln-{{ target_arch }}'
 

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -7,7 +7,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 
 config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['releasever'] = '38'
+config_opts['releasever'] = '39'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
 config_opts['description'] = 'Fedora Rawhide'

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -18,7 +18,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.77
+Requires:   distribution-gpg-keys >= 1.82
 # specify minimal compatible version of mock
 Requires:   mock >= 2.5
 Requires:   mock-filesystem


### PR DESCRIPTION
One week to branching according to https://fedorapeople.org/groups/schedule/f-38/f-38-key-tasks.html

 * Branch Fedora Linux 38 from Rawhide -- Tue 2023-02-07


> WARNING: Make sure Fedora Copr maintainers are informed that
> WARNING: they should run 'copr-frontend branch-fedora 38'.
> WARNING: That has to be done right on time when branching is done.

@praiskup @FrostyX :eyes: :up: 

> WARNING: Please check that distribution-gpg-keys have the N+1 key,

It does.

>         you likely want to bump Requires: distribution-gpg-keys!

Done.