### PR TITLE
Rewrites "original_name" method to check if "cls" has a "backmap"

### DIFF
--- a/mock/py/mockbuild/file_downloader.py
+++ b/mock/py/mockbuild/file_downloader.py
@@ -80,9 +80,9 @@ class FileDownloader:
     @classmethod
     def original_name(cls, localname):
         """ Get the URL from the local name """
-        if not cls.backmap:
-            return localname
-        return cls.backmap.get(localname, localname)
+        if getattr(cls, 'backmap', None):
+            return cls.backmap.get(localname, localname)
+        return localname
 
     @classmethod
     def cleanup(cls):

--- a/releng/release-notes-next/FileDownloader-original_name.bugfix
+++ b/releng/release-notes-next/FileDownloader-original_name.bugfix
@@ -1,0 +1,5 @@
+When a `mock --chain --recurse` fails to built at least one package, it is
+unable to print a list of failed packages and displays `AttributeError: type
+object 'FileDownloader' has no attribute 'backmap'` instead. The `original_name`
+method of `FileDownloader` class has been fixed, and the chain build results
+displayed as expected ([issue#1345][]).


### PR DESCRIPTION
In some cases, such as fail of "mock --chain --recurse some.src.rpm.tofail", FileDownloader "cls" may not have a "backmap" attribute. So we have to check if it exists before accessing it.

Fixes: #1345