### PR TITLE
mock: don't use dnf5 for bootstrap installation, yet

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -18,9 +18,9 @@ from .trace_decorator import traceLog, getLog
 from .mounts import BindMountPoint
 
 fallbacks = {
-    'dnf': ['dnf', 'dnf5', 'yum'],
-    'yum': ['yum', 'dnf5', 'dnf'],
-    'microdnf': ['microdnf', 'dnf5', 'dnf', 'yum'],
+    'dnf': ['dnf', 'yum'],
+    'yum': ['yum', 'dnf'],
+    'microdnf': ['microdnf', 'dnf', 'yum'],
     'dnf5': ['dnf5', 'dnf', 'yum'],
 }
 


### PR DESCRIPTION
Seems like there's not yet the time, per: https://github.com/rpm-software-management/dnf5/issues/617
Reverts: 6c7cb9fcb248ef6ba7ab0559eefc02c4065e77f2.
Relates: #1089