### PR TITLE
Don't kill orphans without the exclusive lock

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -90,7 +90,6 @@ class Commands(object):
         if self.backup:
             self.backup_results()
         self.state.start("clean chroot")
-        util.orphansKill(self.buildroot.make_chroot_path())
         self.buildroot.delete()
         self.state.finish("clean chroot")
 


### PR DESCRIPTION
Turns out that the very next command 'self.buildroot.delete()' already does this properly (locking the buildroot first to assure no other mock process is killed, and then calling killOrphans).

Also, the '--rebuild' action calls 'do_rebuild' with 'commands.clean()' first - which without asking killed existing background Mock processes:

    $ mock /tmp/tito/mock-4.1.post1-1.git.3565.2f68fb1.fc38.src.rpm
    INFO: mock.py version 4.1.post1 starting (python version = 3.11.4, NVR = mock-4.1.post1-1.git.3565.2f68fb1.fc38)...
    Start(bootstrap): init plugins
    INFO: selinux enabled
    Finish(bootstrap): init plugins
    Start: init plugins
    INFO: selinux enabled
    Finish: init plugins
    INFO: Signal handler active
    Start: run
    INFO: Start(/tmp/tito/mock-4.1.post1-1.git.3565.2f68fb1.fc38.src.rpm)  Config(fedora-38-x86_64)
    Start: clean chroot
    WARNING: Machine 8943e61c7fc54cf1bba7ebfbb9b03c36 still running. Killing...
    ERROR: Exception(/tmp/tito/mock-4.1.post1-1.git.3565.2f68fb1.fc38.src.rpm) Config(fedora-38-x86_64) 0 minutes 0 seconds
    INFO: Results and/or logs in: /var/lib/mock/fedora-38-x86_64/result
    ERROR: Build root is locked by another process.

My bet is that the 0960289912ef06a182c5b7a3885726b91c46b8ce is anyway the critical piece that will eventually fix all the bugs that we aimed to fix with bf6f5197a7f20bcc01af842d00dc75982ca0b17b.

This reverts commit bf6f5197a7f20bcc01af842d00dc75982ca0b17b.