### PR TITLE
rpm: mock requires a precise version of mock-filesystem

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -35,7 +35,7 @@ Conflicts: mock-core-configs < 33
 
 # Requires 'mock-core-configs', or replacement (GitHub PR#544).
 Requires: mock-configs
-Requires: %{name}-filesystem
+Requires: %{name}-filesystem = %{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel} >= 8
 # This is still preferred package providing 'mock-configs'
 Suggests: mock-core-configs


### PR DESCRIPTION
This was the only loosely specified dependency that could lead to incompatible installations. These specific requirements become crucial when attempting to install Mock from the Git main branch or even from a pull request Copr repository. In such cases, it often involves a 'mock' downgrade, and it's advisable to downgrade all the sub-packages in a single transaction.