### PR TITLE
configs: use DNF5-team-provided bootstrap images

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-branched.tpl
@@ -9,10 +9,16 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 config_opts['dist'] = 'fc{{ releasever }}'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 
-# https://fedoraproject.org/wiki/Changes/BuildWithDNF5 for Fedora 40+
-config_opts['package_manager'] = '{% if releasever|int >= 40 %}dnf5{% else %}dnf{% endif %}'
-
-config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
+# For F41+ there's https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5 so
+# once finished, we may use the default Fedora image.  Now we are on nightlies
+# maintained by the RPM Software Management team.
+if int(config_opts['releasever']) >= 40:
+    config_opts['package_manager'] = 'dnf5'
+    config_opts['bootstrap_image'] = 'quay.io/rpmsoftwaremanagement/fedora-dnf5:{{ releasever }}'
+    config_opts['bootstrap_image_ready'] = True
+else:
+    config_opts['package_manager'] = 'dnf'
+    config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -12,11 +12,11 @@ config_opts['releasever'] = '41'
 # https://fedoraproject.org/wiki/Changes/BuildWithDNF5
 config_opts['package_manager'] = 'dnf5'
 
-config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
-
 # For F41+ there's https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5 so
-# once done, re-revert https://pagure.io/fedora-kickstarts/c/f7bf98d3af6d655c6d64ba9c8d2f88cbffbbb06d?branch=main
-#config_opts['bootstrap_image_ready'] = True
+# once finished, we may use the default Fedora image.  Now we are on nightlies
+# maintained by the RPM Software Management team.
+config_opts['bootstrap_image'] = 'quay.io/rpmsoftwaremanagement/fedora-dnf5:rawhide'
+config_opts['bootstrap_image_ready'] = True
 
 config_opts['description'] = 'Fedora Rawhide'
 

--- a/releng/release-notes-next/fedora-40-plus-bootstrap-ready.config
+++ b/releng/release-notes-next/fedora-40-plus-bootstrap-ready.config
@@ -1,0 +1,5 @@
+The Fedora Rawhide and Branched configurations have been updated to utilize
+bootstrap images `{% raw %}quay.io/rpmsoftwaremanagement/fedora-dnf5:{{ releasever }}{% endraw %}`
+for Fedora 40 and newer versions. These images come pre-installed with the
+`dnf5` and `dnf5-plugins` packages, allowing Mock to set `bootstrap_image_ready`
+and significantly expedite the environment preparation process.


### PR DESCRIPTION
At least temporarily, till the default Fedora images do not contain dnf5 and dnf5-plugins by default.

Fixes: #1336