### PR TITLE
mock: manual page: fix the link to the upstream Mock documentation

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -502,14 +502,15 @@ List package manager history using package manager which is configured in chroot
 
 .SH "BUGS"
 .LP
-To report bugs in mock, go to:
+To report an issue with Mock, go to:
 .LP
 .RS 5
-\fIhttps://apps.fedoraproject.org/packages/mock/\fR.
+\fIhttps://github.com/rpm-software-management/mock/issues\fR
 .RE
 .LP
-Select the \fBBugs\fR tab. If there is a bug similar to the one you are seeing, add your
-information to the comments. If not, press \fBOpen A New Bug\fR and fill in the form.
+Search through the list of existing issues.  If there is a similar
+issue to the one you are seeing, add your information in new comments.
+If not, press \fBNew issue\fR and fill in the form.
 .SH "AUTHORS"
 .LP
 Michael Brown <mebrown\@michaels\-house.net>


### PR DESCRIPTION
Fixes: #1067