### PR TITLE
Enable module_hotfixes flag for local repositories

### DIFF
--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -994,6 +994,7 @@ metadata_expire=0
 gpgcheck=0
 cost=1
 best=1
+module_hotfixes=true
 """.format(repoid=repoid, baseurl=baseurl)
 
     def _fix_cfg(cfg):

--- a/releng/release-notes-next/localrepo-module-hotfixes.bugfix
+++ b/releng/release-notes-next/localrepo-module-hotfixes.bugfix
@@ -1,0 +1,3 @@
+We now set `module_hotfixes=true` on repositories generated via `--localrepo`.
+This allows fetching packages from the local repository that are filtered out
+via modularity when building with `--chain --localrepo <dir>`.


### PR DESCRIPTION
Add `module_hotfixes=true` to repository configurations added by `add_local_repo()` (i.e. when using `--chain --localrepo <dir>`) so `dnf` will consider packages from this repository even when they are filtered out via modularity.

See https://dnf.readthedocs.io/en/latest/modularity.html#hotfix-repositories
