### PR TITLE
podman: redirect 'podman pull' stdout to stderr

### DIFF
--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -101,7 +101,7 @@ class Podman:
         finally:
             logger.info("umounting image %s (%s) with podman image umount",
                         self.image, mountpoint)
-            subprocess.run(cmd_umount, check=True)
+            subprocess.run(cmd_umount, capture_output=True, check=True)
 
     @traceLog()
     def cp(self, destination, tar_cmd):

--- a/releng/release-notes-next/podman-image-unmount.bugfix
+++ b/releng/release-notes-next/podman-image-unmount.bugfix
@@ -1,0 +1,2 @@
+The `--shell` standard output is no longer affected by `podman image unmount`
+output executed in the background (prints out the image ID).


### PR DESCRIPTION
This is to fix the 27-nspawn.tst which again detects an unwanted stdout output from Mock.

Follow-up-for: b626045d2bdde026e0278dd1971ed54b217cc7af