### PR TITLE
Fix installing rpmautospec plugin dependencies

### DIFF
--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -91,7 +91,7 @@ class RpmautospecPlugin:
         # Install the `rpmautospec` command line tool into the build root.
         if self.opts.get("requires", None):
             try:
-                self.buildroot.pkg_manager.install_as_root(*self.opts["requires"], check=True)
+                self.buildroot.install_as_root(*self.opts["requires"])
             except Exception as exc:
                 raise PkgError(
                     "Can’t install rpmautospec dependencies into chroot: "

--- a/mock/tests/plugins/test_rpmautospec.py
+++ b/mock/tests/plugins/test_rpmautospec.py
@@ -143,7 +143,7 @@ class TestRpmautospecPlugin:
             host_chroot_sources.touch()
 
         if "broken-requires" in testcase:
-            plugin.buildroot.pkg_manager.install_as_root.side_effect = RuntimeError("FAIL")
+            plugin.buildroot.install_as_root.side_effect = RuntimeError("FAIL")
             expect_exception = pytest.raises(PkgError)
         else:
             expect_exception = nullcontext()

--- a/releng/release-notes-next/rpmautospec-plugin-fix-install-deps.bugfix
+++ b/releng/release-notes-next/rpmautospec-plugin-fix-install-deps.bugfix
@@ -1,0 +1,1 @@
+This release fixes how the rpmautospec plugin installs its dependencies into the build root.


### PR DESCRIPTION
That’s what I get for only relying on unit tests 😉.

Thanks to @azhuzhu for debugging and working out the patch!