### PR TITLE
bootstrap_image and the local repositories

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -241,14 +241,18 @@ class Buildroot(object):
         self._setup_devices()
 
         self._setup_files()
-        self.mounts.mountall_managed()
 
         # write out config details
         self.root_log.debug('rootdir = %s', self.make_chroot_path())
         self.root_log.debug('resultdir = %s', self.resultdir)
 
         self.set_package_manager()
+
+        # this creates some managed mounts
         self.pkg_manager.initialize()
+
+        self.mounts.mountall_managed()
+
         self._setup_resolver_config()
         self._setup_katello_ca()
 

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -476,9 +476,19 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
                     bind_mount_point = BindMountPoint(srcpath=srcpath,
                                                       bindpath=bindpath)
 
-                    # we need to use user mounts as essential mounts are used
-                    # only for installing into bootstrap chroot
-                    self.buildroot.mounts.add_user_mount(bind_mount_point)
+                    # This is a very tricky hack.  Note we configure the
+                    # package_manager for the "bootstrap" chroot here, but these
+                    # "local repo" mountpoints are actually needed by both
+                    # "bootstrap" and "build" chroots.  The "bootstrap" chroot
+                    # needs this with the 'bootstrap_image' feature (we use
+                    # package manager _in bootstrap_, not on host, to install
+                    # into the bootstrap) and the "build" chroot package manager
+                    # always needs this (but also mounted in bootstrap).  That's
+                    # why we are not using "essential mounts"; these are only
+                    # automatically mounted by the corresponding package manager
+                    # (we wouldn't mount bootstrap's mountpoints when installing
+                    # into the "build" chroot).
+                    self.buildroot.mounts.add(bind_mount_point)
 
     def initialize_config(self):
         # there may be configs we get from container image

--- a/mock/tests/test_package_manager.py
+++ b/mock/tests/test_package_manager.py
@@ -79,7 +79,7 @@ class TestPackageManager:
         pm.pkg_manager_config = config
         pm.initialize_config()
         pm._bind_mount_repos_to_bootstrap()
-        return self.bootstrap_buildroot.mounts.user_mounts
+        return self.bootstrap_buildroot.mounts.managed_mounts
 
     def test_absolute_path_name_in_baseurl(self):
         repo_directory = os.path.join(self.workdir, 'repo')


### PR DESCRIPTION
    
    We can not use user_mountpoints because these aren't (historically, not
    sure what are the reasons) mounted too late during the Buildroot
    preparation (after the self._init_pkg_management()).  This isn't
    actually an issue when 'use_bootstrap_image == False' because we use the
    package manager on host (so it actually sees the repository on host).
    
    So newly we place the local_repo mount points into the "managed"
    category, which seems even semantically better now.  We though need to
    call the 'self.mounts.mountall_managed()' method a little bit later than
    before, when the local repo BindMountPoints are already defined by
    self.pkg_manager.initialize().

    This problem has been triggered by the LVM test-case that creates a
    custom local_repo (on host) with `baseurl=/tmp/foo` that needs to be
    bind-mounted into the bootstrap chroot properly.
