### PR TITLE
Properly handle Fedora ELN

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -124,6 +124,12 @@ almalinux)
 esac
 cfg=$distro_id+epel-$ver-$mock_arch.cfg
 %endif
+
+%if 0%{?eln}
+# overrides rhel value which resolves in fedora+epel-rawhide-$mock_arch.cfg
+cfg=fedora-eln-$mock_arch.cfg
+%endif
+
 %if 0%{?mageia}
 cfg=mageia-$ver-$mock_arch.cfg
 %endif


### PR DESCRIPTION
Properly handle Fedora ELN in `mock-core-configs/mock-core-configs.spec` by setting the default to `fedora-eln-x86_64.cfg` instead of `fedora+epel-rawhide-x86_64.cfg` which doesn't exists.