### PR TITLE
feat: plugin: hw_info: added human-readable flag for memory info

### DIFF
--- a/mock/py/mockbuild/plugins/hw_info.py
+++ b/mock/py/mockbuild/plugins/hw_info.py
@@ -42,7 +42,7 @@ class HwInfo(object):
         out.write("CPU info:\n")
         out.write(output)
 
-        cmd = ["/bin/free"]
+        cmd = ["/bin/free", "--human"]
         output = mockbuild.util.do(cmd, shell=False, returnOutput=True, raiseExc=False)
         out.write("\n\nMemory:\n")
         out.write(output)

--- a/releng/release-notes-next/hwinfo-plugin-memory-human.feature
+++ b/releng/release-notes-next/hwinfo-plugin-memory-human.feature
@@ -1,0 +1,1 @@
+hw_info plugin now reports memory info units in human readable scale


### PR DESCRIPTION
I'm bit confused, when I tried to debug build failure - I expected the worker memory to be less than 4GB, I was surprised when I saw 256MB. As it turned out, it was 256GB actually, I converted the bytes
The `free` program prints values in kibibytes by default. Not in bytes, that more than expected without flags

This PR add's `--human` flag, so that the plugin output for storage and memory has the same units. Currently, such a flag is[ set for storage](https://github.com/rpm-software-management/mock/blob/main/mock/py/mockbuild/plugins/hw_info.py#L50)

> Show all output fields automatically scaled to shortest three digit unit and display the units of print out.  Following units are used:
                **B** = bytes
                **Ki** = kibibyte
                **Mi** = mebibyte
                **Gi** = gibibyte
                **Ti** = tebibyte
                **Pi** = pebibyte
