### PR TITLE
Release mock-core-configs v41.1

### DIFF
--- a/.tito/packages/mock-core-configs
+++ b/.tito/packages/mock-core-configs
@@ -1,1 +1,1 @@
-40.6-1 mock-core-configs/
+41.1-1 mock-core-configs/

--- a/docs/Release-Notes-Configs-41.1.md
+++ b/docs/Release-Notes-Configs-41.1.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: Release Notes - Mock Configs 41.1
+---
+
+## [Release Configs 41.1](https://rpm-software-management.github.io/mock/Release-Notes-Configs-41.1) - 2024-08-14
+
+
+### Mock Core Configs changes
+
+- Configuration files for Fedora 41 have been branched from Rawhide, according
+  to the [Fedora 41 Schedule](https://fedorapeople.org/groups/schedule/f-41/f-41-all-tasks.html).
+- The "early" CentOS Stream 10 + EPEL 10 configuration files have been added,
+  [issue#1421][].  These chroots only work with Fedora EPEL Koji buildroot(s).
+- Add configuration for openEuler 24.03 LTS.
+- Mock chroots for CentOS Stream 10 now use the mirrored repositories also for
+  baseos-source, baseos-debuginfo, appstream-source, appstream-debuginfo,
+  crb-source, and crb-debuginfo.
+- The CentOS 7 [is now EOL](https://www.redhat.com/en/topics/linux/centos-linux-eol)
+  and the mirroring is disabled.  Corresponding configuration files have been
+  moved to `/etc/mock/eol` and are pointing now to vault.centos.org.
+
+  Similarly, EPEL 7 [goes EOL](https://pagure.io/epel/issue/238), too.  Moving
+  EPEL 7 configuration to `/etc/mock/eol`, too.
+- The Fedora ELN ix86 config has been removed, as 32-bit multilibs are no longer
+  built for ELN.
+- Fedora Rawhide configurations, such as releasever=41 now, accept GPG keys from
+  Fedora releasever+1 (for example, 42, not yet used for RPM signatures).  This
+  change is implemented to address the typically short and unnecessary
+  inconvenience during [the Fedora branching process][issue#1338] in the future.
+- The Fedora Rawhide configuration (F41+) has been updated to use the
+  `bootstrap_image_ready = True` configuration.  The default container images are
+  [already shipped with the `dnf5-plugins` package](https://pagure.io/fedora-kiwi-descriptions/pull-request/63).
+
+  This means we use the container image "as is" to bootstrap the DNF5 stack
+  without installing any additional packages into the prepared bootstrap chroot.
+  Consequently, the bootstrap preparation is much faster (bootstrap preparation
+  basically equals the image download, if not pre-downloaded, and its subsequent
+  "extraction").
+
+#### Following contributors contributed to this release:
+
+- Daan De Meyer
+- Jakub Kadlcik
+- Jiri Kyjovsky
+- Miro Hrončok
+- nucleo
+- Robert Scheck
+- Yaakov Selkowitz
+
+Thank you!
+
+[issue#1338]: https://github.com/rpm-software-management/mock/issues/1338

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ Versions in Linux distributions:
 
 
 ## Release Notes
+* [Configs 41.1](Release-Notes-Configs-41.1) - EL7 configs EOL. F38 EOL. F41 branched.
 * [Configs 40.6](Release-Notes-Configs-40.6) - CentOS Stream 10 uses mirrored repositories.
 * [Configs 40.5](Release-Notes-Configs-40.5) - Fedora 38 moved to EOL. CentOS Stream 8 moved to vault.
 * [5.6](Release-Notes-5.6) - Improved performance of bash completion, don't use `--allowerasing` for commands that doesn't provide it, fixed "no space left" tracebacks, new Circle Linux 9 configs, Mageia Cauldron i686, fixed Fedora ELN.

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -3,7 +3,7 @@
 %endif
 
 Name:       mock-core-configs
-Version:    41.0.post1
+Version:    41.1
 Release:    1%{?dist}
 Summary:    Mock core config files basic chroots
 
@@ -149,6 +149,20 @@ fi
 %ghost %config(noreplace,missingok) %{_sysconfdir}/mock/default.cfg
 
 %changelog
+* Wed Aug 14 2024 Pavel Raiskup <praiskup@redhat.com> 41.1-1
+- branch F41 from Rawhide (frostyx@email.cz)
+- added centos-stream+epel-10 configs
+- Enable RPM sysusers integration (j1.kyjovsky@gmail.com)
+- Rawhide to accept GPG key from future Fedora Rawhide+1
+- openEuler 24.03 LTS (nucleo@fedoraproject.org)
+- drop fedora-eln-i386 (yselkowi@redhat.com)
+- Switch CentOS 7 to vault.centos.org (robert@fedoraproject.org)
+- Fix GPG keys for CentOS Stream 10 repositories (daan.j.demeyer@gmail.com)
+- EOL epel-7 configuration
+- CentOS 7 is EOL
+- Fedora 41+ configuration images are "dnf5 ready"
+- Use metalinks for c10s {baseos,appstream,crb}-{source,debuginfo} (miro@hroncok.cz)
+
 * Sat Jun 15 2024 Pavel Raiskup <praiskup@redhat.com> 40.6-1
 - c10s config use mirrored metalinks
 

--- a/releng/release-notes-next/add-openeuler-2403.config
+++ b/releng/release-notes-next/add-openeuler-2403.config
@@ -1,1 +1,0 @@
-Add configuration for openEuler 24.03 LTS.

--- a/releng/release-notes-next/c10s+epel.config
+++ b/releng/release-notes-next/c10s+epel.config
@@ -1,2 +1,0 @@
-The "early" CentOS Stream 10 + EPEL 10 configuration files have been added,
-[issue#1421][].  These chroots only work with Fedora EPEL Koji buildroots.

--- a/releng/release-notes-next/c10s-metalink.config
+++ b/releng/release-notes-next/c10s-metalink.config
@@ -1,2 +1,0 @@
-Mock chroots for CentOS Stream 10 now use the mirrored repositories also for
-baseos-source, baseos-debuginfo, appstream-source, appstream-debuginfo, crb-source, and crb-debuginfo.

--- a/releng/release-notes-next/centos-7-eol.config
+++ b/releng/release-notes-next/centos-7-eol.config
@@ -1,6 +1,0 @@
-The CentOS 7 [is now EOL](https://www.redhat.com/en/topics/linux/centos-linux-eol)
-and the mirroring is disabled.  Corresponding configuration files have been
-moved to `/etc/mock/eol` and are pointing now to vault.centos.org.
-
-Similarly, EPEL 7 [goes EOL](https://pagure.io/epel/issue/238), too.  Moving
-EPEL 7 configuration to `/etc/mock/eol`, too.

--- a/releng/release-notes-next/fedora-41-branching.feature
+++ b/releng/release-notes-next/fedora-41-branching.feature
@@ -1,2 +1,0 @@
-Configuration files for Fedora 41 have been branched from Rawhide,
-according to the [Fedora 41 Schedule](https://fedorapeople.org/groups/schedule/f-41/f-41-all-tasks.html).

--- a/releng/release-notes-next/fedora-eln-i386.config
+++ b/releng/release-notes-next/fedora-eln-i386.config
@@ -1,2 +1,0 @@
-The Fedora ELN ix86 config has been removed, as 32-bit multilibs are no 
-longer built for ELN.

--- a/releng/release-notes-next/fedora-rawhide-key-plus-one.config
+++ b/releng/release-notes-next/fedora-rawhide-key-plus-one.config
@@ -1,4 +1,0 @@
-Fedora Rawhide configurations, such as releasever=41 now, accept GPG keys from
-Fedora releasever+1 (for example, 42, not yet used for RPM signatures).  This
-change is implemented to address the typically short and unnecessary
-inconvenience during [the Fedora branching process][issue#1338] in the future.

--- a/releng/release-notes-next/rawhide-bootstrap-image-ready.config
+++ b/releng/release-notes-next/rawhide-bootstrap-image-ready.config
@@ -1,9 +1,0 @@
-The Fedora Rawhide configuration (F41+) has been updated to use the
-`bootstrap_image_ready = True` configuration.  The default container images are
-[already shipped with the `dnf5-plugins` package](https://pagure.io/fedora-kiwi-descriptions/pull-request/63).
-
-This means we use the container image "as is" to bootstrap the DNF5 stack
-without installing any additional packages into the prepared bootstrap chroot.
-Consequently, the bootstrap preparation is much faster (bootstrap preparation
-basically equals the image download, if not pre-downloaded, and its
-"extraction").


### PR DESCRIPTION
/usr/bin/tito tag --use-version=41.1
./releng/generate-release-notes --config-only --use-version 41.1