### PR TITLE
Do not create temporary Buildroot.tmpdir for disabled nosync

### DIFF
--- a/releng/release-notes-next/no-tmpdir-for-no-nosync.bugfix
+++ b/releng/release-notes-next/no-tmpdir-for-no-nosync.bugfix
@@ -1,0 +1,3 @@
+The `nosync` logic was preparing temporary directories even when
+`config_opts["nosync"] = False` (meaning nosync was disabled).  This logic has
+been optimized out.  Works around [issue#1351][].


### PR DESCRIPTION
Relates: #1362
Relates: #1351