### PR TITLE
Suggests DNF5 installation on 38+ again

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -68,17 +68,19 @@ BuildRequires: python%{python3_pkgversion}-pylint
 
 %if 0%{?fedora} >= 38
 # DNF5 stack
-Suggests: dnf5
-Suggests: dnf5-plugins
+Recommends: dnf5
+Recommends: dnf5-plugins
 %endif
 
 # DNF4 stack
-Suggests: python3-dnf
-Suggests: dnf-plugins-core
+Recommends: python3-dnf
+Recommends: python3-dnf-plugins-core
 
-Suggests: yum
-Recommends: btrfs-progs
+# YUM stack, dnf-utils replace yum-utils
+Recommends: yum
 Recommends: dnf-utils
+
+Recommends: btrfs-progs
 Suggests: qemu-user-static
 Suggests: procenv
 Recommends: podman

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -66,7 +66,7 @@ BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-pylint
 %endif
 
-%if 0%{?fedora} >= 41
+%if 0%{?fedora} >= 38
 # DNF5 stack
 Suggests: dnf5
 Suggests: dnf5-plugins

--- a/releng/release-notes-next/package-managers-recommended.feature
+++ b/releng/release-notes-next/package-managers-recommended.feature
@@ -1,0 +1,6 @@
+Per [PR#1220][] discussion, Mock package newly `Recommends` having DNF5, DNF and
+YUM package managers installed on host.  These packages are potentially useful,
+at least when the (default) bootstrap preparation mechansim (bootstrap image)
+fails and the bootstrap needs to be installed with host's package management.
+Previously Mock just "suggested" having them installed, which though used to
+have almost zero practical effect (as Suggests are not installed by default).


### PR DESCRIPTION
Actually, having DNF5 on Fedora 38 Mock **host** is still a good idea for the future when we'll be building Fedora 41 chroots.

This reverts commit 8cca2d02aef81c8dbfb05ba46bb2e8bdf37baafb.