### PR TITLE
"native" bootstrap, not cross-arch

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -751,6 +751,9 @@ def main():
         # disable updating bootstrap chroot
         bootstrap_buildroot_config['update_before_build'] = False
 
+        # disable forcearch in bootstrap, per https://github.com/rpm-software-management/mock/issues/1110
+        bootstrap_buildroot_config['forcearch'] = None
+
         bootstrap_buildroot_state = State(bootstrap=True)
         bootstrap_plugins = Plugins(bootstrap_buildroot_config, bootstrap_buildroot_state)
         bootstrap_buildroot = Buildroot(bootstrap_buildroot_config,


### PR DESCRIPTION
This might cause troubles in chroots that don't use '$releasever' properly, or have weird 'if target_arch' Jinja hacks (for example different set of repositories for different architectures).

Possible fixes/workarounds that might be interesting to user:

- Using 'config_opts["bootstrap_target_arch"] = "ppc64le"', so the `target_arch` affects how the `dnf.conf` in bootstrap is generated.

- Using 'config_opts["bootstrap_forcearch"] = True'.  This will revert the effect of this patch for particular config.

Fixes: #1110