### PR TITLE
Add hashdir option to ccache plugin

### DIFF
--- a/docs/Plugin-CCache.md
+++ b/docs/Plugin-CCache.md
@@ -15,6 +15,7 @@ The ccache plugin is enabled by default and has the following values built-in:
     config_opts['plugin_conf']['ccache_opts']['max_cache_size'] = '4G'
     config_opts['plugin_conf']['ccache_opts']['compress'] = None
     config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/u%(chrootuid)s/"
+    config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
 
 To turn on ccache compression, use the following in a config file:
 

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -238,6 +238,7 @@
 # config_opts['plugin_conf']['ccache_opts']['max_cache_size'] = '4G'
 # config_opts['plugin_conf']['ccache_opts']['compress'] = None
 # config_opts['plugin_conf']['ccache_opts']['dir'] = "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/"
+# config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
 # config_opts['plugin_conf']['yum_cache_enable'] = True
 # config_opts['plugin_conf']['yum_cache_opts'] = {}
 # config_opts['plugin_conf']['yum_cache_opts']['max_age_days'] = 30

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -126,7 +126,8 @@ def setup_default_config_opts():
         'ccache_opts': {
             'max_cache_size': "4G",
             'compress': None,
-            'dir': "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/"},
+            'dir': "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/",
+            'hashdir': True},
         'yum_cache_enable': True,
         'yum_cache_opts': {
             'max_age_days': 30,

--- a/mock/py/mockbuild/plugins/ccache.py
+++ b/mock/py/mockbuild/plugins/ccache.py
@@ -56,6 +56,10 @@ class CCache(object):
         envupd = {"CCACHE_DIR": "/var/tmp/ccache", "CCACHE_UMASK": "002"}
         if self.ccache_opts.get('compress') is not None:
             envupd["CCACHE_COMPRESS"] = str(self.ccache_opts['compress'])
+        if self.ccache_opts.get('hashdir'):
+            envupd["CCACHE_HASHDIR"] = "1"
+        else:
+            envupd["CCACHE_NOHASHDIR"] = "1"
         self.buildroot.env.update(envupd)
 
         file_util.mkdirIfAbsent(self.buildroot.make_chroot_path('/var/tmp/ccache'))

--- a/releng/release-notes-next/hashdir.feature
+++ b/releng/release-notes-next/hashdir.feature
@@ -1,0 +1,7 @@
+A new option `hashdir` has been [added][PR#1399] to the ccache plugin. Setting
+it to false the build working directory from the hash used to distinguish two
+compilations when generating debuginfo. While this allows the compiler cache
+to be shared across different package NEVRs, it might cause the debuginfo to be
+incorrect.
+The option can be used for issue bisecting if running the debugger is
+unnecessary. ([issue#1395][])


### PR DESCRIPTION
Setting it to false allows ccache to be shared across different package NEVRs, but the debuginfo files may contain incorrect information in exchange:

https://ccache.dev/manual/4.10.html#config_hash_dir

Fixes #1395 