### PR TITLE
rpmautospec plugin: fix install_as_root call

### DIFF
--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -91,7 +91,7 @@ class RpmautospecPlugin:
         # Install the `rpmautospec` command line tool into the build root.
         if self.opts.get("requires", None):
             try:
-                self.buildroot.pkg_manager.install_as_root(*self.opts["requires"], check=True)
+                self.buildroot.install_as_root(*self.opts["requires"])
             except Exception as exc:
                 raise PkgError(
                     "Can’t install rpmautospec dependencies into chroot: "

--- a/mock/tests/plugins/test_rpmautospec.py
+++ b/mock/tests/plugins/test_rpmautospec.py
@@ -143,7 +143,7 @@ class TestRpmautospecPlugin:
             host_chroot_sources.touch()
 
         if "broken-requires" in testcase:
-            plugin.buildroot.pkg_manager.install_as_root.side_effect = RuntimeError("FAIL")
+            plugin.buildroot.install_as_root.side_effect = RuntimeError("FAIL")
             expect_exception = pytest.raises(PkgError)
         else:
             expect_exception = nullcontext()


### PR DESCRIPTION
It might be a typo that breaks the rpmautospec installation:
```
INFO: ENTER ['attempt_process_distgit'](<rpmautospec.RpmautospecPlugin object at 0x7ffff2d87080>, '/mnt/build/mock/rhel-10.0-beta-build-10827742-7100829/root/builddir/build/SPECS/containers-common.spec', '/mnt/build/mock/rhel-10.0-beta-build-10827742-7100829/root/builddir/build/SOURCES')
INFO: EXCEPTION: [PkgError('Can’t install rpmautospec dependencies into chroot: rpmautospec',)]
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mockbuild/plugins/rpmautospec.py", line 94, in attempt_process_distgit
    self.buildroot.pkg_manager.install_as_root(*self.opts["requires"], check=True)
AttributeError: 'Dnf' object has no attribute 'install_as_root'
```