### PR TITLE
Add Rocky Linux 10 mock configs

### DIFF
--- a/mock-core-configs/etc/mock/rocky+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-aarch64.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-aarch64.cfg')
+include('templates/epel-z-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-ppc64le.cfg')
+include('templates/epel-z-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-s390x.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-s390x.cfg')
+include('templates/epel-z-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky+epel-10-x86_64.cfg
@@ -1,0 +1,5 @@
+include('rocky-10-x86_64.cfg')
+include('templates/epel-z-10.tpl')
+
+config_opts['root'] = "rocky+epel-10-{{ target_arch }}"
+config_opts['description'] = 'Rocky Linux 10 + EPEL'

--- a/mock-core-configs/etc/mock/rocky-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-aarch64'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/rocky-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-ppc64le.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-ppc64le'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/rocky-10-riscv64.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-riscv64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-x86_64'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'riscv64'
+config_opts['legal_host_arches'] = ('riscv64',)

--- a/mock-core-configs/etc/mock/rocky-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-s390x.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-s390x'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/rocky-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/rocky-10-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/rocky-10.tpl')
+
+config_opts['root'] = 'rocky-10-x86_64'
+config_opts['description'] = 'Rocky Linux 10'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/rocky-10.tpl
+++ b/mock-core-configs/etc/mock/templates/rocky-10.tpl
@@ -1,0 +1,151 @@
+config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils findutils gawk glibc-minimal-langpack grep gzip info patch redhat-rpm-config rocky-release rpm-build sed tar unzip util-linux which xz'
+config_opts['dist'] = 'el10'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '10'
+config_opts['releasever_major'] = '10'
+config_opts['package_manager'] = 'dnf'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['bootstrap_image'] = 'quay.io/rockylinux/rockylinux:10'
+
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+metadata_expire=0
+best=1
+install_weak_deps=0
+protected_packages=
+skip_if_unavailable=False
+module_platform_id=platform:el10
+user_agent={{ user_agent }}
+
+
+[baseos]
+name=Rocky Linux $releasever - BaseOS
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/os/
+gpgcheck=1
+countme=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[appstream]
+name=Rocky Linux $releasever - AppStream
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+countme=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[crb]
+name=Rocky Linux $releasever - CRB
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/$basearch/os/
+gpgcheck=1
+countme=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[extras]
+name=Rocky Linux $releasever - Extras
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[devel]
+name=Rocky Linux $releasever - Devel WARNING! FOR BUILDROOT ONLY DO NOT LEAVE ENABLED
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=devel-$releasever
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/devel/$basearch/os/
+gpgcheck=1
+enabled=0
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[baseos-debug]
+name=Rocky Linux $releasever - BaseOS - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[baseos-source]
+name=Rocky Linux $releasever - BaseOS - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=BaseOS-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/BaseOS/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[appstream-debug]
+name=Rocky Linux $releasever - AppStream - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[appstream-source]
+name=Rocky Linux $releasever - AppStream - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=AppStream-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/AppStream/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[crb-debug]
+name=Rocky Linux $releasever - CRB - Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[crb-source]
+name=Rocky Linux $releasever - CRB - Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=source&repo=CRB-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/CRB/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[extras-debug]
+name=Rocky Linux $releasever - Extras Debug
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-debug
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/$basearch/debug/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+[extras-source]
+name=Rocky Linux $releasever - Extras Source
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-$releasever-source
+#baseurl=http://dl.rockylinux.org/pub/rocky/$releasever/extras/source/tree/
+gpgcheck=1
+enabled=0
+metadata_expire=6h
+gpgkey=file:///usr/share/distribution-gpg-keys/rocky/RPM-GPG-KEY-Rocky-10
+
+
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.112
+Requires:   distribution-gpg-keys >= 1.113
 # specify minimal compatible version of mock
 Requires:   mock >= 6.1.test
 Requires:   mock-filesystem

--- a/releng/release-notes-next/rockylinux10.config
+++ b/releng/release-notes-next/rockylinux10.config
@@ -1,0 +1,1 @@
+Added Rocky Linux 10 configs


### PR DESCRIPTION
This PR adds in the Rocky Linux 10 mock configurations. Please let me know if I need to make any changes.

Related: https://github.com/rpm-software-management/distribution-gpg-keys/pull/139