### PR TITLE
tox: drop non-working Python 3.6 from tox tests

### DIFF
--- a/.github/workflows/fedora-tox.yml
+++ b/.github/workflows/fedora-tox.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         tox_env:
           # sync with /tox.ini
-          - py36
           - py39
           - py310
           - py311

--- a/mock/requirements.txt
+++ b/mock/requirements.txt
@@ -1,8 +1,7 @@
 backoff
 distro
 jinja2
-pyroute2==0.5.3; python_version < "3.9"
-pyroute2; python_version >= "3.9"
+pyroute2
 requests
 rpmautospec-core
 templated-dictionary

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # sync with /.github/workflows/fedora-tox.yml
-envlist = py{36,39,310,311,312,313}
+envlist = py{39,310,311,312,313}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
We no longer support Mock on RHEL 7 (`main` branch) anyway. RHEL 8 runs on Python 3.9.