### PR TITLE
Fix root_cache invalidation triggered by config changes

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -685,8 +685,7 @@ def update_config_from_file(config_opts, config_file):
         raise exception.ConfigError("Config error: {}: {}".format(config_file, str(exc)))
 
     # this actually allows multiple inclusion of one file, but not in a loop
-    new_paths = set(config_opts["config_paths"])
-    new_paths.union(included_files)
+    new_paths = set(config_opts["config_paths"]) | included_files
     config_opts["config_paths"] = list(new_paths)
 
 

--- a/mock/tests/data/config-001/fedora-rawhide-x86_64.cfg
+++ b/mock/tests/data/config-001/fedora-rawhide-x86_64.cfg
@@ -1,0 +1,7 @@
+include("templates/fedora-rawhide.tpl")
+
+config_opts["target_arch"] = "x86_64"
+
+config_opts["override_wins_conf"] = "conf"
+config_opts["override_wins_home_site"] = "conf"
+config_opts["override_wins_home_conf"] = "conf"

--- a/mock/tests/data/config-001/site-defaults.cfg
+++ b/mock/tests/data/config-001/site-defaults.cfg
@@ -1,0 +1,7 @@
+config_opts["default"] = True
+
+config_opts["override_wins_site"] = "site"
+config_opts["override_wins_conf"] = "site"
+config_opts["override_wins_home_site"] = "site"
+config_opts["override_wins_home_conf"] = "site"
+config_opts["override_wins_template"] = "site"

--- a/mock/tests/data/config-001/templates/fedora-rawhide.tpl
+++ b/mock/tests/data/config-001/templates/fedora-rawhide.tpl
@@ -1,0 +1,6 @@
+config_opts["template"] = "templated_value"
+
+config_opts["override_wins_conf"] = "template"
+config_opts["override_wins_home_site"] = "template"
+config_opts["override_wins_home_conf"] = "template"
+config_opts["override_wins_template"] = "template"

--- a/mock/tests/data/home-001/.config/mock.cfg
+++ b/mock/tests/data/home-001/.config/mock.cfg
@@ -1,0 +1,8 @@
+config_opts["home_default"] = (1, 2)
+
+# A bit tricky.  The order of evaluation is:
+# 1. site-defaults.cfg
+# 2. configuration file => fedora-rawhide-x86_64.cfg in HOME!
+# 3. configuration file included
+# 4. home mock.cfg
+config_opts["override_wins_home_site"] = "home_site"

--- a/mock/tests/data/home-001/.config/mock/fedora-rawhide-x86_64.cfg
+++ b/mock/tests/data/home-001/.config/mock/fedora-rawhide-x86_64.cfg
@@ -1,0 +1,5 @@
+include("fedora-rawhide-x86_64.cfg")
+config_opts["home_override"] = "10"
+
+config_opts["override_wins_home_conf"] = "home_conf"
+config_opts["override_wins_home_site"] = "home_conf"

--- a/mock/tests/test_config_loader.py
+++ b/mock/tests/test_config_loader.py
@@ -1,0 +1,52 @@
+"""
+Tests for mockbuild.config
+"""
+
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=attribute-defined-outside-init
+
+import pwd
+import os
+import shutil
+import tempfile
+
+from unittest import mock
+from mockbuild.config import simple_load_config
+
+
+class TestConfigLoader:
+    def setup_method(self):
+        testdir = os.path.dirname(os.path.realpath(__file__))
+        self.configdir = os.path.join(testdir, "data", "config-001")
+        self.homedir = tempfile.mkdtemp(prefix='mock-test-home')
+        homedata = os.path.join(testdir, "data", "home-001")
+        self.username = pwd.getpwuid(os.getuid())[0]
+        userdir = os.path.join(self.homedir, self.username)
+        shutil.copytree(homedata, userdir)
+
+    def test_config_paths(self):
+        with mock.patch("mockbuild.config.os.path.expanduser") as patch:
+            patch.side_effect = lambda x: x.replace("~", self.homedir + "/")
+            config = simple_load_config('fedora-rawhide-x86_64', self.configdir)
+        assert set(config["config_paths"]) == {
+            os.path.join(self.configdir, "site-defaults.cfg"),
+            os.path.join(self.configdir, "fedora-rawhide-x86_64.cfg"),
+            os.path.join(self.configdir, "templates", "fedora-rawhide.tpl"),
+            os.path.join(self.homedir, self.username, ".config", "mock.cfg"),
+            os.path.join(self.homedir, self.username, ".config", "mock", "fedora-rawhide-x86_64.cfg"),
+        }
+
+        assert config["default"] is True
+        assert config["target_arch"] == 'x86_64'
+        assert config["template"] == "templated_value"
+        assert config["home_default"] == (1, 2)
+
+        assert config["override_wins_site"] == "site"
+        assert config["override_wins_conf"] == "conf"
+        assert config["override_wins_home_site"] == "home_site"
+        assert config["override_wins_home_conf"] == "home_conf"
+        assert config["override_wins_template"] == "template"
+
+    def teardown_method(self):
+        shutil.rmtree(self.homedir)

--- a/releng/release-notes-next/root_cache_invalidation.bugfix
+++ b/releng/release-notes-next/root_cache_invalidation.bugfix
@@ -1,0 +1,6 @@
+The `root_cache` plugin is designed to invalidate the cache tarball whenever the
+corresponding Mock configuration changes (any file in the list
+`config_opts['config_paths']` changes).  This cache invalidation mechanism had
+been broken since Mock v3.2 when we rewrote the configuration file loader and
+inadvertently broke the `config_opts['config_paths']`.  The config loader [has
+now been fixed][PR#1322], and the cache invalidation works again as expected.


### PR DESCRIPTION
The root_cache plugin assures that no new configuration file in the `config_opts['config_paths']` list is newer than the root_cache cache tarball, otherwise the caches are invalidated.

The bug is caused by use of improper set operation (union() doesn't modify the calling object).