### PR TITLE
fix: expand Oracle Linux distro_id from ol to oraclelinux

### DIFF
--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -119,6 +119,10 @@ almalinux)
   # AlmaLinux configs look like 'alma+epel'
   distro_id=alma
   ;;
+ol)
+  # Oracle Linux uses 'oraclelinux' as the file prefix
+  distro_id=oraclelinux
+  ;;
 esac
 cfg=$distro_id+epel-$ver-$mock_arch.cfg
 %endif
@@ -689,5 +693,3 @@ fi
 
 * Thu Sep 07 2017 Miroslav Suchý <msuchy@redhat.com> 27.1-1
 - Split from Mock package.
-
-

--- a/releng/release-notes-next/oraclelinux-distro_id.config
+++ b/releng/release-notes-next/oraclelinux-distro_id.config
@@ -1,0 +1,1 @@
+Expand Oracle Linux distro_id from `ol` to `oraclelinux` when looking for configuration files [issue#1545]


### PR DESCRIPTION
# Add a reference to related issue - preferably in the git commit message
Fixes: #1545

# Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
# or let us know to add `label no-release-notes` if you think the change does
# not deserve a release note.
Expand Oracle Linux distro_id from `ol` to `oraclelinux` when looking for configuration files [issue#1545]