### PR TITLE
configs: drop fedora-eln-i386

### DIFF
--- a/mock-core-configs/etc/mock/fedora-eln-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-eln-i386.cfg
@@ -1,5 +1,0 @@
-config_opts['target_arch'] = 'i686'
-config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
-
-include('templates/fedora-eln.tpl')
-config_opts['description'] = 'Fedora ELN'

--- a/releng/release-notes-next/fedora-eln-i386.config
+++ b/releng/release-notes-next/fedora-eln-i386.config
@@ -1,0 +1,2 @@
+The Fedora ELN ix86 config has been removed, as 32-bit multilibs are no 
+longer built for ELN.


### PR DESCRIPTION
ELN has dropped ix86 multilib builds: https://pagure.io/releng/issue/12171