### PR TITLE
expand_spec plugin

### DIFF
--- a/docs/Plugin-ExpandSpec.md
+++ b/docs/Plugin-ExpandSpec.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Plugin ExpandSpec
+---
+
+This plugin expands specfile and save the output to `expanded-spec.txt` in result directory in `postdeps` hook.
+
+It uses to expand the specfile
+```bash
+/usr/bin/rpmspec --parse <spec>
+```
+
+## Configuration
+
+You can disable the plugin using this settings:
+```python
+config_opts['plugin_conf']['expand_spec_enable'] = False
+```
+
+To add extra options in `rpmspec` command, use:
+```python
+config_opts['plugin_conf']['expand_spec_opts']['rpmspec_opts'] = ['--verbose', '-d', 'foo bar']
+```
+
+Available since version 6.7.
+
+This plugin is ENABLED by default.

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -62,6 +62,10 @@ class Commands(object):
         self.private_network = not config['rpmbuild_networking']
         self.rpmbuild_noclean_option = None
 
+        # on-demand buildroot properties
+        # spec path in buildroot
+        self.buildroot.spec = None
+
     @traceLog()
     def clean(self):
         """clean out chroot with extreme prejudice :)"""
@@ -175,6 +179,21 @@ class Commands(object):
         return deps
 
     @traceLog()
+    def prepareSpec(self, srpm=None, spec=None):
+        """Prepare the spec file for building."""
+        if spec and not self.config['scm']:
+            # scm sets options.spec, but we want to get spec from SRPM when using scm
+            spec_path = self.copy_spec_into_chroot(spec)
+        else:
+            spec = self.get_specfile_name(srpm)
+            spec_path = os.path.join(self.buildroot.builddir, 'SPECS', spec)
+
+        # store the spec path for later use in hooks
+        self.buildroot.spec = spec_path
+
+        return spec_path
+
+    @traceLog()
     def installSrpmDeps(self, *srpms):
         """Figure out deps from srpm. Call package manager to install them"""
         try:
@@ -256,12 +275,7 @@ class Commands(object):
             srpm = self.copy_srpm_into_chroot(srpm)
             self.install_srpm(srpm)
 
-            if spec and not self.config['scm']:
-                # scm sets options.spec, but we want to get spec from SRPM when using scm
-                spec_path = self.copy_spec_into_chroot(spec)
-            else:
-                spec = self.get_specfile_name(srpm)
-                spec_path = os.path.join(self.buildroot.builddir, 'SPECS', spec)
+            spec_path = self.prepareSpec(srpm, spec)
 
             # We need to rebuild the SRPM and install dependencies multiple
             # times so that cases like #1652 are covered

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -440,13 +440,13 @@ class Buildroot(object):
                 self.uid_manager.restorePrivs()
         return result
 
-    def doChrootPlugin(self, command, cwd=None):
+    def doChrootPlugin(self, command, cwd=None, returnOutput=False):  # pylint: disable=invalid-name
         """
         Execute command (specified as array, not a shell command string) in this
         buildroot  in `cwd`, as a non-privileged user.  Used by plugins.
         """
         private_network = not self.config.get('rpmbuild_networking', False)
-        self.doChroot(
+        return self.doChroot(
             command,
             shell=False,
             cwd=cwd,
@@ -455,7 +455,8 @@ class Buildroot(object):
             gid=self.chrootgid,
             user=self.chrootuser,
             unshare_net=private_network,
-            printOutput=self.config.get('print_main_output', True)
+            printOutput=self.config.get('print_main_output', True),
+            returnOutput=returnOutput,
         )
 
     def all_chroot_packages(self):

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -33,7 +33,7 @@ PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
                'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor',
                'rpmautospec', 'buildroot_lock', 'export_buildroot_image',
-               'unbreq']
+               'unbreq', 'expand_spec']
 
 def nspawn_supported():
     """Detect some situations where the systemd-nspawn chroot code won't work"""
@@ -257,7 +257,11 @@ def setup_default_config_opts():
         'unbreq_enable': False,
         'unbreq_opts': {
             'exclude_accessed_files': []
-        }
+        },
+        'expand_spec_enable': True,
+        'expand_spec_opts': {
+            'rpmspec_opts': [],
+        },
     }
 
     config_opts['environment'] = {

--- a/mock/py/mockbuild/plugins/expand_spec.py
+++ b/mock/py/mockbuild/plugins/expand_spec.py
@@ -1,0 +1,47 @@
+"""A mock plugin to expand specfile in postdeps phase."""
+
+# our imports
+import os
+from mockbuild.trace_decorator import getLog, traceLog
+
+# pylint: disable=invalid-name
+requires_api_version = "1.1"
+
+
+# plugin entry point
+@traceLog()
+def init(plugins, conf, buildroot):
+    """Register the expand_spec plugin with mock."""
+    ExpandSpec(plugins, conf, buildroot)
+
+
+class ExpandSpec:
+    """Get the runtime rpmspec --parse"""
+    # pylint: disable=too-few-public-methods
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        """Init the plugin."""
+        self.buildroot = buildroot
+        self.opts = conf
+        self.config = buildroot.config
+        self.logger = getLog()
+
+        # actually run our plugin at this step
+        plugins.add_hook("postdeps", self._postDepsHook)
+        self.logger.info("expand_spec: initialized")
+
+    @traceLog()
+    def _postDepsHook(self):
+        """postdeps hook to expand specfile by ``rpmspec --parse``."""
+        self.logger.info("Executing expand_spec plugin")
+        chroot_spec = self.buildroot.spec
+        expanded_specfile = os.path.join(self.buildroot.resultdir, 'expanded-spec.txt')
+        self.logger.info("Expanding original spec: %s to %s", chroot_spec, expanded_specfile)
+
+        cmd = ["/usr/bin/rpmspec", "--parse", chroot_spec] + self.opts.get("rpmspec_opts", [])
+        output, _ = self.buildroot.doChrootPlugin(cmd, returnOutput=True)
+        with open(expanded_specfile, "w", encoding="utf-8") as o:
+            o.write(output)
+
+        self.buildroot.uid_manager.changeOwner(expanded_specfile, gid=self.config['chrootgid'])
+        getLog().info("Expanded specfile written to: %s", expanded_specfile)

--- a/releng/release-notes-next/expand-spec-plugin.feature.md
+++ b/releng/release-notes-next/expand-spec-plugin.feature.md
@@ -1,0 +1,4 @@
+A new plugin: expand_spec expanding specfile to `expanded-spec.txt` in result
+directory, in order to get the most correct PARSED specfile within chroot.
+
+* [Issue#1705][issue#1705]


### PR DESCRIPTION
Fixes: #1705

In some cases, we need information in specfile which are not included in
(S)RPMs' headers, e.g: Source and Patch. Expanding it within the chroot is
the simplest and most correct way, so that we don't have to replicate the
same buildroot later.

In the plugin, specfile is expanded by:
```
rpmspec --parse <specfile>
```

And to diable it, adding this in mock.cfg:
```
config_opts['plugin_conf']['expand_spec_enable'] = False