### PR TITLE
Add download file retry mechanism

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -60,6 +60,7 @@ Requires: python%{python3_pkgversion}-rpm
 Requires: python%{python3_pkgversion}-pyroute2
 Requires: python%{python3_pkgversion}-templated-dictionary
 BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-backoff
 %if %{with lint}
 BuildRequires: python%{python3_pkgversion}-pylint
 %endif

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -44,7 +44,7 @@ class FileDownloader:
         cls._initialize()
         try:
             log.info('Fetching remote file %s', pkg)
-            return cls._get_inner(cls, pkg)
+            return cls._get_inner(pkg)
         except requests.exceptions.RequestException as e:
             log.error('Downloading error %s: %s', pkg, str(e))
             return None

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -40,8 +40,7 @@ class FileDownloader:
         if not any([pkg.startswith(pfx) for pfx in url_prefixes]):
             log.debug("Local file: %s", pkg)
             return pkg
-            cls._initialize()
-            
+        cls._initialize()
         try:
             url = pkg
             log.info('Fetching remote file %s', url)
@@ -55,7 +54,6 @@ class FileDownloader:
     def _get_inner(cls, url):
         req = requests.get(url)
         req.raise_for_status()
-        
         filename = urlsplit(req.url).path.rsplit('/', 1)[1]
         if 'content-disposition' in req.headers:
             _, params = cgi.parse_header(req.headers['content-disposition'])

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -40,9 +40,12 @@ class FileDownloader:
         if not any([pkg.startswith(pfx) for pfx in url_prefixes]):
             log.debug("Local file: %s", pkg)
             return pkg
+            cls._initialize()
+            
         try:
-            log.info('Fetching remote file %s', pkg)
-            return cls._get_inner(pkg)
+            url = pkg
+            log.info('Fetching remote file %s', url)
+            return cls._get_inner(url)
         except requests.exceptions.RequestException as e:
             log.error('Downloading error %s: %s', pkg, str(e))
             return None
@@ -52,7 +55,7 @@ class FileDownloader:
     def _get_inner(cls, url):
         req = requests.get(url)
         req.raise_for_status()
-        cls._initialize()
+        
         filename = urlsplit(req.url).path.rsplit('/', 1)[1]
         if 'content-disposition' in req.headers:
             _, params = cgi.parse_header(req.headers['content-disposition'])

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -40,7 +40,6 @@ class FileDownloader:
         if not any([pkg.startswith(pfx) for pfx in url_prefixes]):
             log.debug("Local file: %s", pkg)
             return pkg
-
         try:
             log.info('Fetching remote file %s', pkg)
             return cls._get_inner(pkg)
@@ -53,18 +52,19 @@ class FileDownloader:
     def _get_inner(cls, url):
         req = requests.get(url)
         req.raise_for_status()
-        cls._initialize()
-
+        downloader = cls()
+        downloader._initialize()
+        
         filename = urlsplit(req.url).path.rsplit('/', 1)[1]
         if 'content-disposition' in req.headers:
             _, params = cgi.parse_header(req.headers['content-disposition'])
             if 'filename' in params and params['filename']:
                 filename = params['filename']
-        pkg = cls.tmpdir + '/' + filename
+        pkg = downloader.tmpdir + '/' + filename
         with open(pkg, 'wb') as filed:
             for chunk in req.iter_content(4096):
                 filed.write(chunk)
-        cls.backmap[pkg] = url
+        downloader.backmap[pkg] = url
         return pkg
 
     @classmethod

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -44,7 +44,7 @@ class FileDownloader:
         cls._initialize()
         try:
             log.info('Fetching remote file %s', pkg)
-            return cls._get_inner(pkg)
+            return cls._get_inner(cls, pkg)
         except requests.exceptions.RequestException as e:
             log.error('Downloading error %s: %s', pkg, str(e))
             return None
@@ -52,7 +52,6 @@ class FileDownloader:
     @classmethod
     @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=3, max_time=10)
     def _get_inner(cls, url):
-        log = getLog()
         req = requests.get(url)
         req.raise_for_status()
 

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -52,19 +52,17 @@ class FileDownloader:
     def _get_inner(cls, url):
         req = requests.get(url)
         req.raise_for_status()
-        downloader = cls()
-        downloader._initialize()
-        
+        cls._initialize()
         filename = urlsplit(req.url).path.rsplit('/', 1)[1]
         if 'content-disposition' in req.headers:
             _, params = cgi.parse_header(req.headers['content-disposition'])
             if 'filename' in params and params['filename']:
                 filename = params['filename']
-        pkg = downloader.tmpdir + '/' + filename
+        pkg = cls.tmpdir + '/' + filename
         with open(pkg, 'wb') as filed:
             for chunk in req.iter_content(4096):
                 filed.write(chunk)
-        downloader.backmap[pkg] = url
+        cls.backmap[pkg] = url
         return pkg
 
     @classmethod

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -54,6 +54,7 @@ class FileDownloader:
     def _get_inner(cls, url):
         req = requests.get(url)
         req.raise_for_status()
+        cls._initialize()
 
         filename = urlsplit(req.url).path.rsplit('/', 1)[1]
         if 'content-disposition' in req.headers:

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -4,9 +4,9 @@
 import cgi
 import shutil
 import tempfile
-import backoff
 from urllib.parse import urlsplit
 
+import backoff
 import requests
 
 from .trace_decorator import getLog
@@ -41,7 +41,6 @@ class FileDownloader:
             log.debug("Local file: %s", pkg)
             return pkg
 
-        cls._initialize()
         try:
             log.info('Fetching remote file %s', pkg)
             return cls._get_inner(pkg)

--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -4,6 +4,7 @@
 import cgi
 import shutil
 import tempfile
+import backoff
 from urllib.parse import urlsplit
 
 import requests
@@ -42,28 +43,30 @@ class FileDownloader:
 
         cls._initialize()
         try:
-            url = pkg
-            log.info('Fetching remote file %s', url)
-            req = requests.get(url)
-            req.raise_for_status()
-            if req.status_code != requests.codes.ok:
-                log.error("Can't download {}".format(url))
-                return False
+            log.info('Fetching remote file %s', pkg)
+            return cls._get_inner(pkg)
+        except requests.exceptions.RequestException as e:
+            log.error('Downloading error %s: %s', pkg, str(e))
+            return None
 
-            filename = urlsplit(req.url).path.rsplit('/', 1)[1]
-            if 'content-disposition' in req.headers:
-                _, params = cgi.parse_header(req.headers['content-disposition'])
-                if 'filename' in params and params['filename']:
-                    filename = params['filename']
-            pkg = cls.tmpdir + '/' + filename
-            with open(pkg, 'wb') as filed:
-                for chunk in req.iter_content(4096):
-                    filed.write(chunk)
-            cls.backmap[pkg] = url
-            return pkg
-        except Exception as err:  # pylint: disable=broad-except
-            log.error('Downloading error %s: %s', url, str(err))
-        return None
+    @classmethod
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=3, max_time=10)
+    def _get_inner(cls, url):
+        log = getLog()
+        req = requests.get(url)
+        req.raise_for_status()
+
+        filename = urlsplit(req.url).path.rsplit('/', 1)[1]
+        if 'content-disposition' in req.headers:
+            _, params = cgi.parse_header(req.headers['content-disposition'])
+            if 'filename' in params and params['filename']:
+                filename = params['filename']
+        pkg = cls.tmpdir + '/' + filename
+        with open(pkg, 'wb') as filed:
+            for chunk in req.iter_content(4096):
+                filed.write(chunk)
+        cls.backmap[pkg] = url
+        return pkg
 
     @classmethod
     def original_name(cls, localname):


### PR DESCRIPTION
The retry mechanism for downloading files with errors has been set to a maximum of 3 retries and a waiting time of 10 seconds
