### PR TITLE
file_util: improve rmtree performance

### DIFF
--- a/releng/release-notes-next/improve-file_util_rmtree-performance.bugfix
+++ b/releng/release-notes-next/improve-file_util_rmtree-performance.bugfix
@@ -1,0 +1,2 @@
+The `file_util.rmtree` cleanup process has been significantly accelerated, especially for very large buildroots. The previous pure-Python approach could take over 13 minutes to remove ~2 million files. A new backend now uses either native `rm -r` or `shutil.rmtree`, reducing cleanup times to under one minute.
+Also introduces support for paths exceeding PATH_MAX, applied to all non-excluded directories.


### PR DESCRIPTION
Optimize `rmtree` to significantly reduce cleanup time, especially for large
buildroots. The previous Python-based implementation caused substantial delays
(e.g., ~13 minutes for a ~2M-file buildroot). Introduce a faster backend, using
either `shutil.rmtree` or native `rm -r`, which reduces cleanup time to under
one minute.

Also add support for handling paths longer than PATH_MAX, but only for
directories not listed in `exclude`. Extending this to excluded paths would
overcomplicate the logic, and excluded-path handling was already nonfunctional
and not in high demand.

Some benchmark:
$ sudo find /var/lib/mock/some-big-buildroot/ | wc -l
2056654
$ time mock -r some-big-buildroot --clean
INFO: mock.py version 6.3 starting (python version = 3.9.21, NVR = mock-6.3-1.el9)

previous rmtree implementaiont
real    13m21.176s
user    9m51.712s
sys     2m29.270s

shutil.rmtree as _fastRm
real    1m8.450s
user    0m14.331s
sys     0m31.525s

rm -r as _fastRm
real    0m52.990s
user    0m3.089s
sys     0m29.184s

partially fixes: #31