### PR TITLE
packit: keep testing F40 for now

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,7 +44,8 @@ jobs:
         - mock-core-configs
       targets:
         - fedora-rawhide
-        - fedora-latest-stable
+        - fedora-41
+        - fedora-40
       additional_repos:
         - copr://@mock/mock-deps
 
@@ -58,7 +59,7 @@ jobs:
       job: tests
       trigger: pull_request
       targets:
-        - fedora-latest-stable
+        - fedora-40
       # We don't want to run two test runs; so we limit this to a single package
       packages:
         - mock


### PR DESCRIPTION
The test-suite is not yet ready for F41
https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5

