### PR TITLE
tox: add Python 3.13, drop 3.7

### DIFF
--- a/.github/workflows/fedora-tox.yml
+++ b/.github/workflows/fedora-tox.yml
@@ -18,12 +18,13 @@ jobs:
     strategy:
       matrix:
         tox_env:
-          - py37
+          # sync with /tox.ini
           - py38
           - py39
           - py310
           - py311
           - py312
+          - py313
 
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py{36,37,38,39,310,311,312}
+# sync with /.github/workflows/fedora-tox.yml
+envlist = py{38,39,310,311,312,313}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
The version 3.7 is no longer available:
py37: skipped because could not find python interpreter with spec(s): py37