### PR TITLE
mock: move backoff python requirement

### DIFF
--- a/mock/requirements.txt
+++ b/mock/requirements.txt
@@ -1,7 +1,7 @@
+backoff
 distro
 jinja2
 pyroute2
 requests
 rpmautospec-core
 templated-dictionary
-backoff

--- a/mock/requirements.txt
+++ b/mock/requirements.txt
@@ -4,3 +4,4 @@ pyroute2
 requests
 rpmautospec-core
 templated-dictionary
+backoff

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps =
     jsonschema
     pytest
     pytest-cov
-    backoff
 setenv =
     PYTHONPATH = ./mock/py
 commands =


### PR DESCRIPTION
Move python backoff requirement from pytest requirements to the mock requirements.txt as it is not a test dependency.
This change does not require release notes, as it does not affect the RPM build process.