### PR TITLE
Automatically handle Red Hat subscription in-container

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -696,7 +696,7 @@ def main():
 
     sys.setrecursionlimit(config_opts["recursion_limit"])
 
-    util.subscription_redhat_init(config_opts)
+    util.subscription_redhat_init(config_opts, uidManager)
 
     # allow a different mock group to be specified
     uidManager.fix_different_chrootgid(config_opts)


### PR DESCRIPTION
When a RHEL container is started, the entitlement files are made available in-container and users can then 'dnf install' stuff inside. The entitlement directory though isn't /etc/pki/entitlement, but /etc/pki/entitlement-host.

Mock configuration currently expects that the files exist in /etc/pki/entitlement, so let's try to simplify the job to the end user, and copy the keys into the that directory.  Alternatively (is it needed?) we could create yet another entitlement directory specific to Mock, and change the PEM paths in mock-core-configs.