### PR TITLE
testing-farm: really test only x86 (and exclude hermetic-build config)

### DIFF
--- a/mock/integration-tests/runconfigs.sh
+++ b/mock/integration-tests/runconfigs.sh
@@ -14,8 +14,8 @@ if [ "$1" != "" ]; then
     configs=$1
 else
     configs=$(ls ../mock-core-configs/etc/mock | grep .cfg \
-                | grep -v -e default -e custom -e chroot-aliases \
-                | grep -E -v 'arm|ppc|s390|sparc|aarch')
+                | grep -v -e default -e custom -e chroot-aliases -e hermetic-build \
+                | grep -e "x86_64" -e "i*86")
 fi
 
 cleanup()


### PR DESCRIPTION
Relates: #1633 