### PR TITLE
Add download file retry mechanism

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -59,6 +59,7 @@ Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-rpm
 Requires: python%{python3_pkgversion}-pyroute2
 Requires: python%{python3_pkgversion}-templated-dictionary
+Requires: python%{python3_pkgversion}-backoff
 BuildRequires: python%{python3_pkgversion}-devel
 %if %{with lint}
 BuildRequires: python%{python3_pkgversion}-pylint


### PR DESCRIPTION
The retry mechanism for downloading files with errors has been set to a maximum of 3 retries and a waiting time of 10 seconds