### PR TITLE
mock: Use umask 0022 instead of 0002 to avoid strange permissions

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -65,7 +65,7 @@ from functools import partial
 # our imports
 from mockbuild import config
 from mockbuild import util
-from mockbuild.constants import MOCKCONFDIR, VERSION
+from mockbuild.constants import MOCKCONFDIR, VERSION, DEFAULT_UMASK
 from mockbuild.file_downloader import FileDownloader
 from mockbuild.mounts import BindMountPoint, FileSystemMountPoint
 import mockbuild.backend
@@ -867,7 +867,7 @@ def main():
     for k, v in list(config_opts.items()):
         log.debug("    %s:  %s", k, v)
 
-    os.umask(0o02)
+    os.umask(DEFAULT_UMASK)
     os.environ["HOME"] = buildroot.homedir
 
     # New namespace starting from here

--- a/mock/py/mockbuild/constants.py
+++ b/mock/py/mockbuild/constants.py
@@ -12,3 +12,5 @@ PYTHONDIR = os.path.dirname(os.path.realpath(sys.argv[0]))
 PKGPYTHONDIR = os.path.join(os.path.dirname(os.path.realpath(sys.argv[0])), "mockbuild")
 MOCKCONFDIR = os.path.join(SYSCONFDIR, "mock")
 # end build system subs
+
+DEFAULT_UMASK = 0o022

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -36,6 +36,7 @@ import distro
 from . import exception
 from . import file_util
 from . import text
+from .constants import DEFAULT_UMASK
 from .trace_decorator import getLog, traceLog
 from .uid import setresuid
 from pyroute2 import IPRoute
@@ -636,7 +637,7 @@ class ChildPreExec(object):
     def __call__(self, *args, **kargs):
         if not self.shell and not self.no_setsid:
             os.setsid()
-        os.umask(0o02)
+        os.umask(DEFAULT_UMASK)
         condUnshareNet(self.unshare_net)
         condPersonality(self.personality)
         condEnvironment(self.env)

--- a/releng/release-notes-next/use-standard-umask.bugfix
+++ b/releng/release-notes-next/use-standard-umask.bugfix
@@ -1,0 +1,4 @@
+Use umask 0022 instead of 0002 to avoid strange permissions.
+This was causing issues with image builds running inside of
+mock resulting in weird default permissions that broke some
+workloads.


### PR DESCRIPTION
The unusual umask has caused some pretty weird side effects for image builds operating in mock, as the default permissions get set to unexpected values, which create problems for some applications in the built images.

Fixes: https://github.com/rpm-software-management/mock/issues/1675
