### PR TITLE
configs: update ELN bootstrap image

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -14,7 +14,7 @@ config_opts['package_manager'] = 'dnf5'
 
 # Per https://github.com/fedora-eln/eln/issues/164 updated up to 4 times a day.
 # Docs: https://docs.fedoraproject.org/en-US/eln/deliverables/#_container_image
-config_opts['bootstrap_image'] = 'quay.io/fedoraci/fedora:eln'
+config_opts['bootstrap_image'] = 'quay.io/fedora/eln:latest'
 
 # https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5 applied to ELN!
 config_opts['bootstrap_image_ready'] = True

--- a/releng/release-notes-next/eln-bootstrap-image.bugfix
+++ b/releng/release-notes-next/eln-bootstrap-image.bugfix
@@ -1,0 +1,1 @@
+The Fedora ELN template has been updated for the new pullspec of the bootstrap image.


### PR DESCRIPTION
ELN now has Pungi composes instead of OSBS, and as a result, the bootstrap image pullspec has also changed.

This is a follow-up to #1473.

/cc @praiskup @sgallagher 