### PR TITLE
Add epel and epel-testing repos to the EPEL 10 config

### DIFF
--- a/mock-core-configs/etc/mock/epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/epel-10-aarch64.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-10-aarch64.cfg

--- a/mock-core-configs/etc/mock/epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/epel-10-ppc64le.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-10-ppc64le.cfg

--- a/mock-core-configs/etc/mock/epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/epel-10-s390x.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-10-s390x.cfg

--- a/mock-core-configs/etc/mock/epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/epel-10-x86_64.cfg
@@ -1,0 +1,1 @@
+centos-stream+epel-10-x86_64.cfg

--- a/mock-core-configs/etc/mock/templates/centos-stream-10.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-10.tpl
@@ -1,6 +1,7 @@
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 centos-stream-release coreutils cpio diffutils findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
 config_opts['dist'] = 'el10'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '10'
+config_opts['releasever_major'] = '10'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'CentOS Stream 10'

--- a/mock-core-configs/etc/mock/templates/epel-10.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-10.tpl
@@ -2,10 +2,39 @@ config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
 
 config_opts['dnf.conf'] += """
 
+# The metalinks below differ from the ones used in epel-release.  The
+# epel-release metalinks rely on a dnf variable expansion feature that is only
+# available since dnf 4.18.0.  In some configurations mock will be using the
+# host dnf to bootstrap the chroot, which could be older and lack those
+# features, leading to problems.  The alternative is to use this simplified
+# metalink here in this template for CentOS Stream, and a different metalink in
+# another template for RHEL.
+
+[epel]
+name=Extra Packages for Enterprise Linux $releasever - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-{{ releasever_major }}&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-{{ releasever_major }}
+gpgcheck=1
+countme=1
+
+[epel-testing]
+name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=testing-epel{{ releasever_major }}&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-{{ releasever_major }}
+gpgcheck=1
+countme=1
+enabled=0
+
+{% if koji_primary_repo == "epel" %}
+
+# The baseurl below is a symlink in the koji infrastructure that moves forward
+# over time to the buildroot repo of the latest minor verison tag.
+
 [local]
 name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
-baseurl=https://kojipkgs.fedoraproject.org/repos/epel10.0-build/latest/$basearch/
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel{{ releasever_major }}/centos/$basearch/
 cost=2000
-enabled=1
+enabled=0
 skip_if_unavailable=False
+{% endif %}
 """

--- a/releng/release-notes-next/epel10-metalinks.config.md
+++ b/releng/release-notes-next/epel10-metalinks.config.md
@@ -1,0 +1,3 @@
+The EPEL 10 configuration has been updated to include the epel and epel-testing
+repos with the appropriate metalinks.  Previously it only included the koji
+local repo.


### PR DESCRIPTION
Previously the EPEL 10 config only included the koji local repo, because that was the only thing available at the time.  We now have working MirrorManager metalinks that we can use for the proper repos.  Now that we have those repos, we can set the koji local repo to disabled by default, matching earlier EPEL configs.

We also now have a koji symlink that will be updated over time to point to the latest minor version tag buildroot repo, which can be used in the koji local baseurl.  This avoids the inconvenience of updating that baseurl manually every six months.

Fixes: #1427