### PR TITLE
scm: Use bytes for compatibility with subprocess stdout

### DIFF
--- a/mock/py/mockbuild/scm.py
+++ b/mock/py/mockbuild/scm.py
@@ -114,14 +114,18 @@ class scmWorker(object):
         cwd_dir = util.pretty_getcwd()
         self.log.debug("Adjusting timestamps in %s", self.src_dir)
         os.chdir(self.src_dir)
-        proc = subprocess.Popen(['git', 'ls-files', '-z'], shell=False, stdout=subprocess.PIPE)
+        proc = subprocess.Popen(
+            ['git', 'ls-files', '-z'],
+            shell=False, stdout=subprocess.PIPE, universal_newlines=True,
+        )
         for f in proc.communicate()[0].split('\0')[:-1]:
             rev = subprocess.Popen(
-                ['git', 'rev-list', 'HEAD', f], shell=False, stdout=subprocess.PIPE
+                ['git', 'rev-list', 'HEAD', f],
+                shell=False, stdout=subprocess.PIPE, universal_newlines=True,
             ).stdout.readlines()[0].rstrip('\n')
             ts = subprocess.Popen(
-                ['git', 'show', '--pretty=format:%ai', '--abbrev-commit', rev, f],
-                shell=False, stdout=subprocess.PIPE
+                ['git', 'show', '--pretty=format:%ai', '--no-patch', rev, f],
+                shell=False, stdout=subprocess.PIPE, universal_newlines=True,
             ).stdout.readlines()[0].rstrip('\n')
             subprocess.Popen(['touch', '-d', ts, f], shell=False)
         os.chdir(cwd_dir)

--- a/releng/release-notes-next/scm-git_timestamps.bugfix
+++ b/releng/release-notes-next/scm-git_timestamps.bugfix
@@ -1,0 +1,2 @@
+The SCM plugin's option `git_timestamps` has been updated to work with Python 3
+and to handle Git repositories with non-Unicode data. ([PR#1355][])


### PR DESCRIPTION
I am getting the following type error when attempting to use SCM with Git timestamps on RHEL 9 and Fedora.  Can something like this be applied to fix it?

```
...
  File "/usr/lib/python3.9/site-packages/mockbuild/scm.py", line 118, in adjust_git_timestamps
    for f in proc.communicate()[0].split('\0')[:-1]:
TypeError: a bytes-like object is required, not 'str'
```