### PR TITLE
Enable CentOS 10, RHEL 10, AlmaLinux 10, Oracle Linux 10, and Circle Linux builds

### DIFF
--- a/mock-core-configs/etc/mock/alma+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-aarch64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-ppc64le.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-s390x.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-s3100x.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-x86_64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/almalinux-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-aarch64'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/almalinux-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-ppc64le'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/almalinux-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-s390x.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-s390x'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/almalinux-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-x86_64'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-aarch64.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-aarch64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-ppc64le.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-ppc64le'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-s390x.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-s390x'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-x86_64.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-x86_64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-10-aarch64.cfg
@@ -1,0 +1,9 @@
+config_opts["koji_primary_repo"] = "epel-next"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+include('templates/epel-next-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-next-10-aarch64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL Next'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-10-ppc64le.cfg
@@ -1,0 +1,9 @@
+config_opts["koji_primary_repo"] = "epel-next"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+include('templates/epel-next-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-next-10-ppc64le'
+config_opts['description'] = 'CentOS Stream 10 + EPEL Next'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-10-s390x.cfg
@@ -1,0 +1,9 @@
+config_opts["koji_primary_repo"] = "epel-next"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+include('templates/epel-next-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-next-10-s390x'
+config_opts['description'] = 'CentOS Stream 10 + EPEL Next'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-next-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-next-10-x86_64.cfg
@@ -1,0 +1,9 @@
+config_opts["koji_primary_repo"] = "epel-next"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+include('templates/epel-next-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-next-10-x86_64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL Next'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/circlelinux+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/circlelinux+epel-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('circlelinux-10-aarch64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "circle+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Circle Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/circlelinux+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/circlelinux+epel-10-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('circlelinux-10-ppc64le.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "circle+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Circle Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/circlelinux+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/circlelinux+epel-10-s390x.cfg
@@ -1,0 +1,5 @@
+include('circlelinux-10-s3100x.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "circle+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Circle Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/circlelinux+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/circlelinux+epel-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('circlelinux-10-x86_64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "circle+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Circle Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/circlelinux-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/circlelinux-10-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/circlelinux-10.tpl')
+
+config_opts['root'] = 'circleinux-10-aarch64'
+config_opts['description'] = 'Circle Linux 10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/circlelinux-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/circlelinux-10-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/circlelinux-10.tpl')
+
+config_opts['root'] = 'circlelinux-10-ppc64le'
+config_opts['description'] = 'Circle Linux 10'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/circlelinux-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/circlelinux-10-s390x.cfg
@@ -1,0 +1,6 @@
+include('templates/circlelinux-10.tpl')
+
+config_opts['root'] = 'circlelinux-10-s390x'
+config_opts['description'] = 'Circle Linux 10'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/circlelinux-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/circlelinux-10-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/circlelinux-10.tpl')
+
+config_opts['root'] = 'circlelinux-10-x86_64'
+config_opts['description'] = 'Circle Linux 10'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/oraclelinux+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-10-aarch64.cfg
@@ -1,0 +1,7 @@
+include('templates/oraclelinux-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'oraclelinux+epel-10-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+config_opts['description'] = 'Oracle Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux+epel-10-x86_64.cfg
@@ -1,0 +1,7 @@
+include('templates/oraclelinux-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'oraclelinux+epel-10-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['description'] = 'Oracle Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/oraclelinux-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-10.tpl')
+
+config_opts['root'] = 'oraclelinux-10-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/oraclelinux-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/oraclelinux-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/oraclelinux-10.tpl')
+
+config_opts['root'] = 'oraclelinux-10-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rhel+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('rhel-10-aarch64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rhel+epel-10-{{ target_arch }}"
+config_opts['description'] = 'RHEL 10 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-10-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('rhel-10-ppc64le.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rhel+epel-10-{{ target_arch }}"
+config_opts['description'] = 'RHEL 10 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-10-s390x.cfg
@@ -1,0 +1,5 @@
+include('rhel-10-s3100x.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rhel+epel-10-{{ target_arch }}"
+config_opts['description'] = 'RHEL 10 + EPEL'

--- a/mock-core-configs/etc/mock/rhel+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel+epel-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('rhel-10-x86_64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rhel+epel-10-{{ target_arch }}"
+config_opts['description'] = 'RHEL 10 + EPEL'

--- a/mock-core-configs/etc/mock/rhel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rhel-10-aarch64.cfg
@@ -1,0 +1,4 @@
+include('templates/rhel-10.tpl')
+
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rhel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rhel-10-ppc64le.cfg
@@ -1,0 +1,4 @@
+include('templates/rhel-10.tpl')
+
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rhel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/rhel-10-s390x.cfg
@@ -1,0 +1,4 @@
+include('templates/rhel-10.tpl')
+
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/rhel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rhel-10-x86_64.cfg
@@ -1,0 +1,4 @@
+include('templates/rhel-10.tpl')
+
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/rocky+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-aarch64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-ppc64le.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-s390x.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-s3900x.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-x86_64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-aarch64'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rocky-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-ppc64le'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rocky-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-s390x.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-s3900x'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 's3900x'
+config_opts['legal_host_arches'] = ('s3900x',)

--- a/mock-core-configs/etc/mock/rocky-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-x86_64'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/almalinux-10.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-10.tpl
@@ -1,0 +1,151 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils redhat-release findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'el10.alma'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:10'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el10
+user_agent={{ user_agent }}
+
+
+[baseos]
+name=AlmaLinux $releasever - BaseOS
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+skip_if_unavailable=False
+
+[appstream]
+name=AlmaLinux $releasever - AppStream
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[crb]
+name=AlmaLinux $releasever - CRB
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[extras]
+name=AlmaLinux $releasever - Extras
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[devel]
+name=AlmaLinux $releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/devel
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/devel/$basearch/os/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[baseos-debuginfo]
+name=AlmaLinux $releasever - BaseOS debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[appstream-debuginfo]
+name=AlmaLinux $releasever - AppStream debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[crb-debuginfo]
+name=AlmaLinux $releasever - CRB debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[extras-debuginfo]
+name=AlmaLinux $releasever - Extras debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[devel-debuginfo]
+name=AlmaLinux $releasever - Devel debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/devel-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/devel/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[baseos-source]
+name=AlmaLinux $releasever - BaseOS Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[appstream-source]
+name=AlmaLinux $releasever - AppStream Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[crb-source]
+name=AlmaLinux $releasever - CRB Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[extras-source]
+name=AlmaLinux $releasever - Extras Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[devel-source]
+name=AlmaLinux $releasever - Devel Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/devel-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/devel/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+"""

--- a/mock-core-configs/etc/mock/templates/circlelinux-10.tpl
+++ b/mock-core-configs/etc/mock/templates/circlelinux-10.tpl
@@ -1,0 +1,251 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils redhat-release findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'el10'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/cclinux/circlelinux:10'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el10
+user_agent={{ user_agent }}
+
+
+[baseos]
+name=Circle Linux $releasever - BaseOS
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[appstream]
+name=Circle Linux $releasever - AppStream
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[crb]
+name=Circle Linux $releasever - CRB
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/CRB/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[extras]
+name=Circle Linux $releasever - Extras
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[devel]
+name=Circle Linux $releasever - Devel WARNING! FOR BUILDROOT USE ONLY!
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=devel-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[highavailability]
+name=Circle Linux $releasever - High Availability
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/HighAvailability/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[resilientstorage]
+name=Circle Linux $releasever - Resilient Storage
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/ResilientStorage/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[nfv]
+name=Circle Linux $releasever - NFV
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=NFV-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/NFV/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[rt]
+name=Circle Linux $releasever - Realtime
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/RT/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[baseos-debug]
+name=Circle Linux $releasever - BaseOS - Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/BaseOS/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[baseos-source]
+name=Circle Linux $releasever - BaseOS - Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=source&repo=BaseOS-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/BaseOS/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[appstream-debug]
+name=Circle Linux $releasever - AppStream - Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/AppStream/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[appstream-source]
+name=Circle Linux $releasever - AppStream - Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=source&repo=AppStream-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/AppStream/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[crb-debug]
+name=Circle Linux $releasever - CRB - Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/CRB/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[crb-source]
+name=Circle Linux $releasever - CRB - Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=source&repo=CRB-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/CRB/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[extras-debug]
+name=Circle Linux $releasever - Extras Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/extras/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[extras-source]
+name=Circle Linux $releasever - Extras Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/extras/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[highavailability-debug]
+name=Circle Linux $releasever - High Availability - Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/HighAvailability/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[highavailability-source]
+name=Circle Linux $releasever - High Availability - Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=source&repo=HighAvailability-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/HighAvailability/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[resilientstorage-debug]
+name=Circle Linux $releasever - Resilient Storage - Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/ResilientStorage/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[resilientstorage-source]
+name=Circle Linux $releasever - Resilient Storage - Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=source&repo=ResilientStorage-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/ResilientStorage/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[nfv-debug]
+name=Circle Linux $releasever - NFV Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=NFV-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/NFV/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[nfv-source]
+name=Circle Linux $releasever - NFV Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=NFV-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/NFV/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[rt-debug]
+name=Circle Linux $releasever - Realtime Debug
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-debug
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/RT/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+[rt-source]
+name=Circle Linux $releasever - Realtime Source
+mirrorlist=https://mirrorlist.cclinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-source
+#baseurl=http://mirror.cclinux.org/$contentdir/$releasever/RT/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/circle/RPM-GPG-KEY-circleofficial
+
+
+"""

--- a/mock-core-configs/etc/mock/templates/oraclelinux-10.tpl
+++ b/mock-core-configs/etc/mock/templates/oraclelinux-10.tpl
@@ -1,0 +1,68 @@
+config_opts['chroot_setup_cmd'] = 'install tar redhat-rpm-config redhat-release oraclelinux-release which xz sed make bzip2 gzip coreutils unzip diffutils cpio bash gawk rpm-build info patch util-linux findutils grep glibc-minimal-langpack'
+config_opts['dist'] = 'el10'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'container-registry.oracle.com/os/oraclelinux:10'
+config_opts['description'] = 'Oracle Linux 10'
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el10
+user_agent={{ user_agent }}
+
+# repos
+
+[ol10_baseos_latest]
+name=Oracle Linux 10 BaseOS Latest ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL10/baseos/latest/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol10
+gpgcheck=1
+enabled=1
+
+[ol10_appstream]
+name=Oracle Linux 10 Application Stream ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL10/appstream/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol10
+gpgcheck=1
+enabled=1
+
+[ol10_codeready_builder]
+name=Oracle Linux 10 CodeReady Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL10/codeready/builder/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol10
+gpgcheck=1
+enabled=1
+
+[ol10_distro_builder]
+name=Oracle Linux 10 Distro Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL10/distro/builder/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol10
+gpgcheck=1
+enabled=0
+
+{% if target_arch in ['x86_64'] %}
+[ol10_UEKR7]
+name=Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL10/UEKR7/$basearch/
+gpgkey=file:///usr/share/distribution-gpg-keys/oraclelinux/RPM-GPG-KEY-oracle-ol10
+gpgcheck=1
+enabled=0
+{% endif %}
+
+"""

--- a/mock-core-configs/etc/mock/templates/rhel-10.tpl
+++ b/mock-core-configs/etc/mock/templates/rhel-10.tpl
@@ -1,0 +1,66 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils redhat-release findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['releasever'] = '10'
+config_opts['dist'] = 'el{{ releasever }}'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['package_manager'] = 'dnf'
+config_opts['bootstrap_image'] = 'registry.access.redhat.com/ubi{{ releasever }}/ubi'
+config_opts['bootstrap_image_ready'] = True
+config_opts['description'] = 'RHEL {{ releasever }}'
+
+config_opts['dnf_install_command'] += ' subscription-manager'
+config_opts['yum_install_command'] += ' subscription-manager'
+
+config_opts['root'] = 'rhel-{{ releasever }}-{{ target_arch }}'
+
+config_opts['redhat_subscription_required'] = True
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=1
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+module_platform_id=platform:el{{ releasever }}
+protected_packages=
+user_agent={{ user_agent }}
+
+# repos
+[baseos]
+name = Red Hat Enterprise Linux - BaseOS
+baseurl = https://cdn.redhat.com/content/dist/rhel10/$releasever/$basearch/baseos/os/
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey = file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat{{ releasever }}-release
+skip_if_unavailable=False
+
+[appstream]
+name = Red Hat Enterprise Linux - AppStream
+baseurl = https://cdn.redhat.com/content/dist/rhel10/$releasever/$basearch/appstream/os/
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey = file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat{{ releasever }}-release
+skip_if_unavailable=False
+
+[codeready-builder]
+name = Red Hat Enterprise Linux - CodeReady Linux Builder
+baseurl = https://cdn.redhat.com/content/dist/rhel10/$releasever/$basearch/codeready-builder/os/
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = /etc/pki/entitlement/{{ redhat_subscription_key_id }}-key.pem
+sslclientcert = /etc/pki/entitlement/{{ redhat_subscription_key_id }}.pem
+gpgkey = file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat{{ releasever }}-release
+skip_if_unavailable=False
+"""

--- a/mock-core-configs/etc/mock/templates/rocky-10.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-10.tpl
@@ -1,0 +1,255 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils redhat-release findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'el10'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:10'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el10
+user_agent={{ user_agent }}
+
+
+[baseos]
+name=Rocky Linux $releasever - BaseOS
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[appstream]
+name=Rocky Linux $releasever - AppStream
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[crb]
+name=Rocky Linux $releasever - CRB
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[extras]
+name=Rocky Linux $releasever - Extras
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[devel]
+name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT ONLY DO NOT LEAVE ENABLED
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=devel-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[highavailability]
+name=Rocky Linux $releasever - High Availability
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[resilientstorage]
+name=Rocky Linux $releasever - Resilient Storage
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[nfv]
+name=Rocky Linux $releasever - NFV
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=NFV-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/NFV/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[rt]
+name=Rocky Linux $releasever - Realtime
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/RT/$basearch/os/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[baseos-debug]
+name=Rocky Linux $releasever - BaseOS - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[baseos-source]
+name=Rocky Linux $releasever - BaseOS - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=BaseOS-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[appstream-debug]
+name=Rocky Linux $releasever - AppStream - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[appstream-source]
+name=Rocky Linux $releasever - AppStream - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=AppStream-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[crb-debug]
+name=Rocky Linux $releasever - CRB - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[crb-source]
+name=Rocky Linux $releasever - CRB - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=CRB-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[extras-debug]
+name=Rocky Linux $releasever - Extras Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[extras-source]
+name=Rocky Linux $releasever - Extras Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[highavailability-debug]
+name=Rocky Linux $releasever - High Availability - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[highavailability-source]
+name=Rocky Linux $releasever - High Availability - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=HighAvailability-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/HighAvailability/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[resilientstorage-debug]
+name=Rocky Linux $releasever - Resilient Storage - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[resilientstorage-source]
+name=Rocky Linux $releasever - Resilient Storage - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=ResilientStorage-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/ResilientStorage/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[nfv-debug]
+name=Rocky Linux $releasever - NFV Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/NFV/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[nfv-source]
+name=Rocky Linux $releasever - NFV Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/NFV/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[rt-debug]
+name=Rocky Linux $releasever - Realtime Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-debug$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/RT/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[rt-source]
+name=Rocky Linux $releasever - Realtime Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-$releasever-source$rltype
+#baseurl=http://dl.rockylinux.org/$contentdir/$releasever/RT/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+
+"""


### PR DESCRIPTION
CentOS 10 has been published in the upstream repos. I enabled each RHEL variant's release of version 10 with a different pull request, so they can be cherry picked as needed.