### PR TITLE
mock: Install DNF5 by default on EL11+ Linux distributions

### DIFF
--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -77,7 +77,7 @@ BuildRequires: python%{python3_pkgversion}-rpmautospec-core
 
 BuildRequires: argparse-manpage
 
-%if 0%{?fedora} >= 38 || 0%{?mageia} >= 10
+%if 0%{?fedora} >= 38 || 0%{?rhel} >= 11 || 0%{?mageia} >= 10
 # DNF5 stack
 Recommends: dnf5
 Recommends: dnf5-plugins

--- a/releng/release-notes-next/el11-dnf5.config
+++ b/releng/release-notes-next/el11-dnf5.config
@@ -1,0 +1,1 @@
+The mock package now pulls in DNF5 on Enterprise Linux 11+ distributions by default.


### PR DESCRIPTION
Fedora ELN already uses DNF5 as the package manager, which means that CentOS Stream 11 and derivatives will as well.
