### PR TITLE
Don't use --allowerasing for more DNF commands

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -328,7 +328,13 @@ def setup_default_config_opts():
     config_opts['dnf5_disable_plugins'] = []
     # No --allowerasing with remove, per
     # https://github.com/rpm-software-management/dnf5/issues/729
-    config_opts["dnf5_avoid_opts"] = {"remove": ["--allowerasing"]}
+    config_opts["dnf5_avoid_opts"] = {
+        "remove": ["--allowerasing"],
+        "repoquery": ["--allowerasing"],
+        "makecache": ["--allowerasing"],
+        "search": ["--allowerasing"],
+        "info": ["--allowerasing"],
+    }
 
     config_opts['microdnf_command'] = '/usr/bin/microdnf'
     # "dnf-install" is special keyword which tells mock to use install but with DNF

--- a/releng/release-notes-next/allowerasing.bugfix
+++ b/releng/release-notes-next/allowerasing.bugfix
@@ -1,0 +1,2 @@
+Don't use the `--allowerasing` parameter for DNF subcommands such as
+`repoquery`, `makecache`, `search`, and `info`.


### PR DESCRIPTION
DNF subcommands such as `repoquery`, `makecache` , `search`, and `info`, doesn't support the `--allowerasing` parameter.