### PR TITLE
mock: increase the recursion limit from 1000 to 5000

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -606,3 +606,8 @@
 # because by design Mock doesn't have to fully isolate, we disable seccomp for
 # those containerization tools by default.
 #config_opts["seccomp"] = False
+
+# Mock code can go into a relatively deep recursion (e.g. when doing chroot
+# cleanup via the recursive rmtree() calls).  Use this config option to
+# override the default Mock's stack call limit (5000).
+#config_opts["recursion_limit"] = 5000

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -694,6 +694,8 @@ def main():
     # cmdline options override config options
     config.set_config_opts_per_cmdline(config_opts, options, args)
 
+    sys.setrecursionlimit(config_opts["recursion_limit"])
+
     util.subscription_redhat_init(config_opts)
 
     # allow a different mock group to be specified

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -346,6 +346,9 @@ def setup_default_config_opts():
         's390x': 's390x',
         'x86_64': 'x86_64',
     }
+
+    config_opts["recursion_limit"] = 5000
+
     return config_opts
 
 


### PR DESCRIPTION
This is sometimes problematic for test-suite leftovers, and --scrub. For example all GNU utilities depending on gnulib's getcwd module do some tests related directory structure limits:

https://git.savannah.gnu.org/cgit/gnulib.git/tree/m4/getcwd-path-max.m4?id=c39d83dd0e487e7861349de9fdca7443358fc5f7#n104