### PR TITLE
releng: mock-from-git to have a higher NVR than released versions

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,4 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+test_version_suffix = .test

--- a/docs/Releasing-Mock.md
+++ b/docs/Releasing-Mock.md
@@ -154,16 +154,3 @@ helps you to setup a correct configuration layout.
         [EPEL 8]:
 
         Happy building!
-
-14. Do the post-release administrivia
-
-    - vim mock/mock.spec, and "bump" the version with post-release tag, e.g.
-      from `4.1` to `4.1.post1`.  This assures that any pre-release NVR built
-      from upstream git will be higher than the NVR from Fedora (typically,
-      Fedora bumps the Release `1 => 2` at some point, but we Version from git
-      is still higher).  Also, any subsequent PR that touches
-      `mock-core-configs` so that the package requires newer Mock version, you
-      may specify `Requires: mock >= 4.1.post1` and eventually bump to `post2`,
-      `post3`, etc.
-
-    - `git commit -m 'Post-release administrivia'` (review and push)


### PR DESCRIPTION
Historically, Tito only modified the Release tag for `--test` builds. Now, we also bump the Version field to ensure that Mock built from Git revisions always has a higher NVR than released packages.

https://github.com/rpm-software-management/tito/releases/tag/tito-0.6.27-1