### PR TITLE
ChrootScan: don't fail for missing option

### DIFF
--- a/docs/Plugin-ChrootScan.md
+++ b/docs/Plugin-ChrootScan.md
@@ -10,16 +10,17 @@ The chroot_scan plugin is used to grab files of interest after a build attempt a
 The chroot_scan plugin is disabled by default. To enable it and to add files to the detection logic, add this code to configure file:
 
     config_opts['plugin_conf']['chroot_scan_enable'] = True
-    config_opts['plugin_conf']['chroot_scan_opts'] = {
-        'regexes': [ "core(\.\d+)?", "\.log$",],
-        'only_failed': True,
-        'write_tar': False,
-    }
+    config_opts['plugin_conf']['chroot_scan_opts']['regexes'] = [
+        "core(\.\d+)?",
+        "\.log$",
+    ]
+    config_opts['plugin_conf']['chroot_scan_opts']['only_failed'] = True
+    config_opts['plugin_conf']['chroot_scan_opts']['write_tar'] = False
 
 The above logic turns on the chroot_scan plugin and adds corefiles and log files to the scan plugin. When the 'postbuild' hook is run by mock, the chroot_scan will look through the chroot for files that match the regular expressions in it's list and any matching file will be copied to the mock result directory for the config file. Again if you want this to be enabled across all configs, edit the `/etc/mock/site-defaults.cfg` file.
 
 When `only_failed` is set to False, then those files are always copied. When it is set to True (default when plugin enabled), then those files are only copied when build failed.
 
-when `write_tar` is set to True, then instead of `chroot_scan` directory, `chroot_scan.tar.gz` is created with the directory archive.
+When `write_tar` is set to True, then instead of `chroot_scan` directory, `chroot_scan.tar.gz` is created with the directory archive.
 
-`only_failed` option is available since mock-1.2.8
+The `only_failed` option is available since v1.2.8, `write_tar` since v5.5.

--- a/mock/py/mockbuild/plugins/chroot_scan.py
+++ b/mock/py/mockbuild/plugins/chroot_scan.py
@@ -40,11 +40,11 @@ class ChrootScan(object):
 
     def _only_failed(self):
         """ Returns boolean value if option 'only_failed' is set. """
-        return str(self.scan_opts['only_failed']) == 'True'
+        return str(self.scan_opts.get('only_failed')) == 'True'
 
     def _tarball(self):
         """ Returns boolean value if option 'write_tar' is set. """
-        return str(self.scan_opts['write_tar']) == 'True'
+        return str(self.scan_opts.get('write_tar')) == 'True'
 
     @traceLog()
     def _scanChroot(self):

--- a/releng/release-notes-next/chroot_scan_tarball.feature
+++ b/releng/release-notes-next/chroot_scan_tarball.feature
@@ -1,3 +1,3 @@
-New `write_tar` option for `chroot_scan` plugin. Without it, directory
+New `write_tar` option for `chroot_scan` plugin [added][PR#1324].  Without it, directory
 structure is created in `resultdir`. If `write_tar` is set to `True`,
 write_tar will be created instead.


### PR DESCRIPTION
I just tried to comment-out the 'tarball' option, and Mock started to fail with KeyError traceback.  It's better to use config_opts.get().

While on it, fix documentation to suggest configuration that is not prone to this kind of errors (the default values stay defined).