### PR TITLE
dnf5: Don't output to a PTY

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -291,7 +291,7 @@ class _PackageManager(object):
         if not self.config['print_main_output']:
             kwargs.pop('printOutput', None)
         else:
-            kwargs['pty'] = kwargs.get('pty', True)
+            kwargs.setdefault("pty", True)
         self.buildroot.nuke_rpm_db()
 
         error = None
@@ -758,5 +758,10 @@ class Dnf5(Dnf):
     """
     name = 'dnf5'
     place_common_opts_after = True
+
+    def execute(self, *args, **kwargs):
+        kwargs.setdefault("pty", False)
+        return super(Dnf, self).execute(*args, **kwargs)
+
     def update(self, *args, **_kwargs):
         return self.execute('upgrade', *args)

--- a/releng/release-notes-next/dnf5-logs-with-no-pty.bugfix
+++ b/releng/release-notes-next/dnf5-logs-with-no-pty.bugfix
@@ -1,0 +1,4 @@
+If DNF 5 sees an "interactive" TTY on stdout, it will try to draw progress bars
+and cause the Mock logs to [be garbled](https://github.com/fedora-copr/copr/issues/3040).
+This release brings a fix that simply sets the output of DNF5 to a pipe instead
+of a PTY.


### PR DESCRIPTION
If DNF 5 sees an "interactive" TTY on stdout, it will try to draw progress bars and cause the Mock logs to be garbled: https://github.com/fedora-copr/copr/issues/3040. A simple fix is to have DNF 5 output to a pipe instead of a PTY.

I'm not sure why output is collected via a PTY from yum/dnf (seems to start from commit 99ca2fa), but it's probably no longer needed for DNF 5?