### PR TITLE
configs: update ELN repos

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -3,11 +3,6 @@ config_opts['eln_rawhide_releasever'] = '42'
 
 config_opts['root'] = 'fedora-eln-{{ target_arch }}'
 
-# Fedora ELN i386 doesn't get composes (isn't mirrored on
-# odcs.fedoraproject.org), we need to build using the Koji buildroot.
-# Note that similar idiom used in fedora-branched.tpl and fedora-rawhide.tpl.
-config_opts['mirrored'] = config_opts['target_arch'] != 'i686'
-
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils fedora-release-eln findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
 
 config_opts['dist'] = 'eln'  # only useful for --resultdir variable subst
@@ -53,11 +48,10 @@ file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-rawhide-primar
 {%- endfor %}
 {%- endmacro %}
 
-{% if mirrored %}
 [eln-baseos]
 name=Fedora - ELN BaseOS - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/BaseOS/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-baseos-1&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm
@@ -67,8 +61,8 @@ skip_if_unavailable=False
 
 [eln-baseos-debuginfo]
 name=Fedora - ELN BaseOS - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/BaseOS/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-baseos-debug-1&arch=$basearch
 enabled=0
 repo_gpgcheck=0
 type=rpm
@@ -78,8 +72,8 @@ skip_if_unavailable=False
 
 [eln-baseos-source]
 name=Fedora - ELN BaseOS - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/BaseOS/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-baseos-source-1&arch=source
 enabled=0
 repo_gpgcheck=0
 type=rpm
@@ -90,8 +84,8 @@ skip_if_unavailable=False
 
 [eln-appstream]
 name=Fedora - ELN AppStream - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/AppStream/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-appstream-1&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm
@@ -101,8 +95,8 @@ skip_if_unavailable=False
 
 [eln-appstream-debuginfo]
 name=Fedora - ELN AppStream - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/AppStream/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-appstream-debug-1&arch=$basearch
 enabled=0
 repo_gpgcheck=0
 type=rpm
@@ -112,8 +106,8 @@ skip_if_unavailable=False
 
 [eln-appstream-source]
 name=Fedora - ELN AppStream - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/AppStream/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-appstream-source-1&arch=source
 enabled=0
 repo_gpgcheck=0
 type=rpm
@@ -124,8 +118,8 @@ skip_if_unavailable=False
 
 [eln-crb]
 name=Fedora - ELN CodeReady Linux Builders - Build packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/CRB/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-crb-1&arch=$basearch
 enabled=1
 repo_gpgcheck=0
 type=rpm
@@ -135,8 +129,8 @@ skip_if_unavailable=False
 
 [eln-crb-debuginfo]
 name=Fedora - ELN CodeReady Linux Builders - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/CRB/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-crb-debug-1&arch=$basearch
 enabled=0
 repo_gpgcheck=0
 type=rpm
@@ -146,8 +140,8 @@ skip_if_unavailable=False
 
 [eln-crb-source]
 name=Fedora - ELN CodeReady Linux Builders - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/CRB/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-crb-source-1&arch=source
 enabled=0
 repo_gpgcheck=0
 type=rpm
@@ -159,8 +153,8 @@ skip_if_unavailable=False
 
 [eln-extras]
 name=Fedora - ELN Extras - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Extras/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/Extras/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-extras-1&arch=$basearch
 enabled=1
 countme=1
 metadata_expire=6h
@@ -172,8 +166,8 @@ skip_if_unavailable=False
 
 [eln-extras-debuginfo]
 name=Fedora - ELN Extras - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Extras/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/Extras/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-extras-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -184,8 +178,8 @@ skip_if_unavailable=False
 
 [eln-extras-source]
 name=Fedora - ELN Extras - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Extras/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/Extras/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-extras-source-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -198,8 +192,8 @@ skip_if_unavailable=False
 
 [eln-ha]
 name=Fedora - ELN HighAvailability - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/HighAvailability/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-highavailability-1&arch=$basearch
 enabled=0
 countme=1
 metadata_expire=6h
@@ -211,8 +205,8 @@ skip_if_unavailable=False
 
 [eln-ha-debuginfo]
 name=Fedora - ELN HighAvailability - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/HighAvailability/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-highavailability-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -223,8 +217,8 @@ skip_if_unavailable=False
 
 [eln-ha-source]
 name=Fedora - ELN HighAvailability - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/HighAvailability/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/HighAvailability/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-highavailability-source-1&arch=source
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -237,8 +231,8 @@ skip_if_unavailable=False
 
 [eln-rs]
 name=Fedora - ELN ResilientStorage - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/ResilientStorage/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/ResilientStorage/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-resilientstorage-1&arch=$basearch
 enabled=0
 countme=1
 metadata_expire=6h
@@ -250,8 +244,8 @@ skip_if_unavailable=False
 
 [eln-rs-debuginfo]
 name=Fedora - ELN ResilientStorage - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/ResilientStorage/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/ResilientStorage/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-resilientstorage-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -262,8 +256,8 @@ skip_if_unavailable=False
 
 [eln-rs-source]
 name=Fedora - ELN ResilientStorage - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/ResilientStorage/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/ResilientStorage/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-resilientstorage-source-1&arch=source
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -276,8 +270,8 @@ skip_if_unavailable=False
 
 [eln-rt]
 name=Fedora - ELN RT - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/RT/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/RT/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-rt-1&arch=$basearch
 enabled=0
 countme=1
 metadata_expire=6h
@@ -289,8 +283,8 @@ skip_if_unavailable=False
 
 [eln-rt-debuginfo]
 name=Fedora - ELN RT - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/RT/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/RT/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-rt-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -301,8 +295,8 @@ skip_if_unavailable=False
 
 [eln-rt-source]
 name=Fedora - ELN RT - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/RT/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/RT/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-rt-source-1&arch=source
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -315,8 +309,8 @@ skip_if_unavailable=False
 
 [eln-nfv]
 name=Fedora - ELN NFV - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/NFV/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/NFV/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-nfv-1&arch=$basearch
 enabled=0
 countme=1
 metadata_expire=6h
@@ -328,8 +322,8 @@ skip_if_unavailable=False
 
 [eln-nfv-debuginfo]
 name=Fedora - ELN NFV - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/NFV/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/NFV/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-nfv-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -340,8 +334,8 @@ skip_if_unavailable=False
 
 [eln-nfv-source]
 name=Fedora - ELN NFV - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/NFV/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/NFV/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-nfv-source-1&arch=source
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -354,8 +348,8 @@ skip_if_unavailable=False
 
 [eln-sap]
 name=Fedora - ELN SAP - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAP/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/SAP/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-sap-1&arch=$basearch
 enabled=0
 countme=1
 metadata_expire=6h
@@ -367,8 +361,8 @@ skip_if_unavailable=False
 
 [eln-sap-debuginfo]
 name=Fedora - ELN SAP - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAP/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/SAP/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-sap-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -379,8 +373,8 @@ skip_if_unavailable=False
 
 [eln-sap-source]
 name=Fedora - ELN SAP - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAP/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/SAP/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-sap-source-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -393,8 +387,8 @@ skip_if_unavailable=False
 
 [eln-saphana]
 name=Fedora - ELN SAPHANA - Developmental packages for the next Enterprise Linux release
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAPHANA/$basearch/os/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/SAPHANA/$basearch/os/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-saphana-1&arch=$basearch
 enabled=0
 countme=1
 metadata_expire=6h
@@ -406,8 +400,8 @@ skip_if_unavailable=False
 
 [eln-saphana-debuginfo]
 name=Fedora - ELN SAPHANA - Debug
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAPHANA/$basearch/debug/tree
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-debug&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/SAPHANA/$basearch/debug/tree
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-saphana-debug-1&arch=$basearch
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -418,8 +412,8 @@ skip_if_unavailable=False
 
 [eln-saphana-source]
 name=Fedora - ELN SAPHANA - Source
-baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/SAPHANA/source/tree/
-#metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-source&arch=$basearch
+#baseurl=https://dl.fedoraproject.org/pub/eln/1/SAPHANA/source/tree/
+metalink=https://mirrors.fedoraproject.org/metalink?repo=eln-saphana-source-1&arch=source
 enabled=0
 metadata_expire=6h
 repo_gpgcheck=0
@@ -427,12 +421,11 @@ type=rpm
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch
 skip_if_unavailable=False
-{% endif %}
 
 [local]
 name=local
 baseurl=https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
 cost=2000
-enabled={{ not mirrored }}
+enabled=0
 skip_if_unavailable=False
 """

--- a/releng/release-notes-next/eln-repo-update.bugfix
+++ b/releng/release-notes-next/eln-repo-update.bugfix
@@ -1,0 +1,1 @@
+The Fedora ELN template has been updated to download repositories using mirrors from the Fedora MirrorManager system.


### PR DESCRIPTION
ELN now has Pungi composes instead of OSBS, and are downloadable and mirrorable like other Fedora-hosted projects.  Also, with multilibs no longer being built, the mirrored conditional is no longer necessary.