### PR TITLE
Add Kylin 10, Azure Linux 2 and 3 configuration files

### DIFF
--- a/docs/Mock-Core-Configs.md
+++ b/docs/Mock-Core-Configs.md
@@ -51,6 +51,7 @@ distribution.
 | [EuroLinux](https://en.euro-linux.com/)                                        | `eurolinux-*`     | [@nkadel](https://github.com/nkadel)                                  | [Issues](https://github.com/EuroLinux/eurolinux-distro-bugs-and-rfc)  |
 | [Fedora ELN](https://docs.fedoraproject.org/en-US/eln/)                        | `fedora-eln-*`    | [@fedora-eln](https://github.com/fedora-eln)                          | [Issues](https://github.com/fedora-eln/eln/issues)  |
 | [Fedora](https://fedoraproject.org/)                                           | `fedora-*`        | NA                                                                    | [Issues](https://bugzilla.redhat.com/)  |
+| [Kylin](https://kylinos.cn/)                                                   | `kylin-*`         | [@scaronni](https://github.com/scaronni)                              | NA  |
 | [Mageia](https://www.mageia.org/en/)                                           | `mageia-*`        | [@Conan-Kudo](https://github.com/Conan-Kudo)                          | [Issues](https://bugs.mageia.org/)  |
 | [openEuler](https://www.openeuler.org/en/)                                     | `openeuler-*`     | [@Yikun](https://github.com/Yikun)                                    | NA  |
 | [OpenMandriva](https://www.openmandriva.org/)                                  | `openmandriva-*`  | [berolinux](https://github.com/berolinux)                             | [Issues](https://github.com/OpenMandrivaAssociation/distribution/issues)  |

--- a/docs/Mock-Core-Configs.md
+++ b/docs/Mock-Core-Configs.md
@@ -45,6 +45,7 @@ distribution.
 | [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/)                       | `amazonlinux-2-*` | [@stewartsmith](https://github.com/stewartsmith)                      | NA  |
 | [Amazon Linux](https://aws.amazon.com/linux/amazon-linux-2023/)                | `amazonlinux-*`   | [@amazonlinux](https://github.com/amazonlinux)                        | [Issues](https://github.com/amazonlinux/amazon-linux-2023/issues)  |
 | [Anolis](https://openanolis.cn/)                                               | `anolis-*`        | NA                                                                    | [Issues](https://bugzilla.openanolis.cn/)  |
+| [Azure Linux](https://github.com/microsoft/azurelinux)                         | `azure-linux-*`   | [@scaronni](https://github.com/scaronni)                              | [Issues](https://github.com/microsoft/azurelinux/issues)  |
 | [CentOS Stream](https://www.centos.org/centos-stream/)                         | `centos-stream*`  | [@rpm-software-management](https://github.com/rpm-software-management)| [Issues](https://issues.redhat.com/projects/CS)  |
 | [CentOS Linux](https://www.centos.org/centos-linux/)                           | `centos*`         | [@rpm-software-management](https://github.com/rpm-software-management)| NA  |
 | [Circle Linux](https://cclinux.org/)                                           | `circlelinux-*`   | [@bella485](https://github.com/bella485)                              | [Issues](https://bugzilla.cclinux.org/)  |

--- a/mock-core-configs/etc/mock/azure-linux-2-aarch64.cfg
+++ b/mock-core-configs/etc/mock/azure-linux-2-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/azure-linux-2.tpl')
+
+config_opts['root'] = 'azure-linux-2-x86_64'
+config_opts['description'] = 'Azure Linux 2.0'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/azure-linux-2-x86_64.cfg
+++ b/mock-core-configs/etc/mock/azure-linux-2-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/azure-linux-2.tpl')
+
+config_opts['root'] = 'azure-linux-2-x86_64'
+config_opts['description'] = 'Azure Linux 2.0'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/azure-linux-3-aarch64.cfg
+++ b/mock-core-configs/etc/mock/azure-linux-3-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/azure-linux-3.tpl')
+
+config_opts['root'] = 'azure-linux-3-x86_64'
+config_opts['description'] = 'Azure Linux 3.0'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/azure-linux-3-x86_64.cfg
+++ b/mock-core-configs/etc/mock/azure-linux-3-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/azure-linux-3.tpl')
+
+config_opts['root'] = 'azure-linux-3-x86_64'
+config_opts['description'] = 'Azure Linux 3.0'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/kylin-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/kylin-10-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/kylin-10.tpl')
+
+config_opts['root'] = 'kylin-10-aarch64'
+config_opts['description'] = 'Kylin Linux 10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/kylin-10-loongarch64.cfg
+++ b/mock-core-configs/etc/mock/kylin-10-loongarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/kylin-10.tpl')
+
+config_opts['root'] = 'kylin-10-loongarch64'
+config_opts['description'] = 'Kylin Linux 10'
+config_opts['target_arch'] = 'loongarch64'
+config_opts['legal_host_arches'] = ('loongarch64',)

--- a/mock-core-configs/etc/mock/kylin-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/kylin-10-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/kylin-10.tpl')
+
+config_opts['root'] = 'kylin-10-x86_64'
+config_opts['description'] = 'Kylin Linux 10'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/azure-linux-2.tpl
+++ b/mock-core-configs/etc/mock/templates/azure-linux-2.tpl
@@ -1,0 +1,64 @@
+config_opts['chroot_setup_cmd'] = 'install bash binutils bzip2 coreutils cpio diffutils dnf findutils gawk glibc-devel grep gzip kernel-headers patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'cm2'
+config_opts['releasever'] = '2.0'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+
+# https://mcr.microsoft.com/en-us/product/cbl-mariner/base/core/tags:
+# config_opts['bootstrap_image'] = 'mcr.microsoft.com/cbl-mariner/base/core:2.0'
+# Container image contains tdnf (https://github.com/vmware/tdnf) as the base package manager so it can't be used:
+config_opts['use_bootstrap'] = False
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:2.9
+user_agent={{ user_agent }}
+
+[mariner-official-base]
+name=CBL-Mariner Official Base $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/base/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+[mariner-official-extras]
+name=CBL-Mariner Official Extras $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/extras/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+[mariner-official-extended]
+name=CBL-Mariner Official Extended $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/extended/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+[mariner-official-microsoft]
+name=CBL-Mariner Official Microsoft $releasever $basearch
+baseurl=https://packages.microsoft.com/cbl-mariner/$releasever/prod/Microsoft/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-METADATA-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+"""

--- a/mock-core-configs/etc/mock/templates/azure-linux-3.tpl
+++ b/mock-core-configs/etc/mock/templates/azure-linux-3.tpl
@@ -1,0 +1,64 @@
+config_opts['chroot_setup_cmd'] = 'install bash binutils bzip2 coreutils cpio diffutils dnf findutils gawk glibc-devel grep gzip kernel-headers patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'azl3'
+config_opts['releasever'] = '3.0'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+
+# https://mcr.microsoft.com/en-us/product/azurelinux/base/core/tags:
+# config_opts['bootstrap_image'] = 'mcr.microsoft.com/azurelinux/base/core:3.0'
+# Container image contains tdnf (https://github.com/vmware/tdnf) as the base package manager so it can't be used:
+config_opts['use_bootstrap'] = False
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:2.9
+user_agent={{ user_agent }}
+
+[azurelinux-official-base]
+name=Azure Linux Official Base $releasever $basearch
+baseurl=https://packages.microsoft.com/azurelinux/$releasever/prod/base/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+[azurelinux-official-extended]
+name=Azure Linux Official Extended $releasever $basearch
+baseurl=https://packages.microsoft.com/azurelinux/$releasever/prod/extended/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+[azurelinux-official-ms-oss]
+name=Azure Linux Official Microsoft Open-Source $releasever $basearch
+baseurl=https://packages.microsoft.com/azurelinux/$releasever/prod/ms-oss/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+[azurelinux-official-ms-non-oss]
+name=Azure Linux Official Microsoft Non-Open-Source $releasever $basearch
+baseurl=https://packages.microsoft.com/azurelinux/$releasever/prod/ms-non-oss/$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/azure-linux/MICROSOFT-RPM-GPG-KEY
+gpgcheck=1
+repo_gpgcheck=1
+enabled=1
+
+"""

--- a/mock-core-configs/etc/mock/templates/kylin-10.tpl
+++ b/mock-core-configs/etc/mock/templates/kylin-10.tpl
@@ -1,0 +1,46 @@
+config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ kylin-rpm-config kylin-release which xz sed make bzip2 gzip gcc coreutils unzip diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
+config_opts['dist'] = 'ky10' # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+
+# No official image available:
+config_opts['use_bootstrap_image'] = False
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:ky10
+user_agent={{ user_agent }}
+
+[ks10-adv-os]
+name = Kylin Linux Advanced Server V10 - OS
+baseurl = https://update.cs2c.com.cn/NS/V10/V10SP3-2403/os/adv/lic/base/$basearch/
+gpgkey = file:///usr/share/distribution-gpg-keys/kylin/RPM-GPG-KEY-kylin
+gpgcheck = 1
+enabled = 1
+
+[ks10-adv-updates]
+name = Kylin Linux Advanced Server V10 - Updates
+baseurl = https://update.cs2c.com.cn/NS/V10/V10SP3-2403/os/adv/lic/updates/$basearch/
+gpgkey = file:///usr/share/distribution-gpg-keys/kylin/RPM-GPG-KEY-kylin
+gpgcheck = 1
+enabled = 1
+# This repository is not present if a minor release is out but without any update yet:
+skip_if_unavailable = 1
+
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.108
+Requires:   distribution-gpg-keys >= 1.109
 # specify minimal compatible version of mock
 Requires:   mock >= 5.4.post1
 Requires:   mock-filesystem

--- a/releng/release-notes-next/azure-linux-2.config
+++ b/releng/release-notes-next/azure-linux-2.config
@@ -1,0 +1,1 @@
+Add Azure Linux 2.0 configuration (x68_64, aarch64). The distribution changed name mid lifecycle, it was originally called "CBL Mariner 2.0", replacing "Common Base Linux 1.0". That's why the distribution tag is still "cm2" and has "mariner" references in the repository.

--- a/releng/release-notes-next/azure-linux-3.config
+++ b/releng/release-notes-next/azure-linux-3.config
@@ -1,0 +1,1 @@
+Add Azure Linux 3.0 configuration (x86_64, aarch64).

--- a/releng/release-notes-next/kylin-10.config
+++ b/releng/release-notes-next/kylin-10.config
@@ -1,0 +1,1 @@
+Add Kylin 10 mock configuration files (x86_64, aarch64, loongarch64).


### PR DESCRIPTION
As mentioned in the openSUSE 15.6 merge request, we are moving everything to `mock` for building packages in NVIDIA. These are more configurations for additional distributions I had the "pleasure" to work on for supporting NVIDIA drivers  + CUDA:

- Kylin 10
  - No OCI image used, as there's no official image available.
- Azure Linux 2
  - Microsoft decided to rename it from CBL Mariner 2.0 (following Common Base Linux 1.0) mid lifecycle, so the repositories are called `mariner` and there's `cm2` as a `dist` tag.
  - No OCI image used, it uses "`tiny dandified dnf`" as the package manager.
- Azure Linux 3
  - No OCI image used, it uses "`tiny dandified dnf`" as the package manager.