### PR TITLE
Move Rawhide to F44

### DIFF
--- a/mock-core-configs/etc/mock/fedora-43-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-43-aarch64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-aarch64.cfg
+config_opts['releasever'] = '43'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-43-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-43-i386.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-i386.cfg
+config_opts['releasever'] = '43'
+config_opts['target_arch'] = 'i686'
+config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-43-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-43-ppc64le.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-ppc64le.cfg
+config_opts['releasever'] = '43'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-43-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-43-s390x.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-s390x.cfg
+config_opts['releasever'] = '43'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-43-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-43-x86_64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-x86_64.cfg
+config_opts['releasever'] = '43'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-44-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-44-aarch64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/mock/fedora-44-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-44-i386.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-i386.cfg

--- a/mock-core-configs/etc/mock/fedora-44-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-44-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-ppc64le.cfg

--- a/mock-core-configs/etc/mock/fedora-44-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-44-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-s390x.cfg

--- a/mock-core-configs/etc/mock/fedora-44-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-44-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-x86_64.cfg

--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -1,5 +1,5 @@
 config_opts['releasever'] = 'eln'
-config_opts['eln_rawhide_releasever'] = '43'
+config_opts['eln_rawhide_releasever'] = '44'
 
 config_opts['root'] = 'fedora-eln-{{ target_arch }}'
 

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -7,7 +7,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 
 config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['releasever'] = '43'
+config_opts['releasever'] = '44'
 
 # https://fedoraproject.org/wiki/Changes/BuildWithDNF5
 config_opts['package_manager'] = 'dnf5'

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -3,7 +3,7 @@
 %endif
 
 Name:       mock-core-configs
-Version:    42.4
+Version:    43.0
 Release:    1%{?dist}
 Summary:    Mock core config files basic chroots
 
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.113
+Requires:   distribution-gpg-keys >= 1.114
 # specify minimal compatible version of mock
 Requires:   mock >= 6.1.test
 Requires:   mock-filesystem

--- a/releng/release-notes-next/fedora-43-branching.feature
+++ b/releng/release-notes-next/fedora-43-branching.feature
@@ -1,0 +1,2 @@
+Configuration files for Fedora 43 have been branched from Rawhide,
+according to the [Fedora 43 Schedule](https://fedorapeople.org/groups/schedule/f-43/f-43-all-tasks.html).


### PR DESCRIPTION
Set:    rawhide == Fedora 44
Move:   42 => 43
Arches: aarch64 i386 ppc64le s390x x86_64
WARNING: Make sure Fedora Copr maintainers are informed that
WARNING: they should run 'copr-frontend branch-fedora 43'.
WARNING: That has to be done right on time when branching is done.
WARNING: Please check that distribution-gpg-keys have the N+1 key,
         you likely want to bump Requires: distribution-gpg-keys!