### PR TITLE
Fedora 40+ to use DNF5 for building

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -8,8 +8,16 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['releasever'] = '40'
-config_opts['package_manager'] = 'dnf'
+
+# https://fedoraproject.org/wiki/Changes/BuildWithDNF5
+config_opts['package_manager'] = 'dnf5'
+
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
+
+# For F41+ there's https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5 so
+# once done, re-revert https://pagure.io/fedora-kickstarts/c/f7bf98d3af6d655c6d64ba9c8d2f88cbffbbb06d?branch=main
+#config_opts['bootstrap_image_ready'] = True
+
 config_opts['description'] = 'Fedora Rawhide'
 
 config_opts['dnf.conf'] = """

--- a/releng/release-notes-next/dnf5-for-f40.config
+++ b/releng/release-notes-next/dnf5-for-f40.config
@@ -1,0 +1,6 @@
+Per the approved [Fedora 40 change](https://fedoraproject.org/wiki/Changes/BuildWithDNF5),
+[we switched][PR#1256] the default `package_manager` configuration for Fedora 40
+(Rawhide at that point in time) to `dnf5`.  DNF5 is [the future replacement for
+DNF4](https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5), aiming to be
+much faster than its predecessor.  Hence, the effect of this change is a
+significantly faster buildroot preparation.


### PR DESCRIPTION
Per Fedora system wide change proposal:
https://fedoraproject.org/wiki/Changes/BuildWithDNF5
https://pagure.io/fesco/issue/3096

Fixes: #1147