### PR TITLE
CI: lint the whole project

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -17,10 +17,6 @@ jobs:
         uses: fedora-copr/vcs-diff-lint-action@v1
         id: VCS_Diff_Lint
         with:
-          subdirectories: |
-            behave
-            mock
-            releng
           linter_tags: |
             ruff
             pylint

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,1 @@
+mock/pylintrc


### PR DESCRIPTION
This requires a top-level pylintrc file.  The previous per-subdir
solution was broken (each subdir would need to provide a specfile, or
the .vcs-diff-lint.yml file to work correctly).
