### PR TITLE
Fix certificate copying

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -341,9 +341,8 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
         cert_paths = ["/etc/pki/ca-trust", "/usr/share/pki/ca-trust-source"]
         for cert_path in cert_paths:
             pki_dir = self.buildroot.make_chroot_path(cert_path)
-            file_util.mkdirIfAbsent(pki_dir)
             try:
-                shutil.copytree(cert_path, pki_dir)
+                file_util.copy_or_update_tree(cert_path, pki_dir)
             except OSError as err:
                 warning = "Couldn't copy %s certs from host: %s"
                 self.buildroot.root_log.debug(warning, cert_path, str(err))


### PR DESCRIPTION
The problem with default shutil.copytree() is that it doesn't "update" existing directories.  So I was wrong in adf58f0c172dd8, we can't pre-create the dest-directory.  More, the certificate directory is being updated over and over with subsequent calls, and we want to keep updating the dest directory.  For this to work correctly, we need to use 'shutil.copytree(dirs_exist_ok=True)' which is though not in Python 3.6.

Therefore we try the 'shutil.copytree' first (works for Python standard library 3.7+), and we fallback to the deprecated 'distutils' copy_tree() method to stay compatible with Python 3.6.

Partly-reverts: adf58f0c172dd8d5493ca5e8dead5ade23caf711
Fixes: #1094