### PR TITLE
Remove traceLog decorator from pretty_getcwd

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -884,7 +884,6 @@ def setup_host_resolv(config_opts):
     config_opts['nspawn_args'] += ['--bind={0}:/etc/resolv.conf'.format(resolv_path)]
 
 
-@traceLog()
 def pretty_getcwd():
     try:
         return os.getcwd()


### PR DESCRIPTION
`pretty_getcwd()` is called during module import (to set `ORIGINAL_CWD`), and using a traced function creates unwanted side effects.

Fixes: #1583

I think this can be `label no-release-notes`, let me know if you disagree.