### PR TITLE
dnf5: configure system_cachedir for dnf5

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-branched.tpl
@@ -14,6 +14,7 @@ config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releaseve
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1
+system_cachedir=/var/cache/dnf
 debuglevel=2
 reposdir=/dev/null
 logfile=/var/log/yum.log

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -23,6 +23,7 @@ config_opts['description'] = 'Fedora Rawhide'
 config_opts['dnf.conf'] = """
 [main]
 keepcache=1
+system_cachedir=/var/cache/dnf
 debuglevel=2
 reposdir=/dev/null
 logfile=/var/log/yum.log


### PR DESCRIPTION
With DNF5, the cache directory for root is now configured via `system_cachedir`.  Dnf4 seems to silently ignore this config option.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2256945
Relates: https://github.com/rpm-software-management/dnf5/issues/1150