### PR TITLE
Add AlmaLinux 10 configuration

### DIFF
--- a/mock-core-configs/etc/mock/alma+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-aarch64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-ppc64le.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-s390x.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-s3100x.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/alma+epel-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('almalinux-10-x86_64.cfg')
+include('templates/epel-10.tpl')
+
+config_opts['root'] = "alma+epel-10-{{ target_arch }}"
+config_opts['description'] = 'AlmaLinux 10 + EPEL'

--- a/mock-core-configs/etc/mock/almalinux-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-aarch64'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/almalinux-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-ppc64le'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/almalinux-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-s390x.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-s3100x'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 's3100x'
+config_opts['legal_host_arches'] = ('s3100x',)

--- a/mock-core-configs/etc/mock/almalinux-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/almalinux-10-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/almalinux-10.tpl')
+
+config_opts['root'] = 'almalinux-10-x86_64'
+config_opts['description'] = 'AlmaLinux 10'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/almalinux-10.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-10.tpl
@@ -1,0 +1,151 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils redhat-release findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'el10.alma'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:10'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+install_weak_deps=0
+protected_packages=
+module_platform_id=platform:el10
+user_agent={{ user_agent }}
+
+
+[baseos]
+name=AlmaLinux $releasever - BaseOS
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+skip_if_unavailable=False
+
+[appstream]
+name=AlmaLinux $releasever - AppStream
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[crb]
+name=AlmaLinux $releasever - CRB
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[extras]
+name=AlmaLinux $releasever - Extras
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[devel]
+name=AlmaLinux $releasever - Devel (WARNING: UNSUPPORTED - FOR BUILDROOT USE ONLY!)
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/devel
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/devel/$basearch/os/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[baseos-debuginfo]
+name=AlmaLinux $releasever - BaseOS debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[appstream-debuginfo]
+name=AlmaLinux $releasever - AppStream debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[crb-debuginfo]
+name=AlmaLinux $releasever - CRB debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[extras-debuginfo]
+name=AlmaLinux $releasever - Extras debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[devel-debuginfo]
+name=AlmaLinux $releasever - Devel debuginfo
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/devel-debuginfo
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/devel/debug/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[baseos-source]
+name=AlmaLinux $releasever - BaseOS Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[appstream-source]
+name=AlmaLinux $releasever - AppStream Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[crb-source]
+name=AlmaLinux $releasever - CRB Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[extras-source]
+name=AlmaLinux $releasever - Extras Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+[devel-source]
+name=AlmaLinux $releasever - Devel Source
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/devel-source
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/devel/Source/
+enabled=0
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+
+"""

--- a/releng/release-notes-next/almalinx-10.config
+++ b/releng/release-notes-next/almalinx-10.config
@@ -1,0 +1,1 @@
+Mock chroots for AlmaLinux 10 and AlmaLinux+EPEL 10 have been added.


### PR DESCRIPTION
Mock chroots for AlmaLinux 10 and AlmaLinux+EPEL 10 have been added.

GPG key is already in the `distribution-gpg-keys`.

At the moment of writing, container images are not yet available to test the configuration as is, but they will be shortly. Will create a separate pull request for `x86_64_v2` for AlmaLinux 10, Kitten, EPEL, etc. if no one beats me to it.