### PR TITLE
feat: add support for client certificates

### DIFF
--- a/releng/release-notes-next/mock-hermetic-repo-client-cert.feature
+++ b/releng/release-notes-next/mock-hermetic-repo-client-cert.feature
@@ -1,0 +1,5 @@
+add support for client certificates when using mock-hermetic-repo. Can be specified as:
+
+```
+--client-cert-for example.com /path/crt.pem /path/key.pem
+```


### PR DESCRIPTION
- in some rare cases, a mock config can include a yum repo config section that include a ssl cert and key that are used for authentication by dnf
- when running mock-hermetic-repo, the same client cert is needed to download the rpms.
- this commit adds support for the following:

```
--client-cert-for example.com /path/crt.pem /path/key.pem
```

Assisted-by: Cursor


> Add a reference to related issue - preferably in the git commit message
Fixes: #NUMBER

> Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
> or let us know to add `label no-release-notes` if you think the change does
> not deserve a release note.
