### PR TITLE
Navy Linux 8 configuration fixes #1538

### DIFF
--- a/docs/Mock-Core-Configs.md
+++ b/docs/Mock-Core-Configs.md
@@ -55,7 +55,7 @@ distribution.
 | [Fedora](https://fedoraproject.org/)                                           | `fedora-*`        | [Mock team][]                                                         | [Issues](https://github.com/rpm-software-management/mock/issues) |
 | [Kylin](https://kylinos.cn/)                                                   | `kylin-*`         | [@scaronni](https://github.com/scaronni)                              | NA  |
 | [Mageia](https://www.mageia.org/en/)                                           | `mageia-*`        | [@Conan-Kudo](https://github.com/Conan-Kudo)                          | [Issues](https://bugs.mageia.org/)  |
-| [Navy Linux](https://navylinux.org/)                                           | `navy-*`          | N/A                                                                   | N/A |
+| [Navy Linux](https://navylinux.org/)                                           | `navy-*`          | [@unixlabs](https://github.com/unixlabs)                              | [issues](https://github.com/navy-linux/issue-tracker/issues) |
 | [openEuler](https://www.openeuler.org/en/)                                     | `openeuler-*`     | [@Yikun](https://github.com/Yikun)                                    | NA  |
 | [OpenMandriva](https://www.openmandriva.org/)                                  | `openmandriva-*`  | [berolinux](https://github.com/berolinux)                             | [Issues](https://github.com/OpenMandrivaAssociation/distribution/issues)  |
 | [openSUSE](https://www.opensuse.org/)                                          | `opensuse-*`      | [@Conan-Kudo](https://github.com/Conan-Kudo), [@lkocman](https://github.com/lkocman) | [Issues](https://bugzilla.opensuse.org/)  |

--- a/mock-core-configs/etc/mock/navy+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/navy+epel-8-x86_64.cfg
@@ -1,5 +1,7 @@
 config_opts['root'] = 'navy-8-x86_64'
 config_opts['target_arch'] = 'x86_64'
 config_opts['legal_host_arches'] = ('x86_64',)
+
 include('templates/navy-8.tpl')
 include('templates/epel-8.tpl')
+

--- a/mock-core-configs/etc/mock/navy+epel-8-x86_64.cfg
+++ b/mock-core-configs/etc/mock/navy+epel-8-x86_64.cfg
@@ -1,0 +1,5 @@
+config_opts['root'] = 'navy-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+include('templates/navy-8.tpl')
+include('templates/epel-8.tpl')

--- a/mock-core-configs/etc/mock/templates/navy-8.tpl
+++ b/mock-core-configs/etc/mock/templates/navy-8.tpl
@@ -4,8 +4,6 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['description'] = 'Navy Linux {{ releasever }}'
-# FIXME: this might soon stop working because the image is 8.4, see
-#        https://github.com/rpm-software-management/mock/issues/1171
 config_opts['bootstrap_image'] = 'docker.io/navylinux/navylinux:latest'
 
 config_opts['dnf.conf'] = """

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.109
+Requires:   distribution-gpg-keys >= 1.110
 # specify minimal compatible version of mock
 Requires:   mock >= 5.4.post1
 Requires:   mock-filesystem
@@ -149,6 +149,9 @@ fi
 %ghost %config(noreplace,missingok) %{_sysconfdir}/mock/default.cfg
 
 %changelog
+* Mon Feb 17 2025 Adil Hussain <adil@linux.com> 42.1-1
+- configs: update distribution-gpg-keys v1.110
+  
 * Thu Jan 16 2025 Pavel Raiskup <praiskup@redhat.com> 42.1-1
 - branch fedora-42 configs, move rawhide to releasever=43
 

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -149,9 +149,6 @@ fi
 %ghost %config(noreplace,missingok) %{_sysconfdir}/mock/default.cfg
 
 %changelog
-* Mon Feb 17 2025 Adil Hussain <adil@linux.com> 42.1-1
-- configs: update distribution-gpg-keys v1.110
-  
 * Thu Jan 16 2025 Pavel Raiskup <praiskup@redhat.com> 42.1-1
 - branch fedora-42 configs, move rawhide to releasever=43
 

--- a/releng/release-notes-next/navy-linux.config
+++ b/releng/release-notes-next/navy-linux.config
@@ -1,0 +1,1 @@
+Navy Linux 8 configuration fixed #1538

--- a/releng/release-notes-next/navy-linux.config
+++ b/releng/release-notes-next/navy-linux.config
@@ -1,1 +1,1 @@
-Navy Linux 8 configuration fixed #1538
+Navy Linux 8 configuration [fixed][issue#1538]


### PR DESCRIPTION
# Navy Linux 8 configuration fixes
Fixes: #1538

# dependency update for config: distribution-gpg-keys 
# add `label no-release-notes` 
