### PR TITLE
workflows: enable tox tests in all branches

### DIFF
--- a/.github/workflows/fedora-tox.yml
+++ b/.github/workflows/fedora-tox.yml
@@ -1,11 +1,7 @@
 ---
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 name: Run Tox tests
 jobs:


### PR DESCRIPTION
Per discussion in:
https://github.com/fedora-infra/mock/pull/3