### PR TITLE
Enable bootstrap container for CentOS Stream 10

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-10.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-10.tpl
@@ -5,8 +5,8 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'CentOS Stream 10'
 
-config_opts['use_bootstrap_image'] = False
-config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream10'
+config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream10-development'
+config_opts['bootstrap_image_ready'] = True
 
 config_opts['dnf.conf'] = """
 [main]

--- a/releng/release-notes-next/c10s-bootstrap-ready.config.md
+++ b/releng/release-notes-next/c10s-bootstrap-ready.config.md
@@ -1,0 +1,8 @@
+The CentOS Stream 10 configuration has been updated to use
+`quay.io/centos/centos:stream10-development` as its bootstrap image.  Since
+this image [already has the `python3-dnf-plugins-core` package
+installed](https://issues.redhat.com/browse/CS-2506), the configuration is also
+updated to set `bootstrap_image_ready = True`.  This means the image can be
+used "as is" to bootstrap the DNF stack without installing any additional
+packages into the prepared bootstrap chroot, significantly speeding up
+bootstrap preparation.


### PR DESCRIPTION
Since CentOS Stream 10 hasn't been released yet, the container image exists but is using the tag stream10-development instead of stream10. At some point (probably the release announcement) it will start using the stream10 tag.  This image is "ready" (i.e. `dnf builddep` is pre-installed).

cc: @tdawson