### PR TITLE
Fix EOL template locations for CentOS7/EPEL7

### DIFF
--- a/mock-core-configs/etc/mock/eol/centos+epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/eol/centos+epel-7-aarch64.cfg
@@ -1,5 +1,5 @@
-include('templates/eol/centos-7.tpl')
-include('templates/eol/epel-7.tpl')
+include('eol/templates/centos-7.tpl')
+include('eol/templates/epel-7.tpl')
 
 config_opts['root'] = 'centos+epel-7-aarch64'
 config_opts['target_arch'] = 'aarch64'

--- a/mock-core-configs/etc/mock/eol/centos+epel-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/eol/centos+epel-7-ppc64.cfg
@@ -1,5 +1,5 @@
-include('templates/eol/centos-7.tpl')
-include('templates/eol/epel-7.tpl')
+include('eol/templates/centos-7.tpl')
+include('eol/templates/epel-7.tpl')
 
 config_opts['root'] = 'centos+epel-7-ppc64'
 config_opts['target_arch'] = 'ppc64'

--- a/mock-core-configs/etc/mock/eol/centos+epel-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/eol/centos+epel-7-ppc64le.cfg
@@ -1,5 +1,5 @@
-include('templates/eol/centos-7.tpl')
-include('templates/eol/epel-7.tpl')
+include('eol/templates/centos-7.tpl')
+include('eol/templates/epel-7.tpl')
 
 config_opts['root'] = 'centos+epel-7-ppc64le'
 config_opts['description'] = 'CentOS 7 + EPEL'

--- a/mock-core-configs/etc/mock/eol/centos+epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/eol/centos+epel-7-x86_64.cfg
@@ -1,5 +1,5 @@
-include('templates/eol/centos-7.tpl')
-include('templates/eol/epel-7.tpl')
+include('eol/templates/centos-7.tpl')
+include('eol/templates/epel-7.tpl')
 
 config_opts['root'] = 'centos+epel-7-x86_64'
 config_opts['description'] = 'CentOS 7 + EPEL'

--- a/mock-core-configs/etc/mock/eol/centos-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/eol/centos-7-aarch64.cfg
@@ -1,4 +1,4 @@
-include('templates/eol/centos-7.tpl')
+include('eol/templates/centos-7.tpl')
 
 config_opts['root'] = 'centos-7-aarch64'
 config_opts['target_arch'] = 'aarch64'

--- a/mock-core-configs/etc/mock/eol/centos-7-ppc64.cfg
+++ b/mock-core-configs/etc/mock/eol/centos-7-ppc64.cfg
@@ -1,4 +1,4 @@
-include('templates/eol/centos-7.tpl')
+include('eol/templates/centos-7.tpl')
 
 config_opts['root'] = 'centos-7-ppc64'
 config_opts['target_arch'] = 'ppc64'

--- a/mock-core-configs/etc/mock/eol/centos-7-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/eol/centos-7-ppc64le.cfg
@@ -1,4 +1,4 @@
-include('templates/eol/centos-7.tpl')
+include('eol/templates/centos-7.tpl')
 
 config_opts['root'] = 'centos-7-ppc64le'
 config_opts['target_arch'] = 'ppc64le'

--- a/mock-core-configs/etc/mock/eol/centos-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/eol/centos-7-x86_64.cfg
@@ -1,4 +1,4 @@
-include('templates/eol/centos-7.tpl')
+include('eol/templates/centos-7.tpl')
 
 config_opts['root'] = 'centos-7-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/mock-core-configs/etc/mock/eol/oraclelinux+epel-7-aarch64.cfg
+++ b/mock-core-configs/etc/mock/eol/oraclelinux+epel-7-aarch64.cfg
@@ -1,5 +1,5 @@
 include('templates/oraclelinux-7.tpl')
-include('templates/eol/epel-7.tpl')
+include('eol/templates/epel-7.tpl')
 
 config_opts['root'] = 'oraclelinux+epel-7-aarch64'
 config_opts['target_arch'] = 'aarch64'

--- a/mock-core-configs/etc/mock/eol/oraclelinux+epel-7-x86_64.cfg
+++ b/mock-core-configs/etc/mock/eol/oraclelinux+epel-7-x86_64.cfg
@@ -1,5 +1,5 @@
 include('templates/oraclelinux-7.tpl')
-include('templates/eol/epel-7.tpl')
+include('eol/templates/epel-7.tpl')
 
 config_opts['root'] = 'oraclelinux+epel-7-x86_64'
 config_opts['target_arch'] = 'x86_64'


### PR DESCRIPTION
Disclosure: This is my first PR on a public project. Apologies if I missed to follow any rules on this repo (I did not see a  contribution guide)

I think there was a typo introduced when CentOS7 and EPEL7 templates were EOL´d with #1397 

Please disregard if I misunderstood template locations and corresponding includes.

Did not file an issue yet since I do not have access to a recent mock version that has #1397 changes.

Have a nice day :)