### PR TITLE
capture_output=True is not supported on EL8

### DIFF
--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -88,7 +88,9 @@ class Podman:
         logger = getLog()
         cmd_mount = [self.podman_binary, "image", "mount", self.image]
         cmd_umount = [self.podman_binary, "image", "umount", self.image]
-        result = subprocess.run(cmd_mount, capture_output=True, check=False, encoding="utf8")
+        result = subprocess.run(cmd_mount, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, check=False,
+                                encoding="utf8")
         if result.returncode:
             message = "Podman mount failed: " + result.stderr
             raise BootstrapError(message)
@@ -101,7 +103,8 @@ class Podman:
         finally:
             logger.info("umounting image %s (%s) with podman image umount",
                         self.image, mountpoint)
-            subprocess.run(cmd_umount, capture_output=True, check=True)
+            subprocess.run(cmd_umount, stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE, check=True)
 
     @traceLog()
     def cp(self, destination, tar_cmd):

--- a/releng/release-notes-next/epel-8-compat.bugfix.md
+++ b/releng/release-notes-next/epel-8-compat.bugfix.md
@@ -1,0 +1,6 @@
+The fixes introduced in Mock 5.1 included a compatibility issue with Python in
+Enterprise Linux 8 due to a dependency on the `capture_output=True` feature in
+the `subprocess` module, which was added in Python 3.7.  However, EL 8 is
+running on Python 3.6.  This compatibility issue has been resolved in Mock by
+using `stdout=subprocess.PIPE` instead.  This update was made based on a [report
+from Bodhi update](https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-45ace77fca).


### PR DESCRIPTION
Per report in Bodhi update:
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-45ace77fca