### PR TITLE
Show ccache stats at the end of the build

### DIFF
--- a/docs/Plugin-CCache.md
+++ b/docs/Plugin-CCache.md
@@ -17,6 +17,7 @@ The ccache plugin is enabled by default and has the following values built-in:
     config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/u%(chrootuid)s/"
     config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
     config_opts['plugin_conf']['ccache_opts']['debug'] = False
+    config_opts['plugin_conf']['ccache_opts']['show_stats'] = False
 
 To turn on ccache compression, use the following in a config file:
 
@@ -36,3 +37,7 @@ This option is available since Mock 5.7.
 Setting `debug` to `True` creates per-object debug files that are helpful when debugging unexpected cache misses.
 See [ccache documentation](https://ccache.dev/manual/4.10.html#config_debug).
 This option is available since Mock 5.7.
+
+If `show_stats` is set to True, Mock calls `ccache --zero-stats` first (before
+doing the build), and then calls `ccache --show-stats`.
+This option is available since Mock v5.7+.

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -242,6 +242,7 @@
 # config_opts['plugin_conf']['ccache_opts']['compress'] = None
 # config_opts['plugin_conf']['ccache_opts']['dir'] = "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/"
 # config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
+# config_opts['plugin_conf']['ccache_opts']['show_stats'] = False
 # config_opts['plugin_conf']['ccache_opts']['debug'] = False
 # config_opts['plugin_conf']['yum_cache_enable'] = True
 # config_opts['plugin_conf']['yum_cache_opts'] = {}

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -130,6 +130,7 @@ def setup_default_config_opts():
             'dir': "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/",
             'hashdir': True,
             'debug': False,
+            'show_stats': False,
         },
         'yum_cache_enable': True,
         'yum_cache_opts': {

--- a/releng/release-notes-next/ccache-show-stats.feature
+++ b/releng/release-notes-next/ccache-show-stats.feature
@@ -1,0 +1,3 @@
+There's a new [ccache](Plugin-CCache) plugin option
+`config_opts['plugin_conf']['ccache_opts']['show_stats']`; if set to `True`,
+Mock prints the ccache statistics (hits/misses) to logs.


### PR DESCRIPTION
Zero the ccache stats at the beginning of the build and then display the ccache stats at the end of the build to see how effective ccache was.