### PR TITLE
mock: simplify forcearch code

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -572,18 +572,8 @@ def check_arch_combination(target_arch, config_opts):
     # Check below that we can do cross-architecture builds.
 
     option = f"--forcearch={config_opts['forcearch']}"
-    binary_pattern = config_opts["qemu_user_static_mapping"].get(config_opts["forcearch"])
-    if not binary_pattern:
-        # Probably a missing configuration.
-        log.warning(
-            "Mock will likely fail, %s is enabled "
-            "while Mock is unable to detect the corresponding "
-            "/usr/bin/qemu-*-static binary",
-            option,
-        )
-        time.sleep(5)
-        return
-
+    binary_pattern = config_opts["qemu_user_static_mapping"].get(config_opts["forcearch"],
+                                                                 config_opts["forcearch"])
     binary = f'/usr/bin/qemu-{binary_pattern}-static'
     if os.path.exists(binary):
         return

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -421,15 +421,8 @@ def setup_default_config_opts():
 
     # mapping from target_arch (or forcearch) to arch in /usr/bin/qemu-*-static
     config_opts["qemu_user_static_mapping"] = {
-        'aarch64': 'aarch64',
         'armv7hl': 'arm',
-        'i386': 'i386',
         'i686': 'i386',
-        'loongarch64': 'loongarch64',
-        'ppc64': 'ppc64',
-        'ppc64le': 'ppc64le',
-        's390x': 's390x',
-        'x86_64': 'x86_64',
     }
 
     config_opts["recursion_limit"] = 5000

--- a/releng/release-notes-next/forcearch-defaults.feature.md
+++ b/releng/release-notes-next/forcearch-defaults.feature.md
@@ -1,0 +1,6 @@
+Mock now automatically maps the target build architecture directly to the
+appropriate QEMU user-static binary variant for `forcearch` builds.  For
+example, a build for `riscv64` (for `fedora-43-riscv64` target) is mapped to
+`/usr/bin/qemu-riscv64-static` (see the architecture string matches).  Mock
+config contributors no longer need to modify Mock code to add support for new
+architectures (if these architecture specifiers match).


### PR DESCRIPTION
Mock now automatically maps the target build architecture directly to the
appropriate QEMU user-static binary variant for `forcearch` builds.  For
example, `fedora-43-riscv64` is mapped to `/usr/bin/qemu-riscv64-static` (see
the architecture string matches).  Mock config contributors no longer need to
modify Mock code to add support for new architectures (if these architecture
specifiers match).
