### PR TITLE
Fix aarch64 configuration for Azure Linux 3

### DIFF
--- a/mock-core-configs/etc/mock/azure-linux-3-aarch64.cfg
+++ b/mock-core-configs/etc/mock/azure-linux-3-aarch64.cfg
@@ -1,6 +1,6 @@
 include('templates/azure-linux-3.tpl')
 
-config_opts['root'] = 'azure-linux-3-x86_64'
+config_opts['root'] = 'azure-linux-3-aarch64'
 config_opts['description'] = 'Azure Linux 3.0'
-config_opts['target_arch'] = 'x86_64'
-config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)

--- a/releng/release-notes-next/azl3-aarch64.config
+++ b/releng/release-notes-next/azl3-aarch64.config
@@ -1,0 +1,1 @@
+Fix aarch64 configuration for Azure Linux 3 (copy & paste error).


### PR DESCRIPTION
Copy / paste error when the original Azure Linux 3 Pull Request went in.

Didn't notice as we still had the local override for the `.cfg` file before the package was released with the changes.