### PR TITLE
Update Kylin OS configuration and fix `loongarch64`

### DIFF
--- a/mock-core-configs/etc/mock/templates/kylin-10.tpl
+++ b/mock-core-configs/etc/mock/templates/kylin-10.tpl
@@ -4,9 +4,8 @@ config_opts['releasever'] = '10'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 
-# No official up to date image available, the existing ones are all outdated:
-# https://cr.kylinos.cn/zh/image?name=kylin-server
-config_opts['use_bootstrap_image'] = False
+# Registry web interface: https://cr.kylinos.cn/zh/image
+config_opts['bootstrap_image'] = 'cr.kylinos.cn/kylin/kylin-server-platform:v10sp3-2403'
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/kylin-11.tpl
+++ b/mock-core-configs/etc/mock/templates/kylin-11.tpl
@@ -4,8 +4,7 @@ config_opts['releasever'] = '11'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 
-# Images are not always kept up to date:
-# https://cr.kylinos.cn/zh/image?name=kylin-server
+# Registry web interface: https://cr.kylinos.cn/zh/image
 config_opts['bootstrap_image'] = 'cr.kylinos.cn/kylin/kylin-server-platform:v11-2503'
 
 config_opts['dnf.conf'] = """

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -423,6 +423,7 @@ def setup_default_config_opts():
         'armv7hl': 'arm',
         'i386': 'i386',
         'i686': 'i386',
+        'loongarch64': 'loongarch64',
         'ppc64': 'ppc64',
         'ppc64le': 'ppc64le',
         's390x': 's390x',

--- a/releng/release-notes-next/kylin-images.config
+++ b/releng/release-notes-next/kylin-images.config
@@ -1,0 +1,1 @@
+Kylin OS has [updated all container images for supported versions](https://cr.kylinos.cn/zh/image), so use those for bootstrapping.

--- a/releng/release-notes-next/loongarch64.bugfix
+++ b/releng/release-notes-next/loongarch64.bugfix
@@ -1,0 +1,1 @@
+The `loongarch64` architecture was missing from the `target_arch` to `force_arch` mapping, preventing the use of QEMU user static binaries for `loongarch64` chroots.


### PR DESCRIPTION
Images are now kept up to date and all versions for Kylin 10 are now available.

- They are available for all 3 supported architectures (`x86_64`, `aarch64`, `loongarch64`) for both Kylin 10 and 11.
- The `loongarch64` for some reason is not listed on the registry web interface for version 10, but it's there.

Also, fix `forcearch` for `loongarch64`.

- The `loongarch64` architecture is missing from the `target_arch` to `forcearch` mapping, preventing builds for this architecture when executing `mock` on a different architecture.