### PR TITLE
automation: update VCS Diff Lint config

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -13,6 +13,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: VCS Diff Lint
-        uses: fedora-copr/vcs-diff-lint-action@v0.0.2
+        uses: fedora-copr/vcs-diff-lint-action@v1
+        id: VCS_Diff_Lint
         with:
           subdirectory: mock
+
+      - if: ${{ always() }}
+        name: Upload artifact with detected defects in SARIF format
+        uses: actions/upload-artifact@v3
+        with:
+          name: VCS Diff Lint SARIF
+          path: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+
+      - if: ${{ always() }}
+        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.VCS_Diff_Lint.outputs.sarif }}


### PR DESCRIPTION
    The new version is able to automatically upload SARIF data into the
    GitHub UI.  Config updated according to the current vcs-diff-lint-action
    documentation.
