### PR TITLE
Run shadow-utils inside the chroot to avoid contradictory configurations

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -653,3 +653,13 @@
 # 'BuildRequires: pesign' package which would overwrite the ownership of the
 # socket file.  See https://github.com/rpm-software-management/mock/issues/1091
 #config_opts["copy_host_users"] = []
+
+# Whether to use host's shadow-utils to provision users and groups in the
+# buildroot, which we normally want to do because host shadow-utils are
+# newer and more flexible than buildroot ones. However, there is an issue in shadow-utils
+# where even using the --prefix (or, even --root if we did it that way) option, the host
+# config will "leak" into the chroot. This is not an issue if the configs are
+# effectively the same between host and buildroot, but will cause problems if, for
+# example, the host is configured to use FreeIPA-provided subids.
+# See https://github.com/shadow-maint/shadow/issues/897
+# config_opts["use_host_shadow_utils"] = True

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -355,6 +355,13 @@ def setup_default_config_opts():
 
     config_opts["copy_host_users"] = []
 
+    # shadow-utils --prefix and --root options do not play well with
+    # FreeIPA-provided subids. Using the shadow-utils inside the
+    # chroot works around this but this is a niche situation so it is
+    # not the default.
+    # Upstream issue https://github.com/shadow-maint/shadow/issues/897
+    config_opts["use_host_shadow_utils"] = True
+
     # mapping from target_arch (or forcearch) to arch in /usr/bin/qemu-*-static
     config_opts["qemu_user_static_mapping"] = {
         'aarch64': 'aarch64',

--- a/releng/release-notes-next/use_host_shadow_utils.config
+++ b/releng/release-notes-next/use_host_shadow_utils.config
@@ -1,0 +1,6 @@
+Added a config option called "use_host_shadow_utils", to account for situations where
+users have host shadow-utils configurations that cannot provision or destroy users and
+groups in the buildroot; one example of this kind of configuration is using
+FreeIPA-provided subids on the buildhost. The option defaults to True since mock has made a conscious
+design decision to prefer using the host's shadow-utils, and we hope that this is a
+temporary workaround. Upstream issue is being tracked [here](https://github.com/shadow-maint/shadow/issues/897).


### PR DESCRIPTION
This is the suggestion that @sgallagher offered; I tested this on a FreeIPA-enrolled system and it worked.
I'm a bit nervous about the comment above the line about old shadow-utils being problematic; but we definitely also have the case where shadow-utils config from the host "leaks" into the chroot. I'm not sure which problem is bigger.