### PR TITLE
config: Use the correct openSUSE Backports key for Leap 15.5

### DIFF
--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.5.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.5.tpl
@@ -53,7 +53,7 @@ baseurl=https://download.opensuse.org/distribution/leap/$releasever/repo/oss/
 #metalink=https://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-2022
-        file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports
+        file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports-2023
         file:///usr/share/distribution-gpg-keys/suse/RPM-GPG-KEY-SuSE-SLE-15
         file:///usr/share/distribution-gpg-keys/suse/RPM-GPG-KEY-SuSE-SLE-Main-2023
 gpgcheck=1
@@ -79,7 +79,7 @@ name=openSUSE Leap $releasever - {{ target_arch }} - Updates from Backports for 
 baseurl=https://download.opensuse.org/update/leap/$releasever/backports/
 #metalink=https://download.opensuse.org/update/leap/$releasever/backports/repodata/repomd.xml.metalink
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-Backports-2023
 gpgcheck=1
 
 """

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.96
+Requires:   distribution-gpg-keys >= 1.98
 # specify minimal compatible version of mock
 Requires:   mock >= 5.0
 Requires:   mock-filesystem

--- a/releng/release-notes-next/leap15.5-gpgkeys.config
+++ b/releng/release-notes-next/leap15.5-gpgkeys.config
@@ -1,0 +1,2 @@
+The set of GPG keys used for openSUSE Leap 15.5 was updated to include
+the correct key used for the openSUSE Backports repository.


### PR DESCRIPTION
The openSUSE Backports signing key was replaced in May for Leap 15.5, so this configuration needs to be updated for the new key.

Requires: https://github.com/xsuchy/distribution-gpg-keys/pull/108

Fixes: #1240 