### PR TITLE
Add openSUSE Leap 16.0 configurations

### DIFF
--- a/mock-core-configs/etc/mock/opensuse-leap-16.0-aarch64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-16.0-aarch64.cfg
@@ -1,0 +1,5 @@
+include('templates/opensuse-leap-16.0.tpl')
+
+config_opts['root'] = 'opensuse-leap-16.0-aarch64'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/mock-core-configs/etc/mock/opensuse-leap-16.0-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-16.0-ppc64le.cfg
@@ -1,0 +1,5 @@
+include('templates/opensuse-leap-16.0.tpl')
+
+config_opts['root'] = 'opensuse-leap-16.0-ppc64le'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)

--- a/mock-core-configs/etc/mock/opensuse-leap-16.0-s390x.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-16.0-s390x.cfg
@@ -1,0 +1,5 @@
+include('templates/opensuse-leap-16.0.tpl')
+
+config_opts['root'] = 'opensuse-leap-16.0-s390x'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)

--- a/mock-core-configs/etc/mock/opensuse-leap-16.0-x86_64.cfg
+++ b/mock-core-configs/etc/mock/opensuse-leap-16.0-x86_64.cfg
@@ -1,0 +1,5 @@
+include('templates/opensuse-leap-16.0.tpl')
+
+config_opts['root'] = 'opensuse-leap-16.0-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)

--- a/mock-core-configs/etc/mock/templates/opensuse-leap-16.0.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-16.0.tpl
@@ -1,0 +1,51 @@
+config_opts['chroot_setup_cmd'] = 'install patterns-devel-base-devel_rpm_build'
+config_opts['dist'] = 'suse.lp160'  # only useful for --resultdir variable subst
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['releasever'] = '16.0'
+config_opts['macros']['%dist'] = '.suse.lp160'
+config_opts['package_manager'] = 'dnf'
+config_opts['ssl_ca_bundle_path'] = '/var/lib/ca-certificates/ca-bundle.pem'
+config_opts['description'] = 'openSUSE Leap {{ releasever }}'
+
+# Container image contains zypper as the base package manager so it can't be used:
+config_opts['use_bootstrap_image'] = False
+
+# Due to the nature of the OpenSUSE mirroring system, we can not use
+# metalinks easily and also we can not rely on the fact that baseurl's
+# always work (issue #553) -- by design we need to expect a one minute
+# repository problems (configured four attempts means 3 periods of 20s).
+config_opts['package_manager_max_attempts'] = 4
+config_opts['package_manager_attempt_delay'] = 20
+
+config_opts['dnf.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+best=1
+
+protected_packages=
+user_agent={{ user_agent }}
+
+# repos
+
+[opensuse-leap-oss]
+name=openSUSE Leap $releasever - {{ repo_arch }} - OSS
+baseurl=https://download.opensuse.org/distribution/leap/$releasever/repo/oss/
+#metalink=https://download.opensuse.org/distribution/leap/$releasever/repo/oss/repodata/repomd.xml.metalink
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-2022
+       file:///usr/share/distribution-gpg-keys/suse/RPM-GPG-KEY-SuSE-ALP-Main
+       file:///usr/share/distribution-gpg-keys/opensuse/RPM-GPG-KEY-openSUSE-16-Backports
+gpgcheck=1
+
+"""

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.114
+Requires:   distribution-gpg-keys >= 1.115
 # specify minimal compatible version of mock
 Requires:   mock >= 6.1.test
 Requires:   mock-filesystem

--- a/releng/release-notes-next/opensuse-leap-16.config
+++ b/releng/release-notes-next/opensuse-leap-16.config
@@ -1,0 +1,3 @@
+Add openSUSE Leap 16.0 configurations. Some of the packages are signed with the ALP Package signing key from SUSE Linux Enterprise 16.
+openSUSE Leap 16.0 does not have `leap-dnf` images available, so do not use a bootstrap image.
+At the moment of writing this, openSUSE Leap 16.0 [does not have all the other repositories of 15.6 available](https://en.opensuse.org/Package_repositories).


### PR DESCRIPTION
Add openSUSE Leap 16.0 configurations.

- Some of the packages are signed with the ALP Package signing key from SUSE Linux Enterprise 16.
- openSUSE Leap 16.0 does not have `leap-dnf` images available, so do not use a bootstrap image.
- At the moment of writing this, openSUSE Leap 16.0 does not have all the other repositories of 15.6 available: https://en.opensuse.org/Package_repositories. Not clear if it ever will.