### PR TITLE
mock: fix bootstrap_* prefixed options

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -412,7 +412,7 @@
 #   * rpm-build - mock needs /usr/bin/rpmbuild
 #   * glibc-minimal-langpack - this is optional, but helps to avoid
 #                              installation of huge glibc-all-langpacks.
-# config_opts['chroot_additional_packages'] = ''
+# config_opts['chroot_additional_packages'] = []
 # config_opts['log_config_file'] = 'logging.ini'
 # config_opts['more_buildreqs']['srpm_name-version-release'] = 'dependency'
 # config_opts['more_buildreqs']['srpm_name-version-release'] = ['dependency1', 'dependency2']

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -764,10 +764,14 @@ def main():
         # query pkg_manager to know which manager is in use
         bootstrap_buildroot.config['chroot_setup_cmd'] = bootstrap_buildroot.pkg_manager.install_command
         # override configs for bootstrap_*
-        for k in bootstrap_buildroot.config.copy():
-            if "bootstrap_" + k in bootstrap_buildroot.config:
-                bootstrap_buildroot.config[k] = bootstrap_buildroot_config["bootstrap_" + k]
-                del bootstrap_buildroot.config["bootstrap_" + k]
+        for option in list(bootstrap_buildroot.config.keys()):
+            # options that are not related to bootstrap chroot config_opts
+            dont_copy = ["bootstrap_image"]
+            prefix = "bootstrap_"
+            if option.startswith(prefix) and option not in dont_copy:
+                bootstrap_option = option[len(prefix):]
+                bootstrap_buildroot.config[bootstrap_option] = bootstrap_buildroot.config[option]
+                del bootstrap_buildroot.config[option]
 
         if config_opts['redhat_subscription_required']:
             key_dir = '/etc/pki/entitlement'

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -322,6 +322,12 @@ def setup_default_config_opts():
     config_opts['opstimeout'] = 0
 
     config_opts['stderr_line_prefix'] = ""
+
+    # Packages from this option are baked into the root-cache tarball.
+    config_opts['chroot_additional_packages'] = []
+
+    # This option is command-line only, packages are always re-installed (ie.
+    # not cached in the root-cache tarball).
     config_opts['additional_packages'] = None
 
     config_opts["no-config"] = {}


### PR DESCRIPTION
    Previously, the "bootstrap_<option>" was copied into the "<option>" if and only
    if the "<option>" was already defined (the value was replaced). Newly, we copy
    all the options prefixed with bootstrap_ prefix, minus the 'bootstrap_image'
    (the only one which has a specific semantics).
