### PR TITLE
hermetic: retry on failed network requests

### DIFF
--- a/mock/py/mock-hermetic-repo.py
+++ b/mock/py/mock-hermetic-repo.py
@@ -15,14 +15,18 @@ import os
 import shutil
 import subprocess
 import sys
+
 from urllib.parse import quote
 
+import backoff
 import requests
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException,
+                      max_tries=5, max_time=300)
 def download_file(url, outputdir):
     """
     Download a single file (pool worker)

--- a/releng/release-notes-next/hermetic-download-retry.bugfix.md
+++ b/releng/release-notes-next/hermetic-download-retry.bugfix.md
@@ -1,0 +1,1 @@
+The mock-hermetic-repo command now implements a retry mechanism for downloading files.


### PR DESCRIPTION
No release note required for this one, I think. Pretty small change.