### PR TITLE
Post-release administrivia

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -24,7 +24,7 @@ Provides: mock-configs
 # distribution-gpg-keys contains GPG keys used by mock configs
 Requires:   distribution-gpg-keys >= 1.85
 # specify minimal compatible version of mock
-Requires:   mock >= 4.0
+Requires:   mock >= 4.1.post1
 Requires:   mock-filesystem
 
 Requires(post): coreutils

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -9,7 +9,7 @@
 
 Summary: Builds packages inside chroots
 Name: mock
-Version: 4.1
+Version: 4.1.post1
 Release: 1%{?dist}
 License: GPL-2.0-or-later
 # Source is created by


### PR DESCRIPTION
The 'postX' Version tag allows us to explicitly require a specific pre-release version of mock in a pre-release mock-core-configs Version. The tag can be bumped during the development according to the actual needs.

This way of version handling is also a way-around the missing Tito RFE: https://github.com/rpm-software-management/tito/issues/460