### PR TITLE
Use monorepo syntax for Packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,43 +1,43 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-
+---
+packages:
+  mock:
+    specfile_path: mock.spec
+    paths:
+      - ./mock
+    actions:
+      create-archive:
+        - bash -c "tito build --tgz --test -o ."
+        - bash -c "ls -1t ./*.tar.gz | head -n 1"
+      get-current-version:
+        - bash -c "git describe --match mock-[0-9]* --abbrev=0 HEAD | egrep -o
+          [0-9]+\.[0-9]+"
+    downstream_package_name: mock
+    upstream_tag_template: mock-{version}
+  mock-core-configs:
+    specfile_path: mock-core-configs.spec
+    paths:
+      - ./mock-core-configs
+    actions:
+      create-archive:
+        - bash -c "tito build --tgz --test -o ."
+        - bash -c "ls -1t ./*.tar.gz | head -n 1"
+      get-current-version:
+        - bash -c "git describe --match mock-core-configs-[0-9]* --abbrev=0 HEAD
+          | egrep -o [0-9]+\.[0-9]+"
+    downstream_package_name: mock-core-configs
+    upstream_tag_template: mock-core-configs-{version}
 srpm_build_deps:
   - tito
   - git
-
 jobs:
-# job for mock
-- job: copr_build
-  trigger: pull_request
-  identifier: mock
-  metadata:
-    targets:
-    - fedora-rawhide
-  actions:
-    create-archive:
-    - bash -c "cd mock/ && tito build --tgz --test -o ."
-    - bash -c "ls -1t ./mock/*.tar.gz | head -n 1"
-    get-current-version:
-    - bash -c "git describe --match mock-[0-9]* --abbrev=0 HEAD | egrep -o [0-9]+\.[0-9]+"
-  specfile_path: mock/mock.spec
-  upstream_package_name: mock
-  downstream_package_name: mock
-  upstream_tag_template: 'mock-{version}'
-# job for mock-core-configs
-- job: copr_build
-  trigger: pull_request
-  identifier: mock-core-configs
-  metadata:
-    targets:
-    - fedora-rawhide
-  actions:
-    create-archive:
-    - bash -c "cd mock-core-configs/ && tito build --tgz --test -o ."
-    - bash -c "ls -1t ./mock-core-configs/*.tar.gz | head -n 1"
-    get-current-version:
-    - bash -c "git describe --match mock-core-configs-[0-9]* --abbrev=0 HEAD | egrep -o [0-9]+\.[0-9]+"
-  specfile_path: mock-core-configs/mock-core-configs.spec
-  upstream_package_name: mock-core-configs
-  downstream_package_name: mock-core-configs
-  upstream_tag_template: 'mock-core-configs-{version}'
+  - job: copr_build
+    trigger: pull_request
+    packages:
+      - mock
+      - mock-core-configs
+    metadata:
+      targets:
+        - fedora-rawhide


### PR DESCRIPTION
Use monorepo syntax for Packit builds which should simplify the config.

More info:
* https://packit.dev/docs/configuration/#packages
* https://packit.dev/posts/monorepos/