### PR TITLE
Provide <pkg_manager>_avoid_opts defaults as empty dict

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -297,12 +297,14 @@ def setup_default_config_opts():
     config_opts['system_yum_command'] = '/usr/bin/yum'
     config_opts['yum_install_command'] = 'install yum yum-utils'
     config_opts['yum_builddep_command'] = '/usr/bin/yum-builddep'
+    config_opts["yum_avoid_opts"] = {}
 
     config_opts['dnf_command'] = '/usr/bin/dnf-3'
     config_opts['system_dnf_command'] = '/usr/bin/dnf-3'
     config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
     config_opts['dnf_install_command'] = 'install python3-dnf python3-dnf-plugins-core'
     config_opts['dnf_disable_plugins'] = ['local', 'spacewalk', 'versionlock']
+    config_opts["dnf_avoid_opts"] = {}
 
     config_opts['dnf5_command'] = '/usr/bin/dnf5'
     config_opts['system_dnf5_command'] = '/usr/bin/dnf5'
@@ -319,6 +321,7 @@ def setup_default_config_opts():
     config_opts['microdnf_builddep_command'] = '/usr/bin/dnf'
     config_opts['microdnf_builddep_opts'] = []
     config_opts['microdnf_common_opts'] = []
+    config_opts['microdnf_avoid_opts'] = {}
 
     config_opts['rpm_command'] = '/bin/rpm'
     config_opts['rpmbuild_command'] = '/usr/bin/rpmbuild'


### PR DESCRIPTION
Then, in real life configuration files we can assume it already is a dictionary and we can just:

    config_opts["dnf5_avoid_opts]["remove"] = ["--allowerasing"]

Instead of:

    config_opts["dnf5_avoid_opts] = {
        "remove": ["--allowerasing"],
    }