### PR TITLE
Use 'allow_vendor_change=yes' with DNF5

### DIFF
--- a/docs/Release-Notes-Next.md
+++ b/docs/Release-Notes-Next.md
@@ -11,6 +11,15 @@ Released on ????-??-??.
   use-cases) has been changed to automatically retry the download several times
   to work-around random network failures ([PR#1132][] and [PR#1134][]).
 
+- The `dnf` and `dnf5` processes are newly always executed with the
+  `--setopt=allow_vendor_change=yes` option.  This is done in belief that we
+  don't have to protect the Mock builds against `Vendor` changes, and we do this
+  because overriding the distro-default RPMs is quite common thing (`mock
+  --chain` e.g.) while mimicking the distro-default `Vendor` tag would be
+  a painful task.  The thing is that the `allow_vendor_change=no` is going to be
+  set by default in DNF5 soon and we want to prevent unnecessary surprises.
+  Also, openSUSE has been reported to use this even now with DNF4 ([PR#1160][]).
+
 ## Mock v?.? bugfixes:
 
 -
@@ -27,3 +36,4 @@ Thank you.
 
 [PR#1132]: https://github.com/rpm-software-management/mock/pull/1132
 [PR#1134]: https://github.com/rpm-software-management/mock/pull/1134
+[PR#1160]: https://github.com/rpm-software-management/mock/pull/1160

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -487,7 +487,7 @@
 
 # DNF (or DNF4, Python) - https://github.com/rpm-software-management/dnf
 #config_opts['dnf_command'] = '/usr/bin/dnf-3'
-#config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
+#config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
 # DF5 sub-command 'builddep' doesn't support the '--allowerasing' option:
 # https://github.com/rpm-software-management/dnf5/issues/461
 #config_opts["dnf5_avoid_opts"] = {"builddep": ["--allowerasing"]}
@@ -499,7 +499,7 @@
 # Known issue with DNF5: --forcearch is not supported by DNF5
 # https://github.com/rpm-software-management/dnf5/issues/112
 #config_opts['dnf5_command'] = '/usr/bin/dnf5'
-#config_opts['dnf5_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
+#config_opts['dnf5_common_opts'] = ['--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
 #config_opts['dnf5_install_command'] = 'install dnf5 dnf5-plugins'
 #config_opts['dnf5_disable_plugins'] = []
 

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -299,14 +299,14 @@ def setup_default_config_opts():
 
     config_opts['dnf_command'] = '/usr/bin/dnf-3'
     config_opts['system_dnf_command'] = '/usr/bin/dnf-3'
-    config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
+    config_opts['dnf_common_opts'] = ['--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
     config_opts['dnf_install_command'] = 'install python3-dnf python3-dnf-plugins-core'
     config_opts['dnf_disable_plugins'] = ['local', 'spacewalk', 'versionlock']
     config_opts["dnf_avoid_opts"] = {}
 
     config_opts['dnf5_command'] = '/usr/bin/dnf5'
     config_opts['system_dnf5_command'] = '/usr/bin/dnf5'
-    config_opts['dnf5_common_opts'] = ['--setopt=deltarpm=False', '--allowerasing']
+    config_opts['dnf5_common_opts'] = ['--setopt=deltarpm=False', '--setopt=allow_vendor_change=yes', '--allowerasing']
     config_opts['dnf5_install_command'] = 'install dnf5 dnf5-plugins'
     config_opts['dnf5_disable_plugins'] = []
     # No --allowerasing with remove, per


### PR DESCRIPTION
The `allow_vendor_change=no` option is going to be set in DNF5 as default: https://github.com/rpm-software-management/dnf5/issues/712

With Mock though, it is very common to override the distro default package with a custom one (newer or fixed one?).  And blindly trying to keep the Vendor tag unchanged for the overridden packages would be very complicated, without any real benefits.

Note `allow_vendor_change=no` only affects the cases when some package in the buildroot/bootstrap needs to be _updated_ while _typically_ all the packages are only _installed_ at the beginning and are already up2date.  This is therefore mainly related to the --chain option, or cases like `bootstrap_image_ready=False`, `update_before_build`, etc.

Fixes: #1155