### PR TITLE
package_manager: disable %-interpolation in dnf.conf parser

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -480,7 +480,7 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
         }
 
         # in dnf, the last occurence of the same option beats the previous
-        config = ConfigParser(strict=False)
+        config = ConfigParser(strict=False, interpolation=None)
         config.read_string(self.pkg_manager_config)
 
         # don't bindmount the same paths multiple times

--- a/mock/tests/test_package_manager.py
+++ b/mock/tests/test_package_manager.py
@@ -89,6 +89,9 @@ class TestPackageManager:
         [external]
         baseurl = http://exmaple.com/test/
 
+        [external-urlencoded]
+        baseurl = http://example.com/results/%40fedora-llvm-team/
+
         [fedora]
         baseurl = {}
         """.format(repo_directory)


### PR DESCRIPTION
This fixes parsing of dnf.conf containing url-encoded links.

Fixes: #1310