### PR TITLE
mockbuild/buildroot: Make the FUSE device available if supported

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -121,6 +121,7 @@ class Buildroot(object):
         self._homedir_bindmounts = {}
         self._setup_nspawn_btrfs_device()
         self._setup_nspawn_devicemapper_device()
+        self._setup_nspawn_fuse_device()
         self._setup_nspawn_loop_devices()
 
 
@@ -700,6 +701,13 @@ class Buildroot(object):
             self.config['nspawn_args'].append('--bind=/dev/mapper/control')
 
     @traceLog()
+    def _setup_nspawn_fuse_device(self):
+        if not util.USE_NSPAWN or self.is_bootstrap:
+            return
+        if os.path.exists('/dev/fuse'):
+            self.config['nspawn_args'].append('--bind=/dev/fuse')
+
+    @traceLog()
     def _setup_nspawn_loop_devices(self):
         if not util.USE_NSPAWN or self.is_bootstrap:
             return
@@ -732,6 +740,7 @@ class Buildroot(object):
                 (stat.S_IFCHR | 0o666, os.makedev(5, 0), "dev/tty"),
                 (stat.S_IFCHR | 0o600, os.makedev(5, 1), "dev/console"),
                 (stat.S_IFCHR | 0o666, os.makedev(5, 2), "dev/ptmx"),
+                (stat.S_IFCHR | 0o666, os.makedev(10, 229), "dev/fuse"),
                 (stat.S_IFCHR | 0o660, os.makedev(10, 234), "dev/btrfs-control"),
                 (stat.S_IFCHR | 0o600, os.makedev(10, 236), "dev/mapper/control"),
                 (stat.S_IFCHR | 0o666, os.makedev(10, 237), "dev/loop-control"),


### PR DESCRIPTION
Without the FUSE device, we cannot use FUSE filesystems with image builds.

This is particularly important for RPM-OSTree builds that use FUSE as part of the image build process.

Reference: https://pagure.io/fedora-infrastructure/issue/11420