### PR TITLE
Fix multilib builds with --use-bootstrap-image

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -521,7 +521,7 @@ def check_arch_combination(target_arch, config_opts):
         legal = config_opts['legal_host_arches']
     except KeyError:
         return
-    host_arch = os.uname()[-1]
+    host_arch = config_opts['host_arch']
     if (host_arch not in legal) and not config_opts['forcearch']:
         log.info("Unable to build arch %s natively on arch %s. Setting forcearch to use software emulation.",
                  target_arch, host_arch)

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -62,6 +62,7 @@ def setup_default_config_opts():
     config_opts['chroothome'] = '/builddir'
     config_opts['log_config_file'] = 'logging.ini'
     config_opts['rpmbuild_timeout'] = 0
+    config_opts['host_arch'] = os.uname()[-1]
     config_opts['chrootuid'] = os.getuid()
     try:
         config_opts['chrootgid'] = grp.getgrnam("mock")[2]

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -270,9 +270,21 @@ class _PackageManager(object):
                 # either it does not support --installroot (microdnf) or
                 # it is bootstrap image made by container with incomaptible dnf/rpm
                 if not self.support_installroot or self.is_bootstrap_image:
+
+                    personality = kwargs.pop("personality", None)
+                    if self.is_bootstrap_image:
+                        # Multilib fix, see on an example: The host-native
+                        # 64-bit package manager installed in the bootstrap
+                        # chroot (from image) needs to know how to resolve the
+                        # $basearch variable.  It would be confused our previous
+                        # 'condPersonality("i386")' call (switched to 32-bit).
+                        # Switch back to 64-bit mode (only the particular DNF
+                        # sub-process).
+                        personality = self.config['host_arch']
+
                     out = util.do(invocation, env=env,
                                   chrootPath=self.buildroot.make_chroot_path(),
-                                  **kwargs)
+                                  personality=personality, **kwargs)
                 elif self.bootstrap_buildroot is None:
                     out = util.do(invocation, env=env,
                                   **kwargs)


### PR DESCRIPTION
When building an i?86 package (with i?86 chroot config) on an x86_64 host, we report to kernel that we work in 32 bit mode (using the '/bin/setarch'-like condPersonality() call).  This is completely OK and desired for the build (target) chroot, but not for the bootstrap chroot which is generated from a container image.

The container image has always a host-native arch (unless there's a configuration error).  So the pre-installed packages are x86_64. When we want to install additional packages there (typically to provide the 'dnf builddep' command in bootstrap), and we do that using the package manager already installed in bootstrap image (no package manager on host is required!), the package manager is confused by the 32-bit mode and resolves '$basearch' into 'i386' instead of 'x86_64'.  So we need to switch back to 64-bit mode (in a subprocess, preexec_fn).

Note that a late call to `os.uname()` would be confused by the condPersonality() call.  So newly we rather remember the 'host_arch' at the beginning in config_opts, before the initial call to condPersonality().

Fixes: #1110