### PR TITLE
Fix the Testing Farm testsuite

### DIFF
--- a/mock/integration-tests/22-rootdir.tst
+++ b/mock/integration-tests/22-rootdir.tst
@@ -7,14 +7,17 @@ fi
 . "${TESTDIR}/functions"
 set -e
 
-TMPDIR=$(mktemp -d)
-cleanup() { rm -rf "$TMPDIR"; }
+# creating special files (e.g. /dev/null doesn't work below tmpfs)
+WORKDIR=$(mktemp -d -p "$HOME")
+
+cleanup() { rm -rf "$WORKDIR"; }
 trap cleanup EXIT
 
 header "mock with --rootdir option"
 
 for isolation in simple nspawn; do
-    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$TMPDIR --scrub=chroot"
-    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$TMPDIR --scrub=bootstrap"
-    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$TMPDIR --bootstrap-chroot ${TESTDIR}/test-C-1.1-0.src.rpm"
+    rootdir=$WORKDIR/$isolation
+    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$rootdir --scrub=chroot"
+    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$rootdir --scrub=bootstrap"
+    runcmd "$MOCKCMD --isolation=$isolation --rootdir=$rootdir --bootstrap-chroot ${TESTDIR}/test-C-1.1-0.src.rpm"
 done

--- a/mock/integration-tests/runtests.sh
+++ b/mock/integration-tests/runtests.sh
@@ -44,15 +44,7 @@ else
     MOCKSRPM=$1
 fi
 
-if [ -e /usr/bin/dnf ]; then
-    header "pre-populating the cache (DNF)"
-    runcmd "$MOCKCMD --init --dnf"
-    header "clean up"
-    runcmd "$MOCKCMD --offline --clean"
-else
-    header "pre-populating the cache (YUM)"
-    runcmd "$MOCKCMD --init"
-fi
+runcmd "$MOCKCMD --init"
 header "installing dependencies for $MOCKSRPM"
 runcmd "$MOCKCMD --disable-plugin=tmpfs --installdeps $MOCKSRPM"
 if [ ! -e $CHROOT/usr/include/python* ]; then


### PR DESCRIPTION
Mock has a build-in abstraction for in-bootstrap DNF version (or YUM), there's no need to check if DNF exists on host (this whole dropped test code comes from the pre-bootstrap era).