### PR TITLE
Mock core configs - README.md with maintainers and issue trackers

### DIFF
--- a/mock-core-configs/README.md
+++ b/mock-core-configs/README.md
@@ -1,0 +1,44 @@
+# Mock core configs
+
+The mock configs in this package are maintained by the community.
+When encountering an issue please use your best judgement to decide
+whether a Mock config is broken, or the distribution is broken.
+
+
+## Mock config issues
+
+If a Mock config is broken (e.g. [#756][mock-756]), please
+[create a ticket for this repository][mock-issues]
+and tag the responsible maintainer from the table below.
+
+
+## Distribution or repository issues
+
+If a distribution or repository is broken (e.g. [#889][mock-889]),
+please report the issue to the appropriate issue tracker for the
+distribution.
+
+
+## Table
+
+| Distribution                                                                   | Chroots           | Maintainer                                                            | Distribution or repository issue tracker |
+| ------------------------------------------------------------------------------ | ----------------- | --------------------------------------------------------------------- | ------------- |
+| [AlmaLinux](https://almalinux.org/)                                            | `almalinux-*`     | [@Conan-Kudo](https://github.com/Conan-Kudo)                          | [Issues](https://bugs.almalinux.org/)  |
+| [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)                       | `amazonlinux-2-*` | [@stewartsmith](https://github.com/stewartsmith)                      | NA  |
+| [Amazon Linux](https://aws.amazon.com/linux/amazon-linux-2023/)                | `amazonlinux-*`   | [@amazonlinux](https://github.com/amazonlinux)                        | [Issues](https://github.com/amazonlinux/amazon-linux-2023/issues)  |
+| [Anolis](https://openanolis.cn/)                                               | `anolis-*`        | NA                                                                    | [Issues](https://bugzilla.openanolis.cn/)  |
+| [CentOS Stream](https://www.centos.org/centos-stream/)                         | `centos-stream*`  | [@rpm-software-management](https://github.com/rpm-software-management)| [Issues](https://issues.redhat.com/projects/CS)  |
+| [CentOS Linux](https://www.centos.org/centos-linux/)                           | `centos*`         | [@rpm-software-management](https://github.com/rpm-software-management)| NA  |
+| [Circle Linux](https://cclinux.org/)                                           | `circlelinux-*`   | [@bella485](https://github.com/bella485)                              | [Issues](https://bugzilla.cclinux.org/)  |
+| [EuroLinux](https://en.euro-linux.com/)                                        | `eurolinux-*`     | [@nkadel](https://github.com/nkadel)                                  | [Issues](https://github.com/EuroLinux/eurolinux-distro-bugs-and-rfc)  |
+| [Fedora ELN](https://docs.fedoraproject.org/en-US/eln/)                        | `fedora-eln-*`    | [@fedora-eln](https://github.com/fedora-eln)                          | [Issues](https://github.com/fedora-eln/eln/issues)  |
+| [Fedora](https://fedoraproject.org/)                                           | `fedora-*`        | NA                                                                    | [Issues](https://bugzilla.redhat.com/)  |
+| [Mageia](https://www.mageia.org/en/)                                           | `mageia-*`        | [@Conan-Kudo](https://github.com/Conan-Kudo)                          | [Issues](https://bugs.mageia.org/)  |
+| [openEuler](https://www.openeuler.org/en/)                                     | `openeuler-*`     | [@Yikun](https://github.com/Yikun)                                    | NA  |
+| [RHEL](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux)| `rhel-*`          | [@rpm-software-management](https://github.com/rpm-software-management)| [Issues](https://issues.redhat.com/projects/RHEL)  |
+| [Rocky Linux](https://rockylinux.org/)                                         | `rocky-*`         | [@nazunalika](https://github.com/nazunalika)                          | [Issues](https://bugs.rockylinux.org/)  |
+
+
+[mock-issues]: https://github.com/rpm-software-management/mock/issues
+[mock-756]: https://github.com/rpm-software-management/mock/issues/756
+[mock-889]: https://github.com/rpm-software-management/mock/issues/889

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -147,6 +147,7 @@ fi
 
 %files -f %{name}.cfgs
 %license COPYING
+%doc README.md
 %ghost %config(noreplace,missingok) %{_sysconfdir}/mock/default.cfg
 
 %changelog


### PR DESCRIPTION
See also #1171

We have a lot of chroots, so it is not uncommon, that some of them break from time to time. Most of the reports that I've got were about Fedora ELN but there were others as well. People usually report them as a Copr issue, so I need to point them here (and make sure the maintainer knows) or point them to the distribution issue tracker, which I don't remember from the top of my head.

Hopefully, this will improve the situation.
What do you think?