### PR TITLE
Make config_opts['dnf5.conf'] alias to config_opts['dnf.conf']

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -49,7 +49,7 @@ def nspawn_supported():
 @traceLog()
 def setup_default_config_opts():
     "sets up default configuration."
-    config_opts = TemplatedDictionary(alias_spec={'dnf.conf': ['yum.conf']})
+    config_opts = TemplatedDictionary(alias_spec={'dnf.conf': ['yum.conf', 'dnf5.conf']})
     config_opts['config_paths'] = []
     config_opts['version'] = VERSION
     config_opts['basedir'] = '/var/lib/mock'  # root name is automatically added to this


### PR DESCRIPTION
This fixes 'mock --chain' with package_manager=dnf5, because the util.py code tries to append repositories into 'dnf5.conf':

Traceback (most recent call last):
  File "/usr/libexec/mock/mock", line 1087, in <module>
    exitStatus = main()
  File "/usr/lib/python3.11/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 847, in main
    result = run_command(options, args, config_opts, commands, buildroot, state)
  File "/usr/lib/python3.11/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 888, in run_command
    result = commands.chain(args, options, buildroot)
  File "/usr/lib/python3.11/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.11/site-packages/mockbuild/backend.py", line 444, in chain
    util.add_local_repo(self.config, local_baseurl, 'local_build_repo',
  File "/usr/lib/python3.11/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/lib/python3.11/site-packages/mockbuild/util.py", line 979, in add_local_repo
    config_opts['{0}.conf'.format(config_opts['package_manager'])] += localyumrepo
  File "/usr/lib/python3.11/site-packages/templated_dictionary/__init__.py", line 36, in __getitem__
    return self.__render_value(self.__dict__[key])
KeyError: 'dnf5.conf'