### PR TITLE
Generate / use OCI image for Mock buildroot

### DIFF
--- a/behave/features/buildroot-image.feature
+++ b/behave/features/buildroot-image.feature
@@ -1,0 +1,19 @@
+Feature: Mock 6.0+ supports --bootstrap-image feature and OCI buildroot exports
+
+    @buildroot_image
+    Scenario: Use image from registry for buildroot preparation
+        Given an unique mock namespace
+        Given mock is always executed with "--buildroot-image registry.fedoraproject.org/fedora:rawhide"
+        When an online source RPM is rebuilt against fedora-rawhide-x86_64
+        Then the build succeeds
+
+    @buildroot_image
+    Scenario: Image from 'export_buildroot_image' works with --buildroot-image
+        Given an unique mock namespace
+        Given next mock call uses --enable-plugin=export_buildroot_image option
+        # No need to do a full build here!
+        When deps for python-copr-999-1.src.rpm are calculated against fedora-rawhide-x86_64
+        And OCI tarball from fedora-rawhide-x86_64 backed up and will be used
+        And the fedora-rawhide-x86_64 chroot is scrubbed
+        And an online SRPM python-copr-999-1.src.rpm is rebuilt against fedora-rawhide-x86_64
+        Then the build succeeds

--- a/behave/steps/other.py
+++ b/behave/steps/other.py
@@ -166,8 +166,9 @@ def step_impl(context, expected_message):
     assert_that(err[0], contains_string(expected_message))
 
 
-def _rebuild_online(context, chroot=None):
-    url = context.test_storage + "mock-test-bump-version-1-0.src.rpm"
+def _rebuild_online(context, chroot=None, package=None):
+    package = package or "mock-test-bump-version-1-0.src.rpm"
+    url = context.test_storage + package
     if chroot:
         context.mock.chroot = chroot
         context.mock.chroot_opt = chroot
@@ -182,6 +183,12 @@ def step_impl(context):
 @when('an online source RPM is rebuilt against {chroot}')
 def step_impl(context, chroot):
     _rebuild_online(context, chroot)
+
+
+@when('an online SRPM {package} is rebuilt against {chroot}')
+def step_impl(context, package, chroot):
+    _rebuild_online(context, chroot, package)
+
 
 @then('{output} contains "{text}"')
 def step_impl(context, output, text):
@@ -309,3 +316,18 @@ def step_impl(context):
                 break
     assert_that(tarball.group(), equal_to("mock"))
     assert_that(tarball.owner(), equal_to(context.current_user))
+
+
+@when('OCI tarball from {chroot} backed up and will be used')
+def step_impl(context, chroot):
+    resultdir = f"/var/lib/mock/{chroot}-{context.uniqueext}/result"
+    tarball_base = "buildroot-oci.tar"
+    tarball = os.path.join(resultdir, tarball_base)
+    assert os.path.exists(tarball)
+    shutil.copy(tarball, context.workdir)
+    context.mock.buildroot_image = os.path.join(context.workdir, tarball_base)
+
+
+@when('the {chroot} chroot is scrubbed')
+def step_impl(context, chroot):
+    context.mock.scrub(chroot)

--- a/docs/Feature-buildroot-image.md
+++ b/docs/Feature-buildroot-image.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Feature buildroot image
+---
+
+Starting from version v6.0, Mock allows users to use an OCI container image for
+pre-creating the buildroot (build chroot).  It can be either an online container
+image hosted in a registry (or cached locally), or a local image in the form of
+a tarball.
+
+Be cautious when using chroot-compatible images (e.g., it is not advisable to
+combine EPEL `ppc64le` images with `fedora-rawhide-x86_64` chroot).
+
+## Example Use-Case
+
+1. Mock aggressively caches the build root, so clean up your chroot first:
+
+    ```bash
+    $ mock -r fedora-rawhide-x86_64 --scrub=all
+    ```
+
+2. Perform any normal Mock operation, but select the OCI image on top of that:
+
+    ```bash
+    $ mock -r fedora-rawhide-x86_64 \
+        --buildroot-image registry.fedoraproject.org/fedora:41 \
+        --rebuild /your/src.rpm
+    ```
+
+## Using Exported Buildroot Image
+
+The [export_buildroot_image](Plugin-Export-Buildroot-Image) plugin allows you to
+wrap a prepared buildroot as an OCI archive (tarball).  If you have this
+tarball, you may select it as well:
+
+```bash
+$ mock -r fedora-rawhide-x86_64 \
+    --buildroot-image /tmp/buildroot-oci.tar \
+    --rebuild /your/src.rpm
+```
+
+Again, ensure that you do not combine incompatible chroot and image pairs.

--- a/docs/Plugin-Export-Buildroot-Image.md
+++ b/docs/Plugin-Export-Buildroot-Image.md
@@ -29,7 +29,9 @@ The archive has been saved in the result directory:
     $ ls /var/lib/mock/fedora-rawhide-x86_64/result/*.tar
     /var/lib/mock/fedora-rawhide-x86_64/result/buildroot-oci.tar
 
-Then, you can try re-running the build without Mock, like this:
+You may use this tarball together with [the `--buildroot-image` option
+then](Feature-buildroot-image).  But also, you can try re-running the
+build without Mock, like this:
 
     $ chmod a+r /tmp/quick-package/dummy-pkg-20241212_1114-1.src.rpm
     $ podman run --rm -ti \

--- a/docs/Plugin-Export-Buildroot-Image.md
+++ b/docs/Plugin-Export-Buildroot-Image.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Plugin export_buildroot_image
+---
+
+This plugin allows you to (on demand) export the Mock chroot as an OCI image in
+local archive format (tarball).  This tarball can provide additional convenience
+for local build reproducibility.  See the example below for details.
+
+By default, this plugin is **disabled**.  You can enable it using the
+`--enable-plugin export_buildroot_image` option in `--rebuild` mode.
+
+This plugin has been added in Mock v6.0.
+
+## Example use-case
+
+First, let's start a standard Mock build, but enable the OCI archive generator:
+
+    $ mock -r fedora-rawhide-x86_64 --enable-plugin export_buildroot_image \
+            /tmp/quick-package/dummy-pkg-20241212_1114-1.src.rpm
+    ... mock installs all build-deps, and does other chroot tweaks ...
+    Start: producing buildroot as OCI image
+    ... mock performs the rpmbuild ...
+    INFO: Results and/or logs in: /var/lib/mock/fedora-rawhide-x86_64/result
+    Finish: run
+
+The archive has been saved in the result directory:
+
+    $ ls /var/lib/mock/fedora-rawhide-x86_64/result/*.tar
+    /var/lib/mock/fedora-rawhide-x86_64/result/buildroot-oci.tar
+
+Then, you can try re-running the build without Mock, like this:
+
+    $ chmod a+r /tmp/quick-package/dummy-pkg-20241212_1114-1.src.rpm
+    $ podman run --rm -ti \
+        -v /tmp/quick-package/dummy-pkg-20241212_1114-1.src.rpm:/dummy-pkg.src.rpm:z \
+        oci-archive:/var/lib/mock/fedora-rawhide-x86_64/result/buildroot-oci.tar \
+        rpmbuild --rebuild /dummy-pkg.src.rpm
+
+    Installing /dummy-pkg.src.rpm
+    setting SOURCE_DATE_EPOCH=1401926400
+    Executing(%mkbuilddir): /bin/sh -e /var/tmp/rpm-tmp.XIm441
+    ...
+    Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.pqJ9hu
+    ...
+    Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.iaeMZG
+    ...
+    Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.SHktaE
+    ...
+    Processing files: dummy-pkg-20241212_1114-1.fc42.x86_64
+    ...
+    Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.E71FWH
+    ...
+    + exit 0
+
+**Warning:** This method of reproducing a Mock build is not recommended for
+production use.  During a normal/full Mock rebuild, Mock ensures the buildroot
+is fully up-to-date.  Using just plain `rpmbuild` within Podman may result in
+outdated files, different structure in the kernel-driven filesystems like
+`/proc`, `/dev`, and `/sys`, different SELinux assumptions, permissions, etc.
+Proceed with caution, and be prepared to encounter some differences (and perhaps
+different build failures).

--- a/docs/index.md
+++ b/docs/index.md
@@ -196,6 +196,7 @@ See a [separate document](Mock-Core-Configs).
 * [ccache](Plugin-CCache) - compiler cache plugin
 * [chroot_scan](Plugin-ChrootScan) - allows you to retrieve build artifacts from buildroot (e.g. additional logs, coredumps)
 * [compress_logs](Plugin-CompressLogs) - compress logs
+* [export_buildroot_image](Plugin-Export-Buildroot-Image) - export prepared build chroot as an OCI image
 * [hw_info](Plugin-HwInfo) - prints HW information of builder
 * [lvm_root](Plugin-LvmRoot) - caching buildroots using LVM
 * [mount](Plugin-Mount) - allows you to mount directories into chroot

--- a/docs/index.md
+++ b/docs/index.md
@@ -221,8 +221,9 @@ Every plugin has a corresponding wiki page with docs.
 
 ## Features
 
-* [container image for bootstrap](Feature-container-for-bootstrap) - set up bootstrap chroot using Podman.
 * [bootstrap](Feature-bootstrap) - bootstrapping chroot. I.e., when building F28 on RHEL7, then first install very minimal bootstrap chroot with DNF and rpm from F28 and then use F28's rpm to install final F28 chroot.
+* [container image for bootstrap](Feature-container-for-bootstrap) - set up bootstrap chroot using Podman.
+* [container image for buildroot](Feature-buildroot-image) - pre-create buildroot from an OCI image
 * [external dependencies](Feature-external-deps) - use of external dependencies, e.g., `BuildRequires external:pypi:foo`.
 * [forcearch](Feature-forcearch) - build for foreign architecture using emulated virtualization.
 * [nosync](Feature-nosync) - speed up build by making `fsync`(2) no-op.

--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -500,6 +500,11 @@ on non-RPM distributions.  This option turns \fB\-\-bootstrap\-chroot\fR on.
 \fB\-\-no-bootstrap-image\fR
 don't create bootstrap chroot from container image
 
+.TP
+\fB\-\-buildroot\-image\fR \fIBUILDROOT_IMAGE\fR
+Use an OCI image (or a local file containing an OCI image as a tarball) as the
+base for the buildroot.  The image must contain a compatible distribution.
+
 .SH "FILES"
 .LP
 \fI/etc/mock/\fP \- default configuration directory

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -401,6 +401,9 @@
 # config['rootdir'] = '/var/lib/mock/<CONFIG>/root/'
 ## This works in F25+ chroots. This overrides 'use_container_host_hostname' option
 # config_opts['macros']['%_buildhost'] = 'my.own.hostname'
+#
+# Each Mock run has a unique UUID
+#config_opts["mock_run_uuid"] = str(uuid.uuid4())
 
 #############################################################################
 #

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -395,6 +395,7 @@
 #############################################################################
 #
 # Things that you can change, but we dont recommend it:
+#
 # config_opts['chroothome'] = '/builddir'
 # config_opts['clean'] = True
 ## you could not really use substitution here so it will not work if overridden:
@@ -404,6 +405,28 @@
 #
 # Each Mock run has a unique UUID
 #config_opts["mock_run_uuid"] = str(uuid.uuid4())
+#
+# These OCI buildroot related options are set&used automatically by
+# --buildroot-image option logic.  The semantics are similar to the *bootstrap*
+# counterparts above, e.g., see `config_opts['bootstrap_image']`.
+#
+# Use OCI image for build chroot initialization.  Requires 'buildroot_image' to be set.
+#config_opts['use_buildroot_image'] = False
+# Initialize buildroot from this OCI image (image reference).
+#config_opts['buildroot_image'] = None
+# Mock normally tries to pull up2date buildroot image.  Set to True if
+# you want to use the local image.
+#config_opts['buildroot_image_skip_pull'] = False
+# No need to intsall any package into the buildroot extracted from an OCI
+# image.  TODO: not implemented.
+#config_opts['buildroot_image_ready'] = False
+# If the 'buildroot_image' above can not be used for any reason, fallback to a
+# normal DNF installation.  If set to False, it leads to hard failure.
+#config_opts['buildroot_image_fallback'] = False
+# Keep trying 'podman pull' for at most 120s.
+#config_opts['buildroot_image_keep_getting'] = 120
+# If set, mock compares the OCI image digest with the one specified here.
+#config_opts['buildroot_image_assert_digest'] = None
 
 #############################################################################
 #

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -94,6 +94,7 @@ Recommends: dnf-utils
 Recommends: btrfs-progs
 Suggests: qemu-user-static
 Suggests: procenv
+Recommends: buildah
 Recommends: podman
 Recommends: fuse-overlayfs
 

--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -398,6 +398,13 @@ def command_parse():
     parser.add_option('--no-bootstrap-image', dest='usebootstrapimage', action='store_false',
                       help="don't create bootstrap chroot from container image", default=None)
 
+    parser.add_option('--buildroot-image',
+                      help=(
+                          "Use an OCI image (or a local file containing an OCI "
+                          "image as a tarball) as the base for the buildroot. "
+                          "The image must contain a compatible distribution "
+                          "(e.g., fedora:41 for fedora-41-x86_64)"))
+
     parser.add_option('--additional-package', action='append', default=[],
                       type=str, dest="additional_packages",
                       help=("Additional package to install into the buildroot before "

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -277,11 +277,6 @@ class Buildroot(object):
                                   self.chroot_image, podman.image_id)
                 podman.tag_image()
 
-                if self.is_bootstrap and self.config["hermetic_build"]:
-                    tarball = os.path.join(self.config["offline_local_repository"],
-                                           "bootstrap.tar")
-                    podman.import_tarball(tarball)
-
                 digest_expected = self.config.get("image_assert_digest", None)
                 if digest_expected:
                     getLog().info("Checking image digest: %s",

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -272,8 +272,10 @@ class Buildroot(object):
                 if not self.config["image_skip_pull"]:
                     podman.retry_image_pull(self.config["image_keep_getting"])
                 else:
-                    getLog().info("Using local image %s (pull skipped)",
-                                  self.chroot_image)
+                    podman.read_image_id()
+                    getLog().info("Using local image %s (%s)",
+                                  self.chroot_image, podman.image_id)
+                podman.tag_image()
 
                 if self.is_bootstrap and self.config["hermetic_build"]:
                     tarball = os.path.join(self.config["offline_local_repository"],
@@ -294,6 +296,7 @@ class Buildroot(object):
                     raise BootstrapError("Container image architecture check failed")
 
                 podman.cp(self.make_chroot_path(), self.config["tar_binary"])
+                podman.untag()
                 file_util.unlink_if_exists(os.path.join(self.make_chroot_path(),
                                                         "etc/rpm/macros.image-language-conf"))
         except _FallbackException as exc:

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -16,6 +16,7 @@ import re
 import shlex
 import socket
 import sys
+import uuid
 import warnings
 
 from templated_dictionary import TemplatedDictionary
@@ -411,6 +412,7 @@ def setup_default_config_opts():
 
     config_opts["calculatedeps"] = None
     config_opts["hermetic_build"] = False
+    config_opts["mock_run_uuid"] = str(uuid.uuid4())
 
     return config_opts
 

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -31,7 +31,7 @@ PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
                'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor',
-               'rpmautospec', 'buildroot_lock']
+               'rpmautospec', 'buildroot_lock', 'export_buildroot_image']
 
 def nspawn_supported():
     """Detect some situations where the systemd-nspawn chroot code won't work"""
@@ -234,6 +234,8 @@ def setup_default_config_opts():
                 'process-distgit',
             ]
         },
+        'export_buildroot_image_enable': False,
+        'export_buildroot_image_opts': {},
     }
 
     config_opts['environment'] = {

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -105,6 +105,14 @@ def setup_default_config_opts():
     config_opts['bootstrap_image_keep_getting'] = 120
     config_opts['bootstrap_image_assert_digest'] = None
 
+    config_opts['use_buildroot_image'] = False
+    config_opts['buildroot_image'] = None
+    config_opts['buildroot_image_skip_pull'] = False
+    config_opts['buildroot_image_ready'] = False
+    config_opts['buildroot_image_fallback'] = False
+    config_opts['buildroot_image_keep_getting'] = 120
+    config_opts['buildroot_image_assert_digest'] = None
+
     config_opts['internal_dev_setup'] = True
 
     # cleanup_on_* only take effect for separate --resultdir
@@ -675,6 +683,16 @@ def set_config_opts_per_cmdline(config_opts, options, args):
     config_opts["calculatedeps"] = options.calculatedeps
     if config_opts["calculatedeps"]:
         config_opts["plugin_conf"]["buildroot_lock_enable"] = True
+
+    if options.buildroot_image:  # --buildroot-image option
+        if os.path.exists(options.buildroot_image):
+            config_opts["buildroot_image"] = \
+                "oci-archive:" + os.path.realpath(options.buildroot_image)
+        else:
+            config_opts["buildroot_image"] = options.buildroot_image
+
+    if config_opts["buildroot_image"]:
+        config_opts["use_buildroot_image"] = True
 
 def check_config(config_opts):
     if 'root' not in config_opts:

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -777,16 +777,16 @@ def process_hermetic_build_config(cmdline_opts, config_opts):
             f"The {repo_reference} doesn't seem to be a valid "
             "offline RPM repository (RPM metadata not found)")
 
+    # Use the offline image for bootstrapping.
+    bootstrap_tarball = os.path.join(final_offline_repo, "bootstrap.tar")
+    config_opts["bootstrap_image"] = f"oci-archive:{bootstrap_tarball}"
+
     config_opts["offline_local_repository"] = final_offline_repo
 
     # We install all the packages at once (for now?).  We could inherit the
     # command from the previous "online" run, but it often employs a group
     # installation command - and we have no groups in the offline repo.
     config_opts["chroot_setup_cmd"] = "install *"
-
-    # The image needs to be prepared on host.  Build-systems implementing SLSA 3
-    # should make sure the config_opts["bootstrap_image"] is already downloaded.
-    config_opts["bootstrap_image_skip_pull"] = True
 
     # With hermetic builds, we always assert that we are reproducing the build
     # with the same image.

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -202,7 +202,7 @@ class _PackageManager(object):
 
         # We want to know the package versions in bootstrap
         if self.bootstrap_buildroot:
-            if self.bootstrap_buildroot.use_bootstrap_image:
+            if self.bootstrap_buildroot.use_chroot_image:
                 # rpm installed from the bootstrap image
                 _do("downloaded with a bootstrap image", cmd,
                     chrootPath=self.bootstrap_buildroot.make_chroot_path())

--- a/mock/py/mockbuild/plugins/buildroot_lock.py
+++ b/mock/py/mockbuild/plugins/buildroot_lock.py
@@ -7,7 +7,7 @@ https://github.com/rpm-software-management/dnf5/issues/833
 import json
 import os
 
-from mockbuild.podman import Podman
+from mockbuild.podman import Podman, PodmanError
 from mockbuild.installed_packages import query_packages, query_packages_location
 
 requires_api_version = "1.1"
@@ -101,9 +101,12 @@ class BuildrootLockfile:
                     # produce lockfiles even if these are useless for hermetic
                     # builds).
                     with self.buildroot.uid_manager.elevated_privileges():
-                        podman = Podman(self.buildroot,
-                                        data["config"]["bootstrap_image"])
-                        digest = podman.get_image_digest()
+                        try:
+                            podman = Podman(self.buildroot,
+                                            data["config"]["bootstrap_image"])
+                            digest = podman.get_image_digest()
+                        except PodmanError:
+                            digest = "unknown"
                     data["bootstrap"] = {
                         "image_digest": digest,
                     }

--- a/mock/py/mockbuild/plugins/export_buildroot_image.py
+++ b/mock/py/mockbuild/plugins/export_buildroot_image.py
@@ -1,0 +1,65 @@
+"""
+Generate OCI from prepared build chroot.
+Use given OCI image as build chroot (TODO).
+"""
+
+import os
+import mockbuild.util
+from mockbuild.trace_decorator import getLog
+
+requires_api_version = "1.1"
+
+
+def init(plugins, conf, buildroot):
+    """ The obligatory plugin entry point """
+    OCIAsBuildroot(plugins, conf, buildroot)
+
+
+class OCIAsBuildroot:
+    """
+    OCIAsBuildroot plugin (class).
+    """
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.state = buildroot.state
+        self.conf = conf
+        plugins.add_hook("postdeps", self.produce_buildroot_image)
+
+    def do(self, cmd):
+        """ Execute command on host (as root) """
+        getLog().info("Executing %s", ' '.join(cmd))
+        mockbuild.util.do(cmd, returnOutput=True, returnStderr=True)
+
+    def _produce_image_as_root(self):
+        name = f"mock-container-{self.buildroot.config['root']}"
+        tarball = os.path.join(self.buildroot.resultdir, "buildroot-oci.tar")
+        chroot = self.buildroot.make_chroot_path()
+
+        # Add the whole chroot directory into the container
+        self.do(["buildah", "from", "--name", name, "scratch"])
+        self.do(["buildah", "add", "--contextdir", chroot,
+                 "--exclude", "sys", "--exclude", "proc",
+                 name, "/", "/"])
+
+        # Keep just /builddir directory, make it correctly owned
+        self.do(["buildah", "run", name, "rm", "-r",
+                 self.buildroot.config["chroothome"] + "/build"])
+        self.do(["buildah", "run", name, "chown", "-R", "mockbuild:mock",
+                 self.buildroot.config["chroothome"]])
+
+        # When starting container, switch to mockbuild user directly
+        self.do(["buildah", "config", "--user", "mockbuild:mock", name])
+
+        # Export the image as OCI archive, and remove the WIP container
+        self.do(["buildah", "commit", "--format", "oci", name,
+                 "oci-archive:" + tarball])
+        self.do(["buildah", "rm", name])
+
+    def produce_buildroot_image(self):
+        """ Generate OCI image from buildroot using Buildah """
+        try:
+            self.state.start("producing buildroot as OCI image")
+            with self.buildroot.uid_manager.elevated_privileges():
+                self._produce_image_as_root()
+        finally:
+            self.state.finish("producing buildroot as OCI image")

--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -8,7 +8,6 @@ from contextlib import contextmanager
 
 import backoff
 from mockbuild.trace_decorator import getLog, traceLog
-from mockbuild import util
 
 
 class PodmanError(Exception):
@@ -96,14 +95,6 @@ class Podman:
         getLog().info("Tagging container image as %s", self._tagged_id)
         subprocess.run(cmd, env=self.buildroot.env, stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE, check=True)
-
-    def import_tarball(self, tarball):
-        """
-        Import tarball using podman into the local database.
-        """
-        getLog().info("Loading container image from %s", tarball)
-        cmd = [self.podman_binary, "load", "-i", tarball]
-        util.do_with_status(cmd, env=self.buildroot.env)
 
     def retry_image_pull(self, max_time):
         """ Try pulling the image multiple times """

--- a/releng/release-notes-next/export-import-oci-buildroot-image.feature
+++ b/releng/release-notes-next/export-import-oci-buildroot-image.feature
@@ -1,0 +1,3 @@
+A new plugin, `export_buildroot_image`, has been added.  This plugin can export
+the Mock chroot as an OCI archive once all the build dependencies have been
+installed (when the chroot is ready-made for runnign `/bin/rpmbuild -bb`).

--- a/releng/release-notes-next/export-import-oci-buildroot-image.feature
+++ b/releng/release-notes-next/export-import-oci-buildroot-image.feature
@@ -1,3 +1,17 @@
 A new plugin, `export_buildroot_image`, has been added.  This plugin can export
 the Mock chroot as an OCI archive once all the build dependencies have been
 installed (when the chroot is ready-made for runnign `/bin/rpmbuild -bb`).
+
+A new complementary feature has been implemented in Mock, and can be enabled
+using the following option:
+
+    --buildroot-image /tmp/buildroot-oci.tar
+
+It allows the use of generated OCI archives as the source for the build chroot,
+similar to how `bootstrap_image` is used "as the base" for the bootstrap chroot.
+
+Additionally, this feature may be used as:
+
+    --buildroot-image registry.access.redhat.com/ubi8/ubi
+
+Of course, in both cases it is important to use chroot-compatible iamges.


### PR DESCRIPTION
Fixes: #1482

[Exporting OCI image from buildroot](https://github.com/rpm-software-management/mock/blob/ce1037d392cbd7e68f10720ff7526afd90564dad/docs/Plugin-Export-Buildroot-Image.md)

[Using OCI image for initializing buildroot](https://github.com/rpm-software-management/mock/blob/ce1037d392cbd7e68f10720ff7526afd90564dad/docs/Feature-buildroot-image.md)