### PR TITLE
Skip the "podman pull" for bootstrap when not needed

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -171,6 +171,9 @@
 # full jitter, see python-backoff docs for more info).
 #config_opts['bootstrap_image_keep_getting'] = 120  # seconds
 
+# Skip the "podman pull" and rely on the image already being in the local cache.
+#config_opts["bootstrap_image_skip_pull"] = False
+
 # anything you specify with 'bootstrap_*' will be copied to bootstrap config
 # e.g. config_opts['bootstrap_system_yum_command'] = '/usr/bin/yum-deprecated' will become
 # config_opts['system_yum_command'] = '/usr/bin/yum-deprecated' for bootstrap config

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -262,7 +262,12 @@ class Buildroot(object):
                 podman = Podman(self, self.bootstrap_image)
 
             with _fallback("Can't initialize from bootstrap image"):
-                podman.retry_image_pull(self.config["image_keep_getting"])
+                if not self.config["image_skip_pull"]:
+                    podman.retry_image_pull(self.config["image_keep_getting"])
+                else:
+                    getLog().info("Using local image %s (pull skipped)",
+                                  self.bootstrap_image)
+
                 podman.cp(self.make_chroot_path(), self.config["tar_binary"])
                 file_util.unlink_if_exists(os.path.join(self.make_chroot_path(),
                                                         "etc/rpm/macros.image-language-conf"))

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -85,6 +85,7 @@ def setup_default_config_opts():
     config_opts['use_bootstrap'] = True
     config_opts['use_bootstrap_image'] = True
     config_opts['bootstrap_image'] = 'fedora:latest'
+    config_opts['bootstrap_image_skip_pull'] = False
     config_opts['bootstrap_image_ready'] = False
     config_opts['bootstrap_image_fallback'] = True
     config_opts['bootstrap_image_keep_getting'] = 120

--- a/releng/release-notes-next/bootstrap-skip-image-pull.feature
+++ b/releng/release-notes-next/bootstrap-skip-image-pull.feature
@@ -1,0 +1,5 @@
+There's a new `config_opts['bootstrap_image_skip_pull']` option that allows you
+to skip image pulling (running the `podman pull` command by Mock) when preparing
+the bootstrap chroot.  This is useful if `podman pull` is failing, for example,
+when the registry is temporarily or permanently unavailable, but the local image
+exists, or if the image reference is pointing at a local-only image.


### PR DESCRIPTION
Relates: #1393

I'm trying to split the PR into smaller pieces.