### PR TITLE
buildroot_lock: better error reporting

### DIFF
--- a/mock/py/mockbuild/installed_packages.py
+++ b/mock/py/mockbuild/installed_packages.py
@@ -132,9 +132,15 @@ def query_packages_location(packages, chrootpath=None,
         arch = basename.split(".")[-2]
         location_map[f"{name}.{arch}"] = url
 
+    failed_packages = []
     for package in packages:
         name_arch = f"{package['name']}.{package['arch']}"
         try:
             package["url"] = location_map[name_arch]
-        except KeyError as exc:
-            raise mockbuild.exception.Error(f"Can't get location for {name_arch}") from exc
+        except KeyError:
+            failed_packages.append(package)
+
+    if failed_packages:
+        failed_str = ", ".join([f"{p['name']}-{p['version']}-{p['release']}.{p['arch']}"
+                                for p in failed_packages])
+        raise mockbuild.exception.Error(f"Can't get location for {failed_str}")

--- a/mock/tests/test_buildroot_lock.py
+++ b/mock/tests/test_buildroot_lock.py
@@ -129,7 +129,7 @@ def test_nonexisting_file_in_repo():
     try:
         _call_method(plugins, buildroot)
     except mockbuild.exception.Error as e:
-        assert e.msg == "Can't get location for cyrus-sasl-lib.x86_64"
+        assert e.msg == "Can't get location for cyrus-sasl-lib-2.1.27-21.el9.x86_64"
         raised = True
     assert raised
 

--- a/releng/release-notes-next/buildroot-lock-err-reporting.feature
+++ b/releng/release-notes-next/buildroot-lock-err-reporting.feature
@@ -1,0 +1,2 @@
+The buildroot_lock plugin's error reporting has been improved to display all the
+package NVRAs that are not found in the configured DNF repositories.


### PR DESCRIPTION
I've observed that we frequently encounter `annobin-docs.noarch` being reported as the missed package, presumably due to it being the first one alphabetically.  Let's modify the reporting to list all the missing packages instead.

Relates: https://github.com/rpm-software-management/dnf5/issues/1673