### PR TITLE
Install Rawhide (39+) buildroot with dnf5

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -8,8 +8,9 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '40'
-config_opts['package_manager'] = 'dnf'
+config_opts['package_manager'] = 'dnf5'
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
+config_opts['bootstrap_image_ready'] = True
 config_opts['description'] = 'Fedora Rawhide'
 
 config_opts['dnf.conf'] = """


### PR DESCRIPTION
The Fedora 39 container images have 'dnf5' and 'dnf5-plugins' installed, so we don't actually have to install anything into the bootstrap now, we mark it "ready" to speedup the builds.

Fixes: #1147