### PR TITLE
bootstrap: install just python3-dnf-plugins-core

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -477,7 +477,7 @@
 # DF5 sub-command 'builddep' doesn't support the '--allowerasing' option:
 # https://github.com/rpm-software-management/dnf5/issues/461
 #config_opts["dnf5_avoid_opts"] = {"builddep": ["--allowerasing"]}
-#config_opts['dnf_install_command'] = 'install python3-dnf dnf-plugins-core'
+#config_opts['dnf_install_command'] = 'install python3-dnf python3-dnf-plugins-core'
 #config_opts['dnf_disable_plugins'] = ['local', 'spacewalk', 'versionlock']
 #config_opts['dnf_builddep_opts'] = []
 

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -298,7 +298,7 @@ def setup_default_config_opts():
     config_opts['dnf_command'] = '/usr/bin/dnf-3'
     config_opts['system_dnf_command'] = '/usr/bin/dnf-3'
     config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
-    config_opts['dnf_install_command'] = 'install python3-dnf dnf-plugins-core'
+    config_opts['dnf_install_command'] = 'install python3-dnf python3-dnf-plugins-core'
     config_opts['dnf_disable_plugins'] = ['local', 'spacewalk', 'versionlock']
 
     config_opts['dnf5_command'] = '/usr/bin/dnf5'


### PR DESCRIPTION
Not the 'dnf-plugins-core' (which transitively brings the python3-* package) that only contains manual pages.