### PR TITLE
Podman save using id.

### DIFF
--- a/mock/py/mock-hermetic-repo.py
+++ b/mock/py/mock-hermetic-repo.py
@@ -137,7 +137,7 @@ def prepare_image(image_specification, bootstrap_data, outputdir):
     subprocess.check_output(pull_cmd)
     subprocess.check_output(["podman", "save", "--format=oci-archive", "--quiet",
                              "-o", os.path.join(outputdir, "bootstrap.tar"),
-                             image_specification])
+                             bootstrap_data["id"]])
 
 
 def _main():


### PR DESCRIPTION
To workaround the error "Digest of source image's manifest would not match destination reference", when image is saved using sha256.
