### PR TITLE
configs: mandriva provides python-* not python3-* packages

### DIFF
--- a/mock-core-configs/etc/mock/templates/openmandriva-cooker.tpl
+++ b/mock-core-configs/etc/mock/templates/openmandriva-cooker.tpl
@@ -4,6 +4,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '5.0'
 config_opts['macros']['%cross_compiling'] = '0' # Mock should generally be considered native builds
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install python-dnf python-dnf-plugins-core'
 config_opts['description'] = 'OpenMandriva Cooker {{ releasever }}'
 config_opts['bootstrap_image'] = 'docker.io/openmandriva/cooker:latest'
 

--- a/mock-core-configs/etc/mock/templates/openmandriva-rolling.tpl
+++ b/mock-core-configs/etc/mock/templates/openmandriva-rolling.tpl
@@ -4,6 +4,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '5.0'
 config_opts['macros']['%cross_compiling'] = '0' # Mock should generally be considered native builds
 config_opts['package_manager'] = 'dnf'
+config_opts['dnf_install_command'] = 'install python-dnf python-dnf-plugins-core'
 config_opts['description'] = 'OpenMandriva Rolling'
 
 # Is there a corresponding rolling image? #1171

--- a/releng/release-notes-next/mandriva-dnf-python.config
+++ b/releng/release-notes-next/mandriva-dnf-python.config
@@ -1,0 +1,3 @@
+The OpenMandriva chroots provide `python-dnf` and `python-dnf-plugins-core`
+packages, not `python3-dnf` and `python3-dnf-plugins-core`.  That's why we
+[had to fix][issue#1251] the `dnf_install_command` config option appropriately.


### PR DESCRIPTION
Fixes: #1251