### PR TITLE
chroot_scan: create chroot_scan/ dir in buildroot.resultdir

### DIFF
--- a/mock/py/mockbuild/plugins/chroot_scan.py
+++ b/mock/py/mockbuild/plugins/chroot_scan.py
@@ -32,10 +32,17 @@ class ChrootScan(object):
         self.config = buildroot.config
         self.state = buildroot.state
         self.scan_opts = conf
-        self.resultdir = os.path.join(buildroot.resultdir, "chroot_scan")
         plugins.add_hook("postbuild", self._scanChroot)
         plugins.add_hook("initfailed", self._scanChroot)
         getLog().info("chroot_scan: initialized")
+
+    @property
+    def resultdir(self):
+        """
+        The plugin's self.resultdir is a subdir of buildroot.resultdir, which
+        is, e.g., for --chain, changed for every single package.
+        """
+        return os.path.join(self.buildroot.resultdir, "chroot_scan")
 
     def _only_failed(self):
         """ Returns boolean value if option 'only_failed' is set. """

--- a/releng/release-notes-next/chroot-scan-resultdir-creation.bugfix
+++ b/releng/release-notes-next/chroot-scan-resultdir-creation.bugfix
@@ -1,0 +1,4 @@
+The [chroot_scan plugin](Plugin-ChrootScan) [issue#1490][] has been fixed so it
+no longer (re)creates resultdir below the global `basedir`, but under the
+per-package resultdir (by default in a `/var/tmp/` sub-directory).  In turn, the
+resultdir is not created with improper ownership.


### PR DESCRIPTION
In the real one now, also for the --chain method which is changing the buildroot.resultdir for every single package.  Previously, chroot_scan/ was (re)created for every --chain package in the basedir:

    /var/lib/mock/fedora-41-x86_64/result/chroot_scan

Now, chroot_scan/ files are written into a package-specific resultdir, for example:

    /var/tmp/mock-chain-root-28259-ie_33sdi/results/default/copr-cli-2.0-1.git.15.526473b.fc41/chroot_scan
    /var/tmp/mock-chain-root-28259-ie_33sdi/results/default/python-copr-2.0-1.git.20.526473b.fc41/chroot_scan

This in turn fixes a --chain build, because it - together with the `chroo_scan` directory it created also `chroot_scan/..` directory, mistakenly root-owned.

Fixes: #1490