### PR TITLE
Add epel-z-10 template

### DIFF
--- a/mock-core-configs/etc/mock/templates/epel-z-10.tpl
+++ b/mock-core-configs/etc/mock/templates/epel-z-10.tpl
@@ -7,19 +7,19 @@ config_opts['dnf.conf'] += """
 # available since dnf 4.18.0.  In some configurations mock will be using the
 # host dnf to bootstrap the chroot, which could be older and lack those
 # features, leading to problems.  The alternative is to use this simplified
-# metalink here in this template for CentOS Stream, and a different metalink in
-# another template for RHEL.
+# metalink here in this template for RHEL, and a different metalink in
+# another template for CentOS Stream.
 
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearch
-metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-{{ releasever_major }}&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-z-{{ releasever_major }}&arch=$basearch
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-{{ releasever_major }}
 gpgcheck=1
 countme=1
 
 [epel-testing]
 name=Extra Packages for Enterprise Linux $releasever - Testing - $basearch
-metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-testing-{{ releasever_major }}&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-z-testing-{{ releasever_major }}&arch=$basearch
 gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-{{ releasever_major }}
 gpgcheck=1
 countme=1
@@ -28,11 +28,11 @@ enabled=0
 {% if koji_primary_repo == "epel" %}
 
 # The baseurl below is a symlink in the koji infrastructure that moves forward
-# over time to the buildroot repo of the minor version tag matching CentOS Stream.
+# over time to the buildroot repo of the minor version tag matching RHEL.
 
 [local]
 name=Extra Packages for Enterprise Linux $releasever - Koji Local - BUILDROOT ONLY!
-baseurl=https://kojipkgs.fedoraproject.org/repos/epel{{ releasever_major }}/latest/$basearch/
+baseurl=https://kojipkgs.fedoraproject.org/repos/epel{{ releasever_major }}z/latest/$basearch/
 cost=2000
 enabled=0
 skip_if_unavailable=False

--- a/releng/release-notes-next/epel10-separate-templates.config
+++ b/releng/release-notes-next/epel10-separate-templates.config
@@ -1,0 +1,3 @@
+The EPEL 10 configuration has been updated to have separate templates available
+for use on CentOS Stream 10 (epel-10.tpl) and RHEL 10 (epel-z-10.tpl).  Relates
+to [issue#1427][].


### PR DESCRIPTION
EPEL 10 "floating target" repo names have been implemented.  This adds a new epel-z-10 template that uses the names for the minor version tracking RHEL 10, and makes minor adjustments to the epel-10 template to use the names for the minor version tracking CentOS Stream 10.

Relates: #1427