### PR TITLE
Add CentOS Stream 10 + EPEL 10 configs

### DIFF
--- a/mock-core-configs/etc/mock/centos-stream+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-aarch64.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-aarch64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-ppc64le.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-ppc64le'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-s390x.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-s3100x'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 's3100x'
+config_opts['legal_host_arches'] = ('s3100x',)

--- a/mock-core-configs/etc/mock/centos-stream+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/centos-stream+epel-10-x86_64.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+include('templates/centos-stream-10.tpl')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = 'centos-stream+epel-10-x86_64'
+config_opts['description'] = 'CentOS Stream 10 + EPEL'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/epel-10.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-10.tpl
@@ -1,0 +1,11 @@
+config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
+
+config_opts['dnf.conf'] += """
+
+[local]
+name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel10.0-build/latest/$basearch/
+cost=2000
+enabled=1
+skip_if_unavailable=False
+"""

--- a/releng/release-notes-next/c10s+epel.config
+++ b/releng/release-notes-next/c10s+epel.config
@@ -1,0 +1,2 @@
+The "early" CentOS Stream 10 + EPEL 10 configuration files have been added,
+[issue#1421][].  These chroots only work with Fedora EPEL Koji buildroots.


### PR DESCRIPTION
These work with Koji EPEL buildroot only for now since there are no composes, yet.

Fixes: #1421