### PR TITLE
Fix docs Plugin-CCache.md (not enabled by default)

### DIFF
--- a/docs/Plugin-CCache.md
+++ b/docs/Plugin-CCache.md
@@ -9,9 +9,9 @@ Note: this plugin was enabled by default in mock-1.2.14 and older.
 
 ## Configuration
 
-The ccache plugin is enabled by default and has the following values built-in:
+The ccache plugin is disabled by default and has the following values built-in:
 
-    config_opts['plugin_conf']['ccache_enable'] = True
+    config_opts['plugin_conf']['ccache_enable'] = False
     config_opts['plugin_conf']['ccache_opts']['max_cache_size'] = '4G'
     config_opts['plugin_conf']['ccache_opts']['compress'] = None
     config_opts['plugin_conf']['ccache_opts']['dir'] = "%(cache_topdir)s/%(root)s/ccache/u%(chrootuid)s/"


### PR DESCRIPTION
The documentation was inconsistent, it stated the ccache plugin as both disabled by default (introduction) and enabled by default (configuration).

according to the code:
https://github.com/rpm-software-management/mock/blob/061d3b64ecce61826d3cbcbe9867a6eba35b9103/mock/py/mockbuild/config.py#L139..L148

The correct statement is disabled by default.

Also fix the configuration snippet accordingly.

Label `no-release-notes` seems appropriate.
