### PR TITLE
bind_mount: pre-create dest directory before mounting file

### DIFF
--- a/mock/py/mockbuild/plugins/bind_mount.py
+++ b/mock/py/mockbuild/plugins/bind_mount.py
@@ -50,4 +50,6 @@ class BindMount(object):
                 file_util.mkdirIfAbsent(srcdir)
                 file_util.mkdirIfAbsent(self.buildroot.make_chroot_path(destdir))
             else:
-                file_util.touch(self.buildroot.make_chroot_path(destdir))
+                dest_file = self.buildroot.make_chroot_path(destdir)
+                file_util.mkdirIfAbsent(os.path.dirname(dest_file))
+                file_util.touch(dest_file)


### PR DESCRIPTION
Previously, the bind_mount plugin relied on pre-existing directory tree, typically created by the chroot directory tree by the _PackageManager installation.  So it was quite easy to mount stuff like `/var/run/socket` because `/var/run` always existed.  Problem happened with files like `/var/run/subdirectory/socket`.

Relates: #1091