### PR TITLE
Fix unclosed file warning

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -719,7 +719,8 @@ def include(config_file, search_path, paths):
             return ""
 
         paths.add(config_file)
-        content = open(config_file).read()
+        with open(config_file) as f:
+            content = f.read()
         # Search for "include(FILE)" and for each "include(FILE)" replace with
         # content of the FILE, in a perpective of search for includes and replace with his content.
         include_arguments = regexp_include.findall(content)


### PR DESCRIPTION
No functional changes - just silencing a ResourceWarning by ensuring the file handle is explicitly closed.
ResourceWarning is typically ignored by default but some distributions enable it.

```
$ python -m pytest -Wdefault tests
...
mock/tests/test_config_loader.py::TestConfigLoader::test_config_paths
  /home/me/mock/mock/py/mockbuild/config.py:722: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/me/mock/mock/tests/data/config-001/site-defaults.cfg' mode='r' encoding='UTF-8'>
    content = open(config_file).read()
```

> or let us know to add `label no-release-notes` if you think the change does
> not deserve a release note.

I don't think this fix needs a release note.