### PR TITLE
tests: move tests to the latest released Fedora

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -59,7 +59,7 @@ jobs:
       job: tests
       trigger: pull_request
       targets:
-        - fedora-42
+        - fedora-latest-stable
       # We don't want to run two test runs; so we limit this to a single package
       packages:
         - mock

--- a/mock/integration-tests/setup-playbook/tasks/main.yml
+++ b/mock/integration-tests/setup-playbook/tasks/main.yml
@@ -119,7 +119,6 @@
     state: present
     username: "{{ mock_rhn_user }}"
     password: "{{ mock_rhn_pass }}"
-    pool: "Red Hat Enterprise Linux for Virtual Datacenters, Standard"
   when:
     - no_subscription_management is not defined or no_subscription_management is false
 


### PR DESCRIPTION
Currently it means F42 => F43.  While on it, drop the `pool:` parameter from our RHSM use-cases, pools are no longer supported:

    Unsupported parameters for (redhat_subscription) module: pool.

