### PR TITLE
enable use_bootstrap_image by default

### DIFF
--- a/docs/Feature-container-for-bootstrap.md
+++ b/docs/Feature-container-for-bootstrap.md
@@ -11,9 +11,9 @@ We come up with a nice feature. Mock will not install bootstrap chroot itself. I
 
 Using this feature, **any** incompatible feature in either RPM or DNF can be used in the target chroot. Now or in future. And you will be able to install the final chroot. You do not even need to have RPM on a host. So this should work on any system. Even Debian based. The only requirement for this feature is [Podman](https://podman.io/). Do not forget to install the `podman` package.
 
-This feature is now disabled by default. You can enable it using:
+This feature is available since 1.4.20 and enabled by default from 5.0. You can disable it using:
 
-    config_opts['use_bootstrap_image'] = True
+    config_opts['use_bootstrap_image'] = False
 
 It can be enabled or disabled on the command line using `--use-bootstrap-image` or `--no-bootstrap-image` options.
 

--- a/mock-core-configs/etc/mock/templates/mageia-7.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-7.tpl
@@ -5,6 +5,7 @@ config_opts['releasever'] = '7'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'docker.io/library/mageia:7'
+config_opts['use_bootstrap_image'] = False
 config_opts['description'] = 'Mageia 7'
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/mageia-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-branched.tpl
@@ -5,6 +5,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'docker.io/library/mageia:{{ releasever }}'
+config_opts['use_bootstrap_image'] = False
 config_opts['description'] = 'Mageia {{ releasever }}'
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/etc/mock/templates/mageia-cauldron.tpl
+++ b/mock-core-configs/etc/mock/templates/mageia-cauldron.tpl
@@ -6,6 +6,7 @@ config_opts['releasever'] = '9'
 config_opts['macros']['%distro_section'] = 'core'
 config_opts['package_manager'] = 'dnf'
 config_opts['bootstrap_image'] = 'docker.io/library/mageia:cauldron'
+config_opts['use_bootstrap_image'] = False
 config_opts['description'] = 'Mageia Cauldron'
 
 config_opts['dnf.conf'] = """

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -140,7 +140,7 @@
 # case, you may need to have "bootstrap" chroot pre-populated from a container
 # image first (where the package manager stack is already pre-installed, so
 # mock doesn't have to).
-#config_opts['use_bootstrap_image'] = False
+#config_opts['use_bootstrap_image'] = True
 #config_opts['bootstrap_image'] = 'fedora:latest'
 
 # Mock in a nutshell needs to have the selected config_opts["package_manager"]

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -80,7 +80,7 @@ Recommends: btrfs-progs
 Recommends: dnf-utils
 Suggests: qemu-user-static
 Suggests: procenv
-Suggests: podman
+Recommends: podman
 
 %if %{with tests}
 BuildRequires: python%{python3_pkgversion}-distro

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -81,7 +81,7 @@ def setup_default_config_opts():
     config_opts['use_container_host_hostname'] = True
 
     config_opts['use_bootstrap'] = True
-    config_opts['use_bootstrap_image'] = False
+    config_opts['use_bootstrap_image'] = True
     config_opts['bootstrap_image'] = 'fedora:latest'
     config_opts['bootstrap_image_ready'] = False
 

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -119,7 +119,7 @@ class _PackageManager(object):
     @classmethod
     def get_command(cls, config):
         command = config.get(f"{cls.name}_command")
-        if config.get("use_bootstrap_image", False):
+        if config.get("use_bootstrap_image", True):
             return command
         if config.get("use_bootstrap", False):
             sys_command = config.get(f"system_{cls.name}_command")


### PR DESCRIPTION
This feature exists for long time. I think it is time to enable it by default. It will allows us to run Mock without package manager on host.