### PR TITLE
bash-completion: pre-build the list of mock known options

### DIFF
--- a/mock/etc/bash_completion.d/mock
+++ b/mock/etc/bash_completion.d/mock
@@ -50,6 +50,12 @@ _mock_isopt_multiarg() {
     return 1
 }
 
+_mock_parse_help()
+{
+    # PRECOMPILED_PARSED_MOCK_HELP
+    _parse_help "$1"
+}
+
 _mock()
 {
     local cur prev words cword split
@@ -161,7 +167,7 @@ _mock()
     $split && return
 
     if [[ "$cur" == -* ]] ; then
-        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+        COMPREPLY=( $( compgen -W '$( _mock_parse_help "$1" )' -- "$cur" ) )
         # _parse_help fails to pick up --define (it's a parsing failure due to
         # the quoted 'MACRO EXPR' argument)
         COMPREPLY+=( $( compgen -W '--define=' -- "$cur" ) )

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -65,6 +65,7 @@ BuildRequires: python%{python3_pkgversion}-devel
 %if %{with lint}
 BuildRequires: python%{python3_pkgversion}-pylint
 %endif
+BuildRequires: python%{python3_pkgversion}-rpm
 BuildRequires: python%{python3_pkgversion}-rpmautospec-core
 
 %if 0%{?fedora} >= 38
@@ -166,6 +167,8 @@ for i in docs/mock.1 docs/mock-parse-buildlog.1; do
     perl -p -i -e 's|\@VERSION\@|%{version}"|' $i
 done
 
+./precompile-bash-completion "mock.complete"
+
 %install
 #base filesystem
 mkdir -p %{buildroot}%{_sysconfdir}/mock/eol/templates
@@ -190,6 +193,7 @@ cp -a etc/consolehelper/mock %{buildroot}%{_sysconfdir}/security/console.apps/%{
 
 install -d %{buildroot}%{_datadir}/bash-completion/completions/
 cp -a etc/bash_completion.d/* %{buildroot}%{_datadir}/bash-completion/completions/
+cp -a mock.complete %{buildroot}%{_datadir}/bash-completion/completions/mock
 ln -s mock %{buildroot}%{_datadir}/bash-completion/completions/mock-parse-buildlog
 
 install -d %{buildroot}%{_sysconfdir}/pki/mock

--- a/mock/precompile-bash-completion
+++ b/mock/precompile-bash-completion
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+mock_options=$(
+    # shellcheck source=/dev/null
+    . /usr/share/bash-completion/bash_completion
+    _parse_help py/mock.py
+)
+
+# Some trivial assert to check it actually works
+case $mock_options in
+*--chroot*) ;;
+*) exit 1 ;;
+esac
+
+while IFS= read -r line; do
+    case $line in
+    *PRECOMPILED_PARSED_MOCK_HELP*)
+        echo "echo '"
+        echo "$mock_options"
+        echo "'"
+        echo "return"
+        ;;
+    *) echo "$line" ;;
+    esac
+done < ./etc/bash_completion.d/mock > "${1-mock-preprocessed}"

--- a/releng/release-notes-next/faster-bash-completion.feature
+++ b/releng/release-notes-next/faster-bash-completion.feature
@@ -1,0 +1,4 @@
+The Bash completion script for Mock has been improved to pre-compile the list of
+available Mock options at package build-time.  This enhancement significantly
+reduces the time required for option completion from approximately 0.5 seconds
+(on a reasonably fast laptop) to just 0.05 seconds. [rhbz#2259430][].


### PR DESCRIPTION
Fixes: rhbz#259430