### PR TITLE
Add Kylin OS 11

### DIFF
--- a/mock-core-configs/etc/mock/kylin-11-aarch64.cfg
+++ b/mock-core-configs/etc/mock/kylin-11-aarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/kylin-11.tpl')
+
+config_opts['root'] = 'kylin-11-aarch64'
+config_opts['description'] = 'Kylin Linux 11'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/kylin-11-loongarch64.cfg
+++ b/mock-core-configs/etc/mock/kylin-11-loongarch64.cfg
@@ -1,0 +1,6 @@
+include('templates/kylin-11.tpl')
+
+config_opts['root'] = 'kylin-11-loongarch64'
+config_opts['description'] = 'Kylin Linux 11'
+config_opts['target_arch'] = 'loongarch64'
+config_opts['legal_host_arches'] = ('loongarch64',)

--- a/mock-core-configs/etc/mock/kylin-11-x86_64.cfg
+++ b/mock-core-configs/etc/mock/kylin-11-x86_64.cfg
@@ -1,0 +1,6 @@
+include('templates/kylin-11.tpl')
+
+config_opts['root'] = 'kylin-11-x86_64'
+config_opts['description'] = 'Kylin Linux 11'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/kylin-11.tpl
+++ b/mock-core-configs/etc/mock/templates/kylin-11.tpl
@@ -1,12 +1,12 @@
 config_opts['chroot_setup_cmd'] = 'install tar gcc-c++ kylin-rpm-config kylin-release which xz sed make bzip2 gzip gcc coreutils unzip diffutils cpio bash gawk rpm-build info patch util-linux findutils grep'
-config_opts['dist'] = 'ky10' # only useful for --resultdir variable subst
-config_opts['releasever'] = '10'
+config_opts['dist'] = 'ky11' # only useful for --resultdir variable subst
+config_opts['releasever'] = '11'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 
-# No official up to date image available, the existing ones are all outdated:
+# Images are not always kept up to date:
 # https://cr.kylinos.cn/zh/image?name=kylin-server
-config_opts['use_bootstrap_image'] = False
+config_opts['bootstrap_image'] = 'cr.kylinos.cn/kylin/kylin-server-platform:v11-2503'
 
 config_opts['dnf.conf'] = """
 [main]
@@ -25,19 +25,19 @@ mdpolicy=group:primary
 best=1
 install_weak_deps=0
 protected_packages=
-module_platform_id=platform:ky10
+module_platform_id=platform:ky11
 user_agent={{ user_agent }}
 
-[ks10-adv-os]
-name = Kylin Linux Advanced Server V10 - OS
-baseurl = https://update.cs2c.com.cn/NS/V10/V10SP3-2403/os/adv/lic/base/$basearch/
+[ks11-adv-os]
+name = Kylin Linux Advanced Server V11 - OS
+baseurl = https://update.cs2c.com.cn/NS/V11/2503/os/adv/lic/base/$basearch/
 gpgkey = file:///usr/share/distribution-gpg-keys/kylin/RPM-GPG-KEY-kylin
 gpgcheck = 1
 enabled = 1
 
-[ks10-adv-updates]
-name = Kylin Linux Advanced Server V10 - Updates
-baseurl = https://update.cs2c.com.cn/NS/V10/V10SP3-2403/os/adv/lic/updates/$basearch/
+[ks11-adv-updates]
+name = Kylin Linux Advanced Server V11 - Updates
+baseurl = https://update.cs2c.com.cn/NS/V11/2503/os/adv/lic/updates/$basearch/
 gpgkey = file:///usr/share/distribution-gpg-keys/kylin/RPM-GPG-KEY-kylin
 gpgcheck = 1
 enabled = 1

--- a/releng/release-notes-next/kylin-11.config
+++ b/releng/release-notes-next/kylin-11.config
@@ -1,0 +1,1 @@
+Add Kylin OS 11, released at the end of 2024. The GPG key is the same as Kylin OS 10.


### PR DESCRIPTION
Add Kylin OS 11, released at the end of 2024. The GPG key is the same as Kylin OS 10.