### PR TITLE
CentOS Stream 8 went EOL and moved to vault

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -41,7 +41,7 @@ skip_if_unavailable=False
 [baseos]
 name=CentOS Stream $releasever - BaseOS
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
-baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False
@@ -49,7 +49,7 @@ skip_if_unavailable=False
 [appstream]
 name=CentOS Stream $releasever - AppStream
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
-baseurl=http://vault.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -63,14 +63,14 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [Stream-centosplus]
 name=CentOS-Stream - Plus
-baseurl=http://vault.centos.org/centos/$releasever-stream/centosplus/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/centosplus/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [cr]
 name=CentOS-$releasever - cr
-baseurl=http://vault.centos.org/centos/$releasever/cr/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever/cr/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -85,7 +85,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [extras]
 name=CentOS Stream $releasever - Extras
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
-baseurl=http://vault.centos.org/centos/$releasever-stream/extras/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -93,7 +93,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [powertools]
 name=CentOS Stream $releasever - PowerTools
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
-baseurl=http://vault.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -101,7 +101,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [rt]
 name=CentOS Stream $releasever - RealTime
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=RT&infra=$infra
-baseurl=http://vault.centos.org/centos/$releasever-stream/RT/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/RT/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -109,49 +109,49 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [ha]
 name=CentOS Stream $releasever - HighAvailability
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=HighAvailability&infra=$infra
-baseurl=http://vault.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-Devel]
 name=CentOS-Stream - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
-baseurl=http://vault.centos.org/centos/$releasever-stream/Devel/$basearch/os/
+baseurl=https://vault.centos.org/centos/$releasever-stream/Devel/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-BaseOS-source]
 name=CentOS-Stream - BaseOS Sources
-baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/Source/
+baseurl=https://vault.centos.org/centos/$releasever-stream/BaseOS/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-AppStream-source]
 name=CentOS-Stream - AppStream Sources
-baseurl=http://vault.centos.org/centos/$releasever-stream/AppStream/Source/
+baseurl=https://vault.centos.org/centos/$releasever-stream/AppStream/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-PowerTools-source]
 name=CentOS-Stream - PowerTools Sources
-baseurl=http://vault.centos.org/centos/$releasever-stream/PowerTools/Source/
+baseurl=https://vault.centos.org/centos/$releasever-stream/PowerTools/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-extras-source]
 name=CentOS-Stream - Extras Sources
-baseurl=http://vault.centos.org/centos/$releasever-stream/extras/Source/
+baseurl=https://vault.centos.org/centos/$releasever-stream/extras/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-centosplus-source]
 name=CentOS-Stream - Plus Sources
-baseurl=http://vault.centos.org/centos/$releasever-stream/centosplus/Source/
+baseurl=https://vault.centos.org/centos/$releasever-stream/centosplus/Source/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -40,16 +40,16 @@ skip_if_unavailable=False
 
 [baseos]
 name=CentOS Stream $releasever - BaseOS
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
+baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False
 
 [appstream]
 name=CentOS Stream $releasever - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
+baseurl=http://mirror.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -84,32 +84,32 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [extras]
 name=CentOS Stream $releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/extras/$basearch/os/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
+baseurl=http://mirror.centos.org/centos/$releasever-stream/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [powertools]
 name=CentOS Stream $releasever - PowerTools
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
+baseurl=http://mirror.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [rt]
 name=CentOS Stream $releasever - RealTime
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=RT&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/RT/$basearch/os/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=RT&infra=$infra
+baseurl=http://mirror.centos.org/centos/$releasever-stream/RT/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [ha]
 name=CentOS Stream $releasever - HighAvailability
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=HighAvailability&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=HighAvailability&infra=$infra
+baseurl=http://mirror.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-8.tpl
@@ -41,7 +41,7 @@ skip_if_unavailable=False
 [baseos]
 name=CentOS Stream $releasever - BaseOS
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra
-baseurl=http://mirror.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/BaseOS/$basearch/os/
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 gpgcheck=1
 skip_if_unavailable=False
@@ -49,7 +49,7 @@ skip_if_unavailable=False
 [appstream]
 name=CentOS Stream $releasever - AppStream
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
-baseurl=http://mirror.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -63,14 +63,14 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [Stream-centosplus]
 name=CentOS-Stream - Plus
-baseurl=http://mirror.centos.org/centos/$releasever-stream/centosplus/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/centosplus/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [cr]
 name=CentOS-$releasever - cr
-baseurl=http://mirror.centos.org/centos/$releasever/cr/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever/cr/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -85,7 +85,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [extras]
 name=CentOS Stream $releasever - Extras
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=extras&infra=$infra
-baseurl=http://mirror.centos.org/centos/$releasever-stream/extras/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -93,7 +93,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [powertools]
 name=CentOS Stream $releasever - PowerTools
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
-baseurl=http://mirror.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -101,7 +101,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [rt]
 name=CentOS Stream $releasever - RealTime
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=RT&infra=$infra
-baseurl=http://mirror.centos.org/centos/$releasever-stream/RT/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/RT/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
@@ -109,14 +109,14 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [ha]
 name=CentOS Stream $releasever - HighAvailability
 #mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=HighAvailability&infra=$infra
-baseurl=http://mirror.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
 [Stream-Devel]
 name=CentOS-Stream - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
-baseurl=http://mirror.centos.org/centos/$releasever-stream/Devel/$basearch/os/
+baseurl=http://vault.centos.org/centos/$releasever-stream/Devel/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -4,7 +4,7 @@
 
 Name:       mock-core-configs
 Version:    40.4.post1
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Mock core config files basic chroots
 
 License:    GPL-2.0-or-later


### PR DESCRIPTION
for solve use baseurl

```
INFO: mock.py version 5.6 starting (python version = 3.12.3, NVR = mock-5.6-1.fc39), args: /usr/libexec/mock/mock -r centos-stream+epel-next-8-x86_64 --init
Start(bootstrap): init plugins
INFO: selinux disabled
Finish(bootstrap): init plugins
Start: init plugins
INFO: selinux disabled
Finish: init plugins
INFO: Signal handler active
Start: run
Start: clean chroot
Finish: clean chroot
Mock Version: 5.6
INFO: Mock Version: 5.6
Start(bootstrap): chroot init
INFO: calling preinit hooks
INFO: enabled root cache
INFO: enabled package manager cache
Start(bootstrap): cleaning package manager metadata
Finish(bootstrap): cleaning package manager metadata
INFO: Guessed host environment type: unknown
INFO: Using bootstrap image: quay.io/centos/centos:stream8
INFO: Pulling image: quay.io/centos/centos:stream8
INFO: Copy content of container quay.io/centos/centos:stream8 to /var/lib/mock/centos-stream+epel-next-8-x86_64-bootstrap/root
INFO: Checking that quay.io/centos/centos:stream8 image matches host's architecture
INFO: mounting quay.io/centos/centos:stream8 with podman image mount
INFO: image quay.io/centos/centos:stream8 as /var/lib/containers/storage/overlay/6ee281da9ae87eca8f44934d7773323021901ceb8f56a5ec52edbbdaa1d5de23/merged
INFO: umounting image quay.io/centos/centos:stream8 (/var/lib/containers/storage/overlay/6ee281da9ae87eca8f44934d7773323021901ceb8f56a5ec52edbbdaa1d5de23/merged) with podman image umount
INFO: Package manager dnf detected and used (fallback)
INFO: Bootstrap image not marked ready
Start(bootstrap): installing dnf tooling
No matches found for the following disable plugin patterns: local, spacewalk, versionlock
CentOS Stream 8 - BaseOS                         95  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'baseos': Cannot prepare internal mirrorlist: No URLs in mirrorlist
ERROR: Command failed: 
 # /usr/bin/systemd-nspawn -q -M dac8fa49d5af4f79b5b8413e0e77fb11 -D /var/lib/mock/centos-stream+epel-next-8-x86_64-bootstrap/root -a --console=pipe --setenv=TERM=vt100 --setenv=SHELL=/bin/bash --setenv=HOME=/var/lib/mock/centos-stream+epel-next-8-x86_64-bootstrap/root/installation-homedir --setenv=HOSTNAME=mock --setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin '--setenv=PROMPT_COMMAND=printf "\033]0;<mock-chroot>\007"' '--setenv=PS1=<mock-chroot> \s-\v\$ ' --setenv=LANG=C.UTF-8 --setenv=LC_MESSAGES=C.UTF-8 --resolv-conf=off /usr/bin/dnf-3 --releasever 8 --setopt=deltarpm=False --setopt=allow_vendor_change=yes --allowerasing --disableplugin=local --disableplugin=spacewalk --disableplugin=versionlock install python3-dnf python3-dnf-plugins-core
No matches found for the following disable plugin patterns: local, spacewalk, versionlock
CentOS Stream 8 - BaseOS                         95  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'baseos': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```