### PR TITLE
doc: `--config-opts` single-item array wants second to be blank

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -314,8 +314,8 @@ Override configuration option. Can be used multiple times.
 When used multiple times for the same key, it will create an array (if you need
 to specify an array value with just a single item, e.g.
 \fIconfig_opts["foo"] = ["baz"]\fR, specify it as array of two items with the
-empty string as the first item, e.g.  \fI--config-opts=foo=
---config-opts=foo=baz\fR).
+empty string as the second item, e.g.  \fI--config-opts=foo=baz
+--config-opts=foo=\fR).
 
 This is evaluated after parsing configs, so command line options override
 previously defined options.


### PR DESCRIPTION
When specifying an array with a single element using `--config-opts`, the user should specify the second item as empty, not the first:

Wrong:

```
$ mock --config-opts=foo= --config-opts=foo=bar --debug-config | grep foo
config_opts['foo'] = ['', 'bar']
```

Correct:

```
$ mock --config-opts=foo=bar --config-opts=foo= --debug-config | grep foo
config_opts['foo'] = ['bar']
```

The release notes where the feature was announced, Release-Notes-1.4.8.md, were correct but the man page was not.

I think this is probably `label no-release-notes`.
