### PR TITLE
Add `debug` option to the ccache plugin

### DIFF
--- a/docs/Plugin-CCache.md
+++ b/docs/Plugin-CCache.md
@@ -16,6 +16,7 @@ The ccache plugin is enabled by default and has the following values built-in:
     config_opts['plugin_conf']['ccache_opts']['compress'] = None
     config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/u%(chrootuid)s/"
     config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
+    config_opts['plugin_conf']['ccache_opts']['debug'] = False
 
 To turn on ccache compression, use the following in a config file:
 
@@ -30,4 +31,8 @@ incorrect.
 The option can be used for issue bisecting if running the debugger is
 unnecessary. ([issue 1395][]https://github.com/rpm-software-management/mock/issues/1395)
 See [ccache documentation](https://ccache.dev/manual/4.10.html#config_hash_dir).
+This option is available since Mock 5.7.
+
+Setting `debug` to `True` creates per-object debug files that are helpful when debugging unexpected cache misses.
+See [ccache documentation](https://ccache.dev/manual/4.10.html#config_debug).
 This option is available since Mock 5.7.

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -242,6 +242,7 @@
 # config_opts['plugin_conf']['ccache_opts']['compress'] = None
 # config_opts['plugin_conf']['ccache_opts']['dir'] = "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/"
 # config_opts['plugin_conf']['ccache_opts']['hashdir'] = True
+# config_opts['plugin_conf']['ccache_opts']['debug'] = False
 # config_opts['plugin_conf']['yum_cache_enable'] = True
 # config_opts['plugin_conf']['yum_cache_opts'] = {}
 # config_opts['plugin_conf']['yum_cache_opts']['max_age_days'] = 30

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -128,7 +128,9 @@ def setup_default_config_opts():
             'max_cache_size': "4G",
             'compress': None,
             'dir': "{{cache_topdir}}/{{root}}/ccache/u{{chrootuid}}/",
-            'hashdir': True},
+            'hashdir': True,
+            'debug': False,
+        },
         'yum_cache_enable': True,
         'yum_cache_opts': {
             'max_age_days': 30,

--- a/mock/py/mockbuild/plugins/ccache.py
+++ b/mock/py/mockbuild/plugins/ccache.py
@@ -60,6 +60,10 @@ class CCache(object):
             envupd["CCACHE_HASHDIR"] = "1"
         else:
             envupd["CCACHE_NOHASHDIR"] = "1"
+        if self.ccache_opts.get('debug'):
+            envupd["CCACHE_DEBUG"] = "1"
+        else:
+            envupd["CCACHE_NODEBUG"] = "1"
         self.buildroot.env.update(envupd)
 
         file_util.mkdirIfAbsent(self.buildroot.make_chroot_path('/var/tmp/ccache'))

--- a/releng/release-notes-next/ccache_debug.feature
+++ b/releng/release-notes-next/ccache_debug.feature
@@ -1,0 +1,4 @@
+A new option `debug` has been [added][PR#1408] to the ccache plugin. Setting
+it to `True` creates per-object debug files that are helpful when debugging
+unexpected cache misses.
+https://ccache.dev/manual/4.10.html#config_debug


### PR DESCRIPTION
Setting it to `True` creates per-object debug files that are helpful when debugging unexpected cache misses.

https://ccache.dev/manual/4.10.html#config_debug