### PR TITLE
Dynamic BuildRequires: Prevent generation of unsatisfied dependency

### DIFF
--- a/releng/release-notes-next/generate_buildrequires.bug
+++ b/releng/release-notes-next/generate_buildrequires.bug
@@ -1,0 +1,19 @@
+When Mock completes the installation of all the requirements generated
+by `%generate_buildrequries`, it calls `rpmbuild -ba` to perform a final build
+of the package.
+
+During the final build, `%generate_buildrequries` runs again in order to
+generate a list of `BuildRequires` to be added to the built SRPM metadata.
+An arbitrary `%generate_buildrequries` section may generate different
+requirements that may not have been installed.
+
+Previously, the `rpmbuild -ba` call used the `--nodeps` option,
+hence it was [possible to successfully build a package with
+unsatisfiable BuildRequires in the built SRPM metadata][issue#1246].
+
+When a bootstrap chroot is used, the `--nodeps` option is
+[no longer used][PR#1249] in the final `rpmbuild -ba` call.
+If `%generate_buildrequries` attempts to generate new unsatisfied requirements
+during the final build, the build will fail.
+When a bootstrap chroot is not used, the `--nodeps` option remains becasue
+Mock cannot know if the RPM in chroot can read the RPM database.


### PR DESCRIPTION
When the %generate_buildrequires section behaved unpredictable, it was possible to successfully build a package with unsatisfied BuildRequires. Now, the build will fail.

Fixes https://github.com/rpm-software-management/mock/issues/1246