### PR TITLE
Disable bootstrap for riscv

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-riscv64.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-riscv64.tpl
@@ -8,7 +8,7 @@ config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 
 config_opts['package_manager'] = 'dnf5'
 
-config_opts['use_bootstrap_image'] = False
+config_opts['use_bootstrap'] = False
 
 config_opts['dnf.conf'] = """
 [main]

--- a/releng/release-notes-next/disable-bootstrap-riscv.config
+++ b/releng/release-notes-next/disable-bootstrap-riscv.config
@@ -1,0 +1,2 @@
+The bootstrap chroot feature has been disabled for fedora-riscv64 chroots, as it is not currently
+functional on this architecture.


### PR DESCRIPTION
There is no boostrap image for native fedora-riscv64 yet.