### PR TITLE
No per-command bootstrap mount leftovers

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -33,8 +33,6 @@ import uuid
 
 import distro
 
-from mockbuild.mounts import BindMountPoint
-
 from . import exception
 from . import file_util
 from . import text
@@ -1000,17 +998,6 @@ best=1
         return
 
     _fix_cfg(bootstrap.config)
-
-    if not baseurl.startswith("file:///") and not baseurl.startswith("/"):
-        return
-
-    local_dir = baseurl.replace("file://", "", 1)
-    if not local_dir or not os.path.isdir(local_dir):
-        return
-
-    mountpoint = bootstrap.make_chroot_path(local_dir)
-    bootstrap.mounts.add(BindMountPoint(srcpath=local_dir,
-                                        bindpath=mountpoint))
 
 
 def subscription_redhat_init(opts, uidManager):

--- a/releng/release-notes-next/buildroot-mounts-redundancy.bugfix
+++ b/releng/release-notes-next/buildroot-mounts-redundancy.bugfix
@@ -1,0 +1,5 @@
+De-duplicating bootstrap mount points for local repositories used with `--chain`
+or `--localrepo=file:///repo/on/host`.  Caused eventual problems during
+`--scrub=bootstrap`.  This bug existed in Mock <= 5.6, but after fixing the
+[issue#1414][], it got exposed by our test suite.  Related issues include
+[issue#357][] ([commit#a0a2cba3][]) and [issue#381][] ([commit#16462acc][]).


### PR DESCRIPTION
For more info poke at the commit message.