### PR TITLE
config: Replace Mageia 10 and Cauldron i586 configs with i686

### DIFF
--- a/mock-core-configs/etc/mock/mageia-10-i586.cfg
+++ b/mock-core-configs/etc/mock/mageia-10-i586.cfg
@@ -1,1 +1,0 @@
-mageia-cauldron-i586.cfg

--- a/mock-core-configs/etc/mock/mageia-10-i686.cfg
+++ b/mock-core-configs/etc/mock/mageia-10-i686.cfg
@@ -1,0 +1,1 @@
+mageia-cauldron-i686.cfg

--- a/mock-core-configs/etc/mock/mageia-cauldron-i686.cfg
+++ b/mock-core-configs/etc/mock/mageia-cauldron-i686.cfg
@@ -1,4 +1,4 @@
-config_opts['target_arch'] = 'i586'
+config_opts['target_arch'] = 'i686'
 config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
 
 include('templates/mageia-cauldron.tpl')

--- a/releng/release-notes-next/cauldron-i686.config
+++ b/releng/release-notes-next/cauldron-i686.config
@@ -1,0 +1,2 @@
+Add i686 configuration for Mageia Cauldron and Mageia 10, and remove
+corresponding i586 configurations ([PR#1360][]).


### PR DESCRIPTION
Mageia replaced i586 arch with i686 in Cauldron, and thus also for upcoming Mageia 10.