### PR TITLE
dockertest: enable @mock/mock-deps

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -12,5 +12,6 @@ RUN tito build --test --rpm
 WORKDIR /home/user/mock/mock
 RUN tito build --test --rpm
 USER root
+RUN dnf -y copr enable @mock/mock-deps
 RUN dnf -y install --allow-downgrade /tmp/tito/*/mock*.rpm
 USER user


### PR DESCRIPTION
This repo is regularly used for pre-release builds of Mock dependencies (e.g. distribution-gpg-keys, when waiting for updates-testing).
