### PR TITLE
mounts: make the hide-from-host mountpoints root-only

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -781,7 +781,7 @@ def main():
             FileSystemMountPoint(filetype='tmpfs',
                                  device='hide_root_in_bootstrap',
                                  path=inner_mount,
-                                 options="private"))
+                                 options="private,mode=0755"))
         buildroot.mounts.bootstrap_mounts.append(
             BindMountPoint(buildroot.make_chroot_path(), inner_mount,
                            recursive=True, options="private").treat_as_chroot())

--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -205,7 +205,7 @@ class Mounts(object):
                 FileSystemMountPoint(filetype='tmpfs',
                                      device=device,
                                      path=host_path,
-                                     options="rprivate"),
+                                     options="rprivate,mode=0755"),
                 BindMountPoint(srcpath=mount_point,
                                bindpath=host_path,
                                recursive=True,

--- a/releng/release-notes-next/hiding-mounts-permissions.bugfix
+++ b/releng/release-notes-next/hiding-mounts-permissions.bugfix
@@ -1,0 +1,5 @@
+Mock uses `tmpfs` mountpoints in some cases just to hide (on host) some rather
+complicated mount structures (done in chroot/separate mount namespace).  These
+"barrier" mount points though used to have the default `mode=0777` potentially
+allowing anyone to accidentally write there and cause e.g. unmount failures.
+New Mock [uses `mode=0755`][PR#1213] instead.


### PR DESCRIPTION
We don't need to allow anyone writing there, these mountpoints are just hiding the complicated recursive bind-mounts in Mock's separate namespace.