### PR TITLE
podman: warn that 'docker run --privileged' may be needed

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -217,6 +217,13 @@ class Buildroot(object):
         if not self.uses_bootstrap_image or self.chroot_was_initialized:
             return
 
+        if util.mock_host_environment_type() == "docker":
+            getLog().info(
+                "It seems that you run Mock in a Docker container.  Mock "
+                "though uses container tooling itself (namely Podman) for "
+                "downloading bootstrap image.  This might require you to "
+                "run Mock in 'docker run --privileged'.")
+
         class _FallbackException(Exception):
             pass
 


### PR DESCRIPTION
This complements 79c36e81be4535b8e45bd33ac95a5b98b2951e37 with useful info, Mock already falls-back to using "normal bootstrap" if in Docker without --privileged.

Fixes: #1184