### PR TITLE
Respect nspawn_args whenever doChroot is called

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -65,12 +65,6 @@ class Commands(object):
         self.private_network = not config['rpmbuild_networking']
         self.rpmbuild_noclean_option = None
 
-    def _get_nspawn_args(self):
-        nspawn_args = []
-        if util.USE_NSPAWN:
-            nspawn_args.extend(self.config['nspawn_args'])
-        return nspawn_args
-
     @traceLog()
     def backup_results(self):
         srcdir = os.path.join(self.buildroot.basedir, "result")
@@ -370,7 +364,7 @@ class Commands(object):
             ret = util.doshell(chrootPath=self.buildroot.make_chroot_path(),
                                environ=self.buildroot.env, uid=uid, gid=gid,
                                cwd=cwd,
-                               nspawn_args=self._get_nspawn_args(),
+                               nspawn_args=self.config.get("nspawn_args", []),
                                unshare_net=self.private_network,
                                cmd=cmd)
         finally:
@@ -400,11 +394,10 @@ class Commands(object):
                 result = self.buildroot.doChroot(args, shell=shell, printOutput=True,
                                                  uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
                                                  user=self.buildroot.chrootuser, cwd=options.cwd,
-                                                 nspawn_args=self._get_nspawn_args(), raiseExc=False,
+                                                 raiseExc=False,
                                                  unshare_net=self.private_network)[1]
             else:
                 result = self.buildroot.doChroot(args, shell=shell, cwd=options.cwd,
-                                                 nspawn_args=self._get_nspawn_args(),
                                                  unshare_net=self.private_network,
                                                  printOutput=True, raiseExc=False)[1]
         finally:
@@ -644,7 +637,6 @@ class Commands(object):
     def get_specfile_name(self, srpm_path):
         files = self.buildroot.doChroot([self.config['rpm_command'], "-qpl", srpm_path],
                                         shell=False, uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
-                                        nspawn_args=self._get_nspawn_args(),
                                         unshare_net=self.private_network,
                                         user=self.buildroot.chrootuser,
                                         returnOutput=True
@@ -661,7 +653,6 @@ class Commands(object):
         output, return_code = self.buildroot.doChroot(
             command, shell=False, uid=self.buildroot.chrootuid,
             gid=self.buildroot.chrootgid, user=self.buildroot.chrootuser,
-            nspawn_args=self._get_nspawn_args(),
             unshare_net=self.private_network, returnOutput=True,
             returnStderr=True, raiseExc=False)
         if return_code:
@@ -704,7 +695,6 @@ class Commands(object):
             shell=False, logger=self.buildroot.build_log, timeout=timeout,
             uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
             user=self.buildroot.chrootuser,
-            nspawn_args=self._get_nspawn_args(),
             unshare_net=self.private_network,
             printOutput=self.config['print_main_output']
         )
@@ -766,7 +756,6 @@ class Commands(object):
                                             shell=False, logger=self.buildroot.build_log, timeout=timeout,
                                             uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
                                             user=self.buildroot.chrootuser,
-                                            nspawn_args=self._get_nspawn_args(),
                                             unshare_net=self.private_network, raiseExc=False,
                                             printOutput=self.config['print_main_output'])
                 if returncode > 0 and returncode != 11:
@@ -816,7 +805,6 @@ class Commands(object):
                                     shell=False, logger=self.buildroot.build_log, timeout=timeout,
                                     uid=self.buildroot.chrootuid, gid=self.buildroot.chrootgid,
                                     user=self.buildroot.chrootuser,
-                                    nspawn_args=self._get_nspawn_args(),
                                     unshare_net=self.private_network,
                                     printOutput=self.config['print_main_output'])
         results = glob.glob(bd_out + '/RPMS/*.rpm')

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -426,6 +426,24 @@ class Buildroot(object):
                 self.uid_manager.restorePrivs()
         return result
 
+    def doChrootPlugin(self, command, cwd=None):
+        """
+        Execute command (specified as array, not a shell command string) in this
+        buildroot  in `cwd`, as a non-privileged user.  Used by plugins.
+        """
+        private_network = not self.config.get('rpmbuild_networking', False)
+        self.doChroot(
+            command,
+            shell=False,
+            cwd=cwd,
+            logger=self.build_log,
+            uid=self.chrootuid,
+            gid=self.chrootgid,
+            user=self.chrootuser,
+            unshare_net=private_network,
+            printOutput=self.config.get('print_main_output', True)
+        )
+
     def all_chroot_packages(self):
         """package set, result of rpm -qa in the buildroot"""
         self.nuke_rpm_db()

--- a/mock/py/mockbuild/plugins/rpkg_preprocessor.py
+++ b/mock/py/mockbuild/plugins/rpkg_preprocessor.py
@@ -117,6 +117,5 @@ class RpkgPreprocessor(object):
             gid=self.buildroot.chrootgid,
             user=self.buildroot.chrootuser,
             unshare_net=private_network,
-            nspawn_args=self.config.get('nspawn_args', []),
             printOutput=self.config.get('print_main_output', True)
         )

--- a/mock/py/mockbuild/plugins/rpkg_preprocessor.py
+++ b/mock/py/mockbuild/plugins/rpkg_preprocessor.py
@@ -104,18 +104,4 @@ class RpkgPreprocessor(object):
         command_str = self.opts.get('cmd') % {'source_spec': chroot_sources_spec,
                                               'target_spec': chroot_spec}
         command = shlex.split(command_str)
-
-        # determine whether to use private network or not based on rpmbuild_networking
-        private_network = (not self.config.get('rpmbuild_networking', False))
-
-        self.buildroot.doChroot(
-            command,
-            shell=False,
-            cwd=chroot_sources,
-            logger=self.buildroot.build_log,
-            uid=self.buildroot.chrootuid,
-            gid=self.buildroot.chrootgid,
-            user=self.buildroot.chrootuser,
-            unshare_net=private_network,
-            printOutput=self.config.get('print_main_output', True)
-        )
+        self.buildroot.doChrootPlugin(command, cwd=chroot_sources)

--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -114,14 +114,4 @@ class RpmautospecPlugin:
         # bonus, spec files will be processed in the environment they will be
         # built for, reducing the impact of the host system on the outcome,
         # leading to more deterministic results and better repeatable builds.
-        self.buildroot.doChroot(
-            command,
-            shell=False,
-            cwd=chroot_sources,
-            logger=self.buildroot.build_log,
-            uid=self.buildroot.chrootuid,
-            gid=self.buildroot.chrootgid,
-            user=self.buildroot.chrootuser,
-            unshare_net=not self.config.get("rpmbuild_networking", False),
-            printOutput=self.config.get("print_main_output", True),
-        )
+        self.buildroot.doChrootPlugin(command, cwd=chroot_sources)

--- a/mock/py/mockbuild/plugins/rpmautospec.py
+++ b/mock/py/mockbuild/plugins/rpmautospec.py
@@ -123,6 +123,5 @@ class RpmautospecPlugin:
             gid=self.buildroot.chrootgid,
             user=self.buildroot.chrootuser,
             unshare_net=not self.config.get("rpmbuild_networking", False),
-            nspawn_args=self.config.get("nspawn_args", []),
             printOutput=self.config.get("print_main_output", True),
         )

--- a/mock/tests/plugins/test_rpmautospec.py
+++ b/mock/tests/plugins/test_rpmautospec.py
@@ -158,19 +158,12 @@ class TestRpmautospecPlugin:
 
             expected_command = plugin.opts["cmd_base"] + [chroot_sources_spec, chroot_spec]
 
-            plugin.buildroot.doChroot.assert_called_once_with(
+            plugin.buildroot.doChrootPlugin.assert_called_once_with(
                 expected_command,
-                shell=False,
                 cwd=chroot_sources,
-                logger=plugin.buildroot.build_log,
-                uid=plugin.buildroot.chrootuid,
-                gid=plugin.buildroot.chrootgid,
-                user=plugin.buildroot.chrootuser,
-                unshare_net=not plugin.config.get("rpmbuild_networking", False),
-                printOutput=plugin.config.get("print_main_output", True),
             )
         else:
-            plugin.buildroot.doChroot.assert_not_called()
+            plugin.buildroot.doChrootPlugin.assert_not_called()
             if "broken-requires" not in testcase:
                 if "spec-files-different" in testcase:
                     log_method = log.warning

--- a/mock/tests/plugins/test_rpmautospec.py
+++ b/mock/tests/plugins/test_rpmautospec.py
@@ -167,7 +167,6 @@ class TestRpmautospecPlugin:
                 gid=plugin.buildroot.chrootgid,
                 user=plugin.buildroot.chrootuser,
                 unshare_net=not plugin.config.get("rpmbuild_networking", False),
-                nspawn_args=plugin.config.get("nspawn_args", []),
                 printOutput=plugin.config.get("print_main_output", True),
             )
         else:

--- a/releng/release-notes-next/nspawn-args-chroot-bootstrap.bugfix
+++ b/releng/release-notes-next/nspawn-args-chroot-bootstrap.bugfix
@@ -1,0 +1,5 @@
+Previously, the `nspawn_args` configuration value was not applied in multiple
+internal `doChroot()` calls.  This could cause issues when custom nspawn
+arguments were needed everywhere (see [PR#1410][]).  Now, `doChroot()`
+automatically applies `nspawn_args`, shifting the responsibility from callers to
+callee.


### PR DESCRIPTION
Which also includes all doOutChroot(), because that method calls doChroot() internally.

This issue was found when trying to workaround an issue [1] when SELinux policy forbid systemd-machine to create a varlink socket and thus start. This resulted in systemd-nspawn not being able to register a machine. To workaround this, Tomáš added the following snippet to the configuration:

    config_opts['nspawn_args'] = ['--register=no']

So that systemd-nspawn does not try to register the machine with systemd-machine.  However, this had no effect (and the argument was not visible on command-line and still failed).

[1] https://issues.redhat.com/browse/RHEL-49567

Co-authored-with: Tomáš Hozza <thozza@redhat.com>