### PR TITLE
Use non development bootstrap image for CentOS Stream 10

### DIFF
--- a/mock-core-configs/etc/mock/templates/centos-stream-10.tpl
+++ b/mock-core-configs/etc/mock/templates/centos-stream-10.tpl
@@ -6,7 +6,7 @@ config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'CentOS Stream 10'
 
-config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream10-development'
+config_opts['bootstrap_image'] = 'quay.io/centos/centos:stream10'
 config_opts['bootstrap_image_ready'] = True
 
 config_opts['dnf.conf'] = """

--- a/releng/release-notes-next/use-non-development-centos-bootstrap-image.config.md
+++ b/releng/release-notes-next/use-non-development-centos-bootstrap-image.config.md
@@ -1,0 +1,3 @@
+The CentOS Stream 10 configuration has been updated to use
+`quay.io/centos/centos:stream10` as its bootstrap image,
+instead of the previously used development image.


### PR DESCRIPTION
cc @carlwgeorge Who did the last commit using the development image for CentOS 10 Streams.
