### PR TITLE
mock: avoid the %pre scriptlet if possible

### DIFF
--- a/releng/release-notes-next/sysusers-on-mageia.bugfix
+++ b/releng/release-notes-next/sysusers-on-mageia.bugfix
@@ -1,0 +1,2 @@
+The %pre scriptlet is not generated for modern distributions like Fedora 39+ or
+Mageia (group/user additions are handled by an RPM built-in feature).


### PR DESCRIPTION
The script for generating the %pre scriptlet is non-existing on new distributions (like Mageia now, but Fedora will drop that sooner or later, too).  The build of Mock on Mageia previously relied on sysusers.generate-pre.sh, and failed.

The sysusers feature is an RPM built-in anyway (on modern systems), so there's no reason to duplicate the logic in %pre.  Generate the %pre scriptlet only for older distributions.

Complements: #1367
Relates: #289
Relates: https://github.com/fedora-copr/copr/issues/2789