### PR TITLE
bootstrap: use DNF5 in package manager fallbacks

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -18,9 +18,9 @@ from .trace_decorator import traceLog, getLog
 from .mounts import BindMountPoint
 
 fallbacks = {
-    'dnf': ['dnf', 'yum'],
-    'yum': ['yum', 'dnf'],
-    'microdnf': ['microdnf', 'dnf', 'yum'],
+    'dnf': ['dnf', 'dnf5', 'yum'],
+    'yum': ['yum', 'dnf5', 'dnf'],
+    'microdnf': ['microdnf', 'dnf5', 'dnf', 'yum'],
     'dnf5': ['dnf5', 'dnf', 'yum'],
 }
 


### PR DESCRIPTION
If possible, we'll use the target package manager for installing bootstrap.  But if not available on host, we'll try to use the most modern one preferably (the most likely available).