### PR TITLE
override ppc64le %_host_cpu

### DIFF
--- a/mock-core-configs/etc/mock/centos-stream+epel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-8-ppc64le.cfg
@@ -6,3 +6,5 @@ config_opts['root'] = 'centos-stream+epel-8-ppc64le'
 config_opts['description'] = 'CentOS Stream 8 + EPEL'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-9-ppc64le.cfg
@@ -6,3 +6,5 @@ config_opts['root'] = 'centos-stream+epel-9-ppc64le'
 config_opts['description'] = 'CentOS Stream 9 + EPEL'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-8-ppc64le.cfg
@@ -8,3 +8,5 @@ config_opts['root'] = 'centos-stream+epel-next-8-ppc64le'
 config_opts['description'] = 'CentOS Stream 8 + EPEL Next'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-9-ppc64le.cfg
@@ -7,3 +7,5 @@ config_opts['root'] = 'centos-stream+epel-next-9-ppc64le'
 config_opts['description'] = 'CentOS Stream 9 + EPEL Next'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/centos-stream-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-8-ppc64le.cfg
@@ -5,3 +5,5 @@ config_opts['root'] = 'centos-stream-8-ppc64le'
 config_opts['description'] = 'CentOS Stream 8'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/centos-stream-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream-9-ppc64le.cfg
@@ -4,3 +4,5 @@ include('templates/centos-stream-9.tpl')
 config_opts['root'] = 'centos-stream-9-ppc64le'
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/rhel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-7-ppc64le.cfg
@@ -4,3 +4,5 @@ config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
 
 config_opts['rhel_product'] = 'power-le'
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/rhel-8-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-8-ppc64le.cfg
@@ -2,3 +2,5 @@ include('templates/rhel-8.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/rhel-9-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-9-ppc64le.cfg
@@ -2,3 +2,5 @@ include('templates/rhel-9.tpl')
 
 config_opts['target_arch'] = 'ppc64le'
 config_opts['legal_host_arches'] = ('ppc64le',)
+# see pull-request #1195
+config_opts['macros']['%_host_cpu'] = 'ppc64le'

--- a/releng/release-notes-next/ppc64le-not-powerpc64le-host-cpu.config
+++ b/releng/release-notes-next/ppc64le-not-powerpc64le-host-cpu.config
@@ -1,0 +1,13 @@
+We [updated the configuration][PR#1195] files for chroots that still use older
+RPM versions (v4.18 and earlier), which affects RHEL/CentOS 9 and older.  These
+older RPM versions were built with an incorrect default for the `%_host_cpu`
+macro in `ppc64le` chroots, where the macro incorrectly resolved to
+`powerpc64le` instead of `ppc64le`.
+
+This incorrect value caused issues during architecture validation, such as when
+checking `ExclusiveArch: ppc64le` for `BuildArch: noarch` packages (done
+in-chroot by `/bin/rpmbuild`).
+
+The incorrect macro value has now been overridden in the relevant `ppc64le`
+configuration files in Mock, ensuring that `ExcludeArch` and `ExclusiveArch`
+validations resolve correctly.


### PR DESCRIPTION
This is what Koji does for all architectures.  The macro is used by
rpmbuild while matching 'ExclusiveArch' patterns.  E.g. "%java_arches"
then contains 'ppc64le', but by default '_host_cpu' contains powerpc64le
on Fedora.

RPM checks %_target_cpu with %_build_cpu fallback:
https://github.com/rpm-software-management/rpm/blob/21457de886faf2415500a8bb7cc6c816d72939ef/build/parsePreamble.c#L442-L449

For 'BuildArch: noarch' packages, %_target_cpu is 'noarch', fallback is
used and '%_build_cpu' is defined as '%_host_cpu' in redhat-rpm-config.
This is set by 'config.guess' to powerpc64le.

TODO: submit a redhat-rpm-config issue
TODO: resolve other EPEL/Fedora targets
Relates: https://github.com/fedora-copr/copr/issues/2870
Relates: https://bugzilla.redhat.com/show_bug.cgi?id=1461288

