### PR TITLE
Release Notes before #1308, and requirement bump

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -24,7 +24,7 @@ Provides: mock-configs
 # distribution-gpg-keys contains GPG keys used by mock configs
 Requires:   distribution-gpg-keys >= 1.98
 # specify minimal compatible version of mock
-Requires:   mock >= 5.0
+Requires:   mock >= 5.4.post1
 Requires:   mock-filesystem
 
 Requires(post): coreutils

--- a/releng/release-notes-next/init-and-ownership-problems.bugfix
+++ b/releng/release-notes-next/init-and-ownership-problems.bugfix
@@ -1,0 +1,17 @@
+Mock [has been][PR#1322] [fixed][commit#27dde5da] so that it no longer
+inadvertently changes the group ownership of the in-chroot $HOME directory
+to the wrong group ID.  In previous versions of Mock, the group ownership
+was changed to the effective group ID of the user on the host that
+executed Mock.  This could confuse some tools during the build process, as
+they might want to create similarly owned files at the `rpmbuild` time
+(but that assumption would be incorrect, such GID doesn't exist
+in-chroot).  Now, Mock changes the files to the `mockbuild:mock`
+ownership, where the `mock` group ID is always 135 (the same GID on host
+and in-chroot).  This matches the effective GID for the `rpmbuild`
+process, ensuring that the tools executed during the build process have
+full control over such files.
+
+While on this, Mock was also [optimized][commit#db64d468202] to do this
+ownership change before, and only if, the `rpmbuild` process is started
+(so e.g. plain `mock --chroot` commands do not touch the file ownership at
+all).

--- a/releng/release-notes-next/mageia-7-eol.config
+++ b/releng/release-notes-next/mageia-7-eol.config
@@ -1,0 +1,1 @@
+Mageia 7 configs [marked as end-of-life][PR#1316].

--- a/releng/release-notes-next/mageia-cross-arch.config
+++ b/releng/release-notes-next/mageia-cross-arch.config
@@ -1,0 +1,2 @@
+Mageia config files started using the `{{ repo_arch }}` option to fix the
+[cross-arch builds][issue#1317].

--- a/releng/release-notes-next/mock-filesystem-deps.bugfix
+++ b/releng/release-notes-next/mock-filesystem-deps.bugfix
@@ -1,0 +1,3 @@
+The `mock` package has been fixed to depend on precisely the same version
+of `mock-filesystem` sub-package (product of the same rpm build).  This is
+to protect against incompatible Mock sub-package installations.

--- a/releng/release-notes-next/openmandriva-i686-eol.config
+++ b/releng/release-notes-next/openmandriva-i686-eol.config
@@ -1,0 +1,2 @@
+The OpenMandriva i686 chroots [have been marked as end-of-life][PR#1315], fixing
+[issue#987][] and [issue#1012][].

--- a/releng/release-notes-next/percent-interpolation-in-dnf-config.bugfix
+++ b/releng/release-notes-next/percent-interpolation-in-dnf-config.bugfix
@@ -1,0 +1,9 @@
+Mock parses the DNF configuration specified in `config_opts["dnf.conf"]` itself
+to perform some post-processing tasks, such as bind-mounting the on-host repo
+directories into the bootstrap chroot based on this DNF config.  In previous
+versions of Mock, there was an issue where it failed to parse the DNF config if
+some of the DNF options contained the '%' symbol.  This was due to Python's
+ConfigParser raising an %-interpolation exception that was ignored but Mock, but
+resulting in Mock ignoring the rest of the config file and finishing without
+performing the mentioned bind-mounts.  This bug has been fixed, and the '%' sign
+is no longer considered to be a special Python ConfigParser character.

--- a/releng/release-notes-next/report-file-system-type.feature
+++ b/releng/release-notes-next/report-file-system-type.feature
@@ -6,7 +6,7 @@ Filesystem                                             Size  Used Avail Use% Mou
 /dev/mapper/luks-3aa4fbe3-5a19-4025-b70c-1d3038b76bd4  399G  9.1G  373G   3% /
 ~~~
 
-Newly, also file system type is reported:
+Newly, [also file system type is reported][issue#1263]:
 
 ~~~
 Filesystem                                             Type   Size  Used Avail Use% Mounted on

--- a/releng/release-notes-next/use_host_shadow_utils.config
+++ b/releng/release-notes-next/use_host_shadow_utils.config
@@ -1,4 +1,4 @@
-Added a config option called "use_host_shadow_utils", to account for situations where
+[Added][PR#1283] a config option called "use_host_shadow_utils", to account for situations where
 users have host shadow-utils configurations that cannot provision or destroy users and
 groups in the buildroot; one example of this kind of configuration is using
 FreeIPA-provided subids on the buildhost. The option defaults to True since mock has made a conscious


### PR DESCRIPTION
New PRs will "enforce" adding the release notes snippets, but we forgot to add some in this release cycle.

The mock-core-cconfig -> mock requirement bump is needed for the new '{{ repo_arch }}' jinja2 template support.