### PR TITLE
Add int_src_dir option to specify source directory

### DIFF
--- a/docs/Plugin-Scm.md
+++ b/docs/Plugin-Scm.md
@@ -20,6 +20,7 @@ In your config file insert the following lines:
     config_opts['scm_opts']['distgit_get'] = 'rpkg clone -a --branch SCM_BRN SCM_PKG SCM_PKG'
     config_opts['scm_opts']['distgit_src_get'] = 'rpkg sources'
     config_opts['scm_opts']['spec'] = 'SCM_PKG.spec'
+    config_opts['scm_opts']['int_src_dir'] = None
     config_opts['scm_opts']['ext_src_dir'] = '/dev/null'
     config_opts['scm_opts']['write_tar'] = True
     config_opts['scm_opts']['git_timestamps'] = True
@@ -47,6 +48,10 @@ This option is available only to Git method and not for others.
 ### exclude-vcs
 
 When `exclude-vcs` is set to True, then `--exclude-vcs` option is passed to tar command.
+
+### int_src_dir
+
+When `int_src_dir` is specified, Mock will use that directory in the repository as the SOURCES instead of the repository root.
 
 ### ext_src_dir
 

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -394,6 +394,7 @@
 # config_opts['scm_opts']['distgit_get'] = 'rpkg clone -a --branch SCM_BRN SCM_PKG SCM_PKG'
 # config_opts['scm_opts']['distgit_src_get'] = 'rpkg sources'
 # config_opts['scm_opts']['spec'] = 'SCM_PKG.spec'
+# config_opts['scm_opts']['int_src_dir'] = None
 # config_opts['scm_opts']['ext_src_dir'] = '/dev/null'
 # config_opts['scm_opts']['write_tar'] = True
 # config_opts['scm_opts']['git_timestamps'] = True

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -236,6 +236,7 @@ def setup_default_config_opts():
         'distgit_get': 'rpkg clone -a --branch SCM_BRN SCM_PKG SCM_PKG',
         'distgit_src_get': 'rpkg sources',
         'spec': 'SCM_PKG.spec',
+        'int_src_dir': None,
         'ext_src_dir': os.devnull,
         'write_tar': False,
         'git_timestamps': False,


### PR DESCRIPTION
This allows users to use repositories with non-standard structures.

There is already a 'spec' scm option to specify a SPEC file in arbitrary directories. Why not allow arbitrary source directories to be specified as well?