### PR TITLE
fix markup in pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 
-# Add a reference to related issue - preferably in the git commit message
+> Add a reference to related issue - preferably in the git commit message
 Fixes: #NUMBER
 
-# Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
-# or let us know to add `label no-release-notes` if you think the change does
-# not deserve a release note.
+> Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
+> or let us know to add `label no-release-notes` if you think the change does
+> not deserve a release note.


### PR DESCRIPTION
Previous markup showed almost everything as H1. This is less agressive if users do not delete the comments.

