### PR TITLE
towncrier: update to v45 && use defaults

### DIFF
--- a/.github/workflows/towncrier.yml
+++ b/.github/workflows/towncrier.yml
@@ -17,9 +17,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
-        with:
-          since_last_remote_commit: true
+        uses: tj-actions/changed-files@v45
 
       - name: Detect the missing Release Notes entry
         env:


### PR DESCRIPTION
The since_last_remote_commit doesn't seem to work correctly;  for some reason, it sometimes gives us a limited set of changed files (appears like it was generated since the last commit in the very same PR, not from the target branch), example:
https://github.com/rpm-software-management/mock/actions/runs/10616932275/job/29431772686?pr=1393