### PR TITLE
Use `rpm.ds(hdr)` instead of now removed hdr.dsFromHeader()

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -218,7 +218,7 @@ class Commands(object):
         try:
             # pylint: disable=no-member
             spec_file = util.host_file(spec_file)
-            spec = rpm.spec(spec_file).sourceHeader.dsFromHeader()
+            spec = rpm.ds(rpm.spec(spec_file).sourceHeader, "requires")
             self.uid_manager.becomeUser(0, 0)
             for i in range(len(spec)): # pylint: disable=consider-using-enumerate
                 requirement_name = spec[i][2:]

--- a/releng/release-notes-next/rpm-ds.bugfix
+++ b/releng/release-notes-next/rpm-ds.bugfix
@@ -1,0 +1,7 @@
+The `--installdeps foo.spec` feature is implemented using the RPM Python API.
+Previously we used the method `hdr.dsFromHeader()` to get the list of
+`BuildRequires`.  This method has been removed from the Python RPM API (rpm
+v4.19) in favor of the long-enough existing `rpm.ds(hdr, ...)` method.  Mock
+[has started using `rpm.ds()` API call][PR#1223] to fix the [`AttributeError:
+'rpm.hdr' object has no attribute 'dsFromHeader'`][issue#1203] traceback on
+newer systems (e.g. Fedora 40+).


### PR DESCRIPTION
Fixes: #1203
Closes: #1223