### PR TITLE
docs: add the case of user's default.cfg.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,13 @@ You may also copy and edit an existing configuration file into a new one:
 
     $ cp /etc/mock/fedora-rawhide-x86_64.cfg ~/.config/mock/foo.cfg
 
+The default chroot configuration file is `/etc/mock/default.cfg`, which is
+usually a symlink to one of the installed chroot configuration files.  You may
+create another symlink to an installed configuration file to change the default
+chroot config file:
+
+    $ ln -s /etc/mock/fedora-rawhide-x86_64.cfg ~/.config/mock/default.cfg
+
 If Koji is already using a config you need, then you can use the Koji client
 tool for generating the file:
 


### PR DESCRIPTION
I am using Fedora. I was looking for a way of using an user's own `default.cfg` instead of the `/etc/mock/default.cfg`. Because I wanted to use the Fedora rawhide as default instead of the current default to the latest Fedora stable version 39. 

```
$ ls /etc/mock/default.cfg -l
lrwxrwxrwx. 1 root root 20 Feb 26 14:57 /etc/mock/default.cfg -> fedora-39-x86_64.cfg
```

I didn't want to modify the `/etc/mock/default.cfg`. Because it might prevent the future update of the file by upgrading the `mock-core-configs` RPM package.

I was not able to find the user's `default.cfg` in the current documents. Below is a part of explaining the `default.cfg`. But it doesn't explain about the user's `default.config` explicitly.

https://github.com/rpm-software-management/mock/blob/fc1f7d4d22777d17f41aa6482e627f1895258110/mock/docs/mock.1#L59-L69

So, I finally found a way to set up the user's `default.cfg`. That is one of either ways below.

```
$ ln -s /etc/mock/fedora-rawhide-x86_64.cfg ~/.config/mock/default.cfg
```

or 

```
$ cp /etc/mock/fedora-rawhide-x86_64.cfg ~/.config/mock/default.cfg
```


So, this PR is my proposal to update the current document to add this topic. You can see the modified `configuration.md` [here](https://github.com/junaruga/mock/blob/wip/doc-user-default-cfg/docs/configuration.md) on my forked repository.


