### PR TITLE
podman: bail clearly when image pull fails

### DIFF
--- a/releng/release-notes-next/podman-pull-fallback.bugfix
+++ b/releng/release-notes-next/podman-pull-fallback.bugfix
@@ -1,0 +1,1 @@
+mock will now fall back smoothly to chroot if podman image pull fails entirely.


### PR DESCRIPTION
We retry the image pull with a `@backoff.on_predicate` wrapper, but it can still fail entirely. When that happens, `image_id` remains as `None` and this causes us to hit a subprocess exception in `tag_image`. Because the buildroot `_fallback` decorator only handles `PodmanError` exceptions, we blow up on that exception instead of falling back smoothly to chroot.

This solves that by giving the backoff wrapper an `on_giveup` handler that raises `PodmanError`, so the fallback mechanism should kick in.