### PR TITLE
eol/epel-6: copy-paste ca-bundle from host

### DIFF
--- a/mock-core-configs/etc/mock/eol/templates/epel-6.tpl
+++ b/mock-core-configs/etc/mock/eol/templates/epel-6.tpl
@@ -1,5 +1,12 @@
 include('eol/templates/centos-6.tpl')
 
+# Copy the ca-bundle file from the host.  This is unnecessary for EL7+ chroots
+# because the bundle is a symlink to
+# /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem, and the /etc/pki/ca-trust
+# directory is already copied from the host via
+# config_opts['ssl_copied_ca_trust_dirs'].
+config_opts['ssl_ca_bundle_path'] = '/etc/pki/tls/certs/ca-bundle.crt'
+
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 
 config_opts['yum.conf'] += """

--- a/releng/release-notes-next/epel-6-ca-trust.config.md
+++ b/releng/release-notes-next/epel-6-ca-trust.config.md
@@ -1,0 +1,2 @@
+The EOL configuration for epel-6 has been updated with a bug fix for CA
+certificate trust, ensuring the chroot trusts the same set of CAs as the host.


### PR DESCRIPTION
It's not enough to copy the default directories from config_opts['ssl_copied_ca_trust_dirs'].

