### PR TITLE
Update Azure Linux configurations

### DIFF
--- a/mock-core-configs/etc/mock/templates/azure-linux-2.tpl
+++ b/mock-core-configs/etc/mock/templates/azure-linux-2.tpl
@@ -1,4 +1,4 @@
-config_opts['chroot_setup_cmd'] = 'install bash binutils bzip2 coreutils cpio diffutils dnf findutils gawk glibc-devel grep gzip kernel-headers patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['chroot_setup_cmd'] = 'install bash binutils bzip2 coreutils cpio diffutils dnf findutils gawk glibc-devel grep gzip kernel-headers patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
 config_opts['dist'] = 'cm2'
 config_opts['releasever'] = '2.0'
 config_opts['package_manager'] = 'dnf'

--- a/mock-core-configs/etc/mock/templates/azure-linux-3.tpl
+++ b/mock-core-configs/etc/mock/templates/azure-linux-3.tpl
@@ -1,5 +1,6 @@
-config_opts['chroot_setup_cmd'] = 'install bash binutils bzip2 coreutils cpio diffutils dnf findutils gawk glibc-devel grep gzip kernel-headers patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['chroot_setup_cmd'] = 'install bash binutils bzip2 coreutils cpio diffutils dnf findutils gawk glibc-devel grep gzip kernel-headers patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz'
 config_opts['dist'] = 'azl3'
+config_opts['macros']['%dist'] = '.azl3'
 config_opts['releasever'] = '3.0'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]

--- a/releng/release-notes-next/azure-linux.config
+++ b/releng/release-notes-next/azure-linux.config
@@ -1,0 +1,2 @@
+Update the list of packages installed by default in the Azure Linux 2 & 3 chroot to include shadow-utils. Due to recent changes, the useradd/groupadd commands are required by other packages in the list, but the requirements are not specified correctly.
+Add %dist macro to the Azure Linux 3 template.


### PR DESCRIPTION
Update the list of packages installed by default in the chroot to include `shadow-utils` so creating the `chroot` does not fail.

Due to recent changes, the `useradd/groupadd` commands are required by other packages in the list but the requirements are not specified correctly. 
