### PR TITLE
always set ownership of homedir (but not recursively)

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -350,6 +350,8 @@ class Buildroot(object):
         # by the current user
         if prebuild:
             self.chown_home_dir()
+        else:
+            self.chown_home_dir(recursive=False)
 
         # mark the buildroot as initialized
         file_util.touch(self.make_chroot_path('.initialized'))
@@ -678,10 +680,10 @@ class Buildroot(object):
             file_util.mkdirIfAbsent(self.make_chroot_path(item))
 
     @traceLog()
-    def chown_home_dir(self):
+    def chown_home_dir(self, recursive=True):
         """ set ownership of homedir and subdirectories to mockbuild user """
         self.uid_manager.changeOwner(self.make_chroot_path(self.homedir),
-                                     recursive=True)
+                                     recursive=recursive)
 
     @traceLog()
     def prepare_installation_time_homedir(self):

--- a/releng/release-notes-next/chown-homedir.bugfix
+++ b/releng/release-notes-next/chown-homedir.bugfix
@@ -1,0 +1,7 @@
+In the [issue#1257][] it was suggested that we do not change recursively
+ownership every run. This was implemented and landed in Mock 5.5.
+But in the [issue#1364][] we found that for fresh chroots the homedir
+is not writable for unpriv user.
+We changed the behaviour that ownership of homedir is changed always (that was
+a behaviour prior 5.5 release) and the ownership is changed recursively only for
+rebuilds. 


### PR DESCRIPTION
Not setting the ownership caused problem when doing
  mock -r fedora-rawhide-x86_64 --chroot --unpriv "touch ~/test"
lets make sure that homedir is always writable but keep the recursion only in rebuild as was previously.

Fixes: #1364