### PR TITLE
mock: use shlex instead of pipes

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -10,9 +10,9 @@ import grp
 import logging
 import os
 import os.path
-import pipes
 import pwd
 import re
+import shlex
 import socket
 import sys
 import warnings
@@ -683,7 +683,7 @@ def nice_root_alias_error(name, alias_name, arch, no_configs, log):
         log.error("")
         log.error("[{}] {}".format(order, short_name))
 
-        alt_cmd = ['mock'] + [short_name if a == arg_name else pipes.quote(a)
+        alt_cmd = ['mock'] + [short_name if a == arg_name else shlex.quote(a)
                               for a in sys.argv[1:]]
 
         log.error("%sUse instead: %s ", pfx, ' '.join(alt_cmd))

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -15,7 +15,6 @@ from glob import glob
 import logging
 import os
 import os.path
-import pipes
 import re
 import select
 import signal
@@ -92,7 +91,7 @@ _OPS_TIMEOUT = 0
 
 def cmd_pretty(cmd):
     if isinstance(cmd, list):
-        return ' '.join(pipes.quote(arg) for arg in cmd)
+        return ' '.join(shlex.quote(arg) for arg in cmd)
     return cmd
 
 


### PR DESCRIPTION
Pipes is a deprecated:
DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13