### PR TITLE
Disable traceLog wrapper

### DIFF
--- a/mock/py/mockbuild/trace_decorator.py
+++ b/mock/py/mockbuild/trace_decorator.py
@@ -106,7 +106,7 @@ def traceLog(logger=None):
         return trace
         #end of trace()
 
-    if os.environ.get("MOCK_TRACE_LOG", "true") == "false":
+    if os.environ.get("MOCK_TRACE_LOG", "false") == "false":
         return noop
 
     if logging.getLogger("trace").propagate:

--- a/releng/release-notes-next/disable-tracelog-wrapper.bugfix.md
+++ b/releng/release-notes-next/disable-tracelog-wrapper.bugfix.md
@@ -1,0 +1,5 @@
+The `traceLog()` decorator, which tracks when internal methods are entered and
+exited, has been disabled.  **Warning:** We plan to remove this decorator
+entirely; please follow [issue#1681][] for updates.  In the meantime, you can
+export the `MOCK_TRACE_LOG=true` environment variable to revert this change and
+re-enable the logging.


### PR DESCRIPTION
The long-term plan is to get rid of it entirely, but for now users still can turn it on by MOCK_TRACE_LOG=true environment variable.

Relates: #1681

