### PR TITLE
Mock/buildroot: respect nspawn_args when bootstrapping chroot

### DIFF
--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -137,6 +137,11 @@ class Buildroot(object):
         self._setup_nspawn_fuse_device()
         self._setup_nspawn_loop_devices()
 
+    def _get_nspawn_args(self):
+        nspawn_args = []
+        if util.USE_NSPAWN:
+            nspawn_args.extend(self.config['nspawn_args'])
+        return nspawn_args
 
     def set_package_manager(self, fallback=None):
         """
@@ -371,7 +376,8 @@ class Buildroot(object):
         """
         if self.bootstrap_buildroot:
             with self.mounts.buildroot_in_bootstrap_mounted():
-                return self.bootstrap_buildroot.doChroot(command, *args, **kwargs)
+                return self.bootstrap_buildroot.doChroot(
+                    command, nspawn_args=self._get_nspawn_args(), *args, **kwargs)
 
         return util.do_with_status(command, *args, **kwargs)
 

--- a/releng/release-notes-next/nspawn-args-chroot-bootstrap.bugfix
+++ b/releng/release-notes-next/nspawn-args-chroot-bootstrap.bugfix
@@ -1,0 +1,4 @@
+Previously, the 'nspawn_args' configuration value was not used when executing
+the systemd-nspawn command during the chroot bootstrapping. 'nspawn_args' are
+now used during the chroot bootstrapping in case systemd-nspawn isolation is
+used.


### PR DESCRIPTION
The 'nspawn_args' configuration value was not used when executing the systemd-nspawn command during the chroot bootstrapping. Make sure that the value is used during the chroot bootstrapping in case systemd-nspawn isolation is used.

This issue was found when trying to workaround an issue [1] when SELinux policy forbid systemd-machine to create a varlink socket and thus start. This resulted in systemd-nspawn not being able to register a machine. To workaround this, I added the following snippet to the configuration:

```
config_opts['nspawn_args'] = ['--register=no']
```

so that systemd-nspawn does not try to register the machine with systemd-machine. However, this had no effect. I could see that the argument was not used when executing systemd-nspawn and it still failed.

[1] https://issues.redhat.com/browse/RHEL-49567