### PR TITLE
bash-completion: add mock-parse-buildlog

### DIFF
--- a/mock/etc/bash_completion.d/mock
+++ b/mock/etc/bash_completion.d/mock
@@ -179,6 +179,31 @@ _mock()
 } &&
 complete -F _mock mock mock.py
 
+_mock_parse_buildlog()
+{
+    local cur prev cword split
+    _init_completion -s || return
+
+    case "$prev" in
+        -h|--help)
+            # no further arguments are accepted after the above arguments
+            return
+            ;;
+        -p|--path)
+            _filedir
+            return
+            ;;
+    esac
+
+    $split && return
+
+    if [[ $cword -eq 1 ]] ; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" )' -- "$cur" ) )
+        [[ $COMPREPLY == *= ]] && compopt -o nospace
+    fi
+} &&
+complete -F _mock_parse_buildlog mock-parse-buildlog mock-parse-buildlog.py
+
 # Local variables:
 # mode: shell-script
 # sh-basic-offset: 4

--- a/releng/release-notes-next/buildlog-parser-completion.bugfix
+++ b/releng/release-notes-next/buildlog-parser-completion.bugfix
@@ -1,0 +1,2 @@
+A missing bash completion script for `mock-parse-buildlog` command [has
+been added][PR#1353].


### PR DESCRIPTION
I have a feeling that no one is using mock-parse-buildlog, but we are installing `%{_datadir}/bash-completion/completions/mock-parse-buildlog`, which does nothing right now.