### PR TITLE
make suppress-sync opt-in

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -82,6 +82,8 @@
 #config_opts['rpmbuild_networking'] = False
 # Additional args for nspawn
 # suppress-sync is added only on system with systemd 250+ (RHEL9, Fedoras)
+# config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
+# If you want to speed up Mock and you do not sync() during %check you can use
 # config_opts['nspawn_args'] = ['--capability=cap_ipc_lock', '--suppress-sync=yes']
 ## When RPM is build in container then build hostname is set to name of
 ## container. This sets the build hostname to name of container's host.

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -26,7 +26,7 @@ from .constants import MOCKCONFDIR, PKGPYTHONDIR, VERSION
 from .file_util import is_in_dir
 from .trace_decorator import getLog, traceLog
 from .uid import getresuid, getresgid
-from .util import set_use_nspawn, setup_operations_timeout, check_nspawn_has_suppress_sync_option
+from .util import set_use_nspawn, setup_operations_timeout
 
 PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'ccache', 'selinux', 'package_state', 'chroot_scan',
@@ -95,8 +95,9 @@ def setup_default_config_opts():
     config_opts['use_nspawn'] = None
     config_opts['rpmbuild_networking'] = False
     config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
-    if check_nspawn_has_suppress_sync_option():
-        config_opts['nspawn_args'] += ['--suppress-sync=yes']
+    # FIXME disable as default because of https://github.com/rpm-software-management/mock/issues/1641
+    # if check_nspawn_has_suppress_sync_option():
+    #    config_opts['nspawn_args'] += ['--suppress-sync=yes']
     config_opts['use_container_host_hostname'] = True
 
     config_opts['use_bootstrap'] = True

--- a/releng/release-notes-next/suppress-sync-as-opt-in.bugfix.md
+++ b/releng/release-notes-next/suppress-sync-as-opt-in.bugfix.md
@@ -1,0 +1,4 @@
+The suppress-sync option that was introduced in the previous release caused
+regression in some packages that use `sync()` during `%check`. Because of that,
+it was disabled by default, and you can enable it as opt-in.
+[#1641](https://github.com/rpm-software-management/mock/issues/1641)


### PR DESCRIPTION
Some tests in %check uses sync() and with this options fails. Until %check can be isolated we need to switch it off by default.

Fixes: #1641


> Add a reference to related issue - preferably in the git commit message
Fixes: #NUMBER

> Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
> or let us know to add `label no-release-notes` if you think the change does
> not deserve a release note.
