### PR TITLE
Suggest dnf5 in Fedora 41+, not Fedora 38+

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -65,7 +65,7 @@ BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-pylint
 %endif
 
-%if 0%{?fedora} >= 38
+%if 0%{?fedora} >= 41
 # DNF5 stack
 Suggests: dnf5
 Suggests: dnf5-plugins


### PR DESCRIPTION
Hi, as you are probably aware, the switch to DNF 5 has been postponed, likely to Fedora 41. In Fedora 39, the `dnf` command will be provided by the `dnf` package, and DNF 5 will not be installed by default.

Here, I suppose the `Suggests` is not too important, but whether the spec file suggests DNF 4 or DNF 5 in some version of Fedora might as well match the default package manager in that version.

In the meantime, we have set up a testing [COPR repository](https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf5-testing/) that provides a version of DNF 5 that obsoletes DNF 4. It can be used to test software in an environment similar to the future release of Fedora (whichever that will be) when DNF 5 replaces DNF 4:

```
sudo dnf-3 copr enable rpmsoftwaremanagement/dnf5-testing
```

Enabling the COPR and upgrading your system should replace DNF 4 (the `dnf` package) with DNF 5 (`dnf5`), and `/usr/bin/dnf` will be DNF 5.
