### PR TITLE
releng: drop f36 from releasers

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -1,6 +1,6 @@
 [fedora-git-all]
 releaser = tito.release.FedoraGitReleaser
-branches = rawhide f38 f37 f36 epel9 epel8
+branches = rawhide f38 f37 epel9 epel8
 
 [@copr-nightly]
 releaser = tito.release.CoprReleaser


### PR DESCRIPTION
Fedora 36 goes EOL on 2023-05-16, per:
https://fedorapeople.org/groups/schedule/f-38/f-38-key-tasks.html