### PR TITLE
add config for gemini reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,12 @@
+# overrides summary setting from default configuration:
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github#default-configuration
+have_fun: true
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+ignore_patterns: []


### PR DESCRIPTION
I want to try the Gemini review in this repo. I've got good feedback on it from the Packit team.
If no one objects, I will enable 
  https://github.com/marketplace/gemini-code-assist

I treat it as an experiment. If that makes more noise than help, we can disable it later.