### PR TITLE
ProcessPoolExecutor changed behaviour with Python 3.14

### DIFF
--- a/releng/release-notes-next/python314.bugfix
+++ b/releng/release-notes-next/python314.bugfix
@@ -1,0 +1,4 @@
+This release include fix with Python 3.14 incompatibility. [#1594](https://github.com/rpm-software-management/mock/issues/1594)
+
+Mock refused to start as non-root user with Python 3.14. This was because of the change in behaviour of ProcessPoolExecutor in Python.
+The code was altered to work with both old and new Python.


### PR DESCRIPTION
Fixes: #1594
RHBZ#2372865

Previously, the default method of starting a process was fork. With Python3.14 it is no longer true (I think that default is spawner). But the new default does not work with Mock code and causes traceback:

```
Traceback (most recent call last):
  File "/usr/libexec/mock/mock", line 1140, in <module>
    main()
    ~~~~^^
  File "/usr/lib/python3.14/site-packages/mockbuild/trace_decorator.py", line 93, in trace
    result = func(*args, **kw)
  File "/usr/libexec/mock/mock", line 718, in main
    config_opts = uidManager.run_in_subprocess_without_privileges(
            config.load_config, config_path, options.chroot)
  File "/usr/lib/python3.14/site-packages/mockbuild/uid.py", line 183, in run_in_subprocess_without_privileges
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/concurrent/futures/_base.py", line 450, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.14/concurrent/futures/_base.py", line 395, in __get_result
    raise self._exception
PermissionError: [Errno 1] Operation not permitted
```

This change explicitely set the start method to "fork".

