### PR TITLE
configs: Fedora 41+ configuration images are "dnf5 ready"

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-branched.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-branched.tpl
@@ -13,6 +13,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['package_manager'] = '{% if releasever|int >= 40 %}dnf5{% else %}dnf{% endif %}'
 
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:{{ releasever }}'
+config_opts['bootstrap_image_ready'] = int(config_opts['releasever']) >= 41
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -13,10 +13,7 @@ config_opts['releasever'] = '41'
 config_opts['package_manager'] = 'dnf5'
 
 config_opts['bootstrap_image'] = 'registry.fedoraproject.org/fedora:rawhide'
-
-# For F41+ there's https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5 so
-# once done, re-revert https://pagure.io/fedora-kickstarts/c/f7bf98d3af6d655c6d64ba9c8d2f88cbffbbb06d?branch=main
-#config_opts['bootstrap_image_ready'] = True
+config_opts['bootstrap_image_ready'] = True
 
 config_opts['description'] = 'Fedora Rawhide'
 

--- a/releng/release-notes-next/rawhide-bootstrap-image-ready.config
+++ b/releng/release-notes-next/rawhide-bootstrap-image-ready.config
@@ -1,0 +1,9 @@
+The Fedora Rawhide configuration (F41+) has been updated to use the
+`bootstrap_image_ready = True` configuration.  The default container images are
+[already shipped with the `dnf5-plugins` package](https://pagure.io/fedora-kiwi-descriptions/pull-request/63).
+
+This means we use the container image "as is" to bootstrap the DNF5 stack
+without installing any additional packages into the prepared bootstrap chroot.
+Consequently, the bootstrap preparation is much faster (bootstrap preparation
+basically equals the image download, if not pre-downloaded, and its
+"extraction").


### PR DESCRIPTION
The latest Rawhide images already have dnf5-plugins package:
https://pagure.io/fedora-kiwi-descriptions/pull-request/63