### PR TITLE
during cleanup when leftover is in directory, try again

### DIFF
--- a/mock/py/mockbuild/file_util.py
+++ b/mock/py/mockbuild/file_util.py
@@ -71,8 +71,11 @@ def rmtree(path, selinux=False, exclude=()):
                 raise
             if e.errno == errno.ENOENT:  # no such file or directory
                 pass
-            elif exclude and e.errno == errno.ENOTEMPTY:  # there's something excluded left
-                pass
+            elif e.errno == errno.ENOTEMPTY:  # there's something left
+                if exclude: # but it is excluded
+                    pass
+                else: # likely during Ctrl+C something additional data
+                    try_again = True
             elif selinux and (e.errno == errno.EPERM or e.errno == errno.EACCES):
                 try_again = True
                 if failed_filename == e.filename:

--- a/mock/py/mockbuild/file_util.py
+++ b/mock/py/mockbuild/file_util.py
@@ -38,7 +38,7 @@ def rmtree(path, selinux=False, exclude=()):
     if os.path.islink(path):
         raise OSError("Cannot call rmtree on a symbolic link: %s" % path)
     try_again = True
-    retries = 0
+    retries = 10
     failed_to_handle = False
     failed_filename = None
     if path in exclude:
@@ -76,6 +76,10 @@ def rmtree(path, selinux=False, exclude=()):
                     pass
                 else: # likely during Ctrl+C something additional data
                     try_again = True
+                    retries -= 1
+                    if retries <= 0:
+                        raise
+                    time.sleep(2)
             elif selinux and (e.errno == errno.EPERM or e.errno == errno.EACCES):
                 try_again = True
                 if failed_filename == e.filename:
@@ -83,8 +87,8 @@ def rmtree(path, selinux=False, exclude=()):
                 failed_filename = e.filename
                 os.system("chattr -R -i %s" % path)
             elif e.errno == errno.EBUSY:
-                retries += 1
-                if retries > 1:
+                retries -= 1
+                if retries <= 0:
                     raise
                 try_again = True
                 getLog().debug("retrying failed tree remove after sleeping a bit")


### PR DESCRIPTION
When you Ctrl+C a child can still write something in directory, so try again. Previously this lead to traceback as we handled only this situation when the data were excluded.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2186613