### PR TITLE
Use python3 macro for post scriptlet

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -1,3 +1,7 @@
+%if 0%{?el8}
+%global python3 /usr/libexec/platform-python
+%endif
+
 Name:       mock-core-configs
 Version:    38.5
 Release:    1%{?dist}
@@ -98,7 +102,7 @@ fi
 if [ -s /etc/mageia-release ]; then
     mock_arch=$(sed -n '/^$/!{$ s/.* \(\w*\)$/\1/p}' /etc/mageia-release)
 else
-    mock_arch=$(python3 -c "import dnf.rpm; import hawkey; print(dnf.rpm.basearch(hawkey.detect_arch()))")
+    mock_arch=$(%{python3} -c "import dnf.rpm; import hawkey; print(dnf.rpm.basearch(hawkey.detect_arch()))")
 fi
 
 cfg=unknown-distro


### PR DESCRIPTION
Use the %python3 macro for determining which Python interpreter to use. The interpreter selection of python3 on RHEL 8 is not guaranteed as the distro allows for any Python 3.x module stream to be used as an alternative for the `python3` symlink. However, only the `platform-python` (`python3` symlink provided by python36) has the DNF Python interfaces available to it.

On one of my RHEL 8 systems where I have Python 3.11 configured as the global `python3`, the following output was logged when upgrading:

```text
  Upgrading        : mock-core-configs-38.5-1.el8.noarch         2/8 
  Running scriptlet: mock-core-configs-38.5-1.el8.noarch         2/8 
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'dnf'
Warning: file /etc/mock/rhel+epel-8-.cfg does not exist.
         unable to update /etc/mock/default.cfg
```