### PR TITLE
Adapt to Changes/droppingOfCertPemFile

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -408,7 +408,7 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
         bundle_path = self.config['ssl_ca_bundle_path']
         if bundle_path:
             self.buildroot.root_log.debug('copying CA bundle into chroot')
-            host_bundle = os.path.realpath('/etc/pki/tls/certs/ca-bundle.crt')
+            host_bundle = os.path.realpath('/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')
             chroot_bundle_path = self.buildroot.make_chroot_path(bundle_path)
             chroot_bundle_dir = os.path.dirname(chroot_bundle_path)
 

--- a/releng/release-notes-next/droppingOfCertPemFile.bugfix.md
+++ b/releng/release-notes-next/droppingOfCertPemFile.bugfix.md
@@ -1,0 +1,7 @@
+The suggested location for the host CRT bundle is changing from
+`/etc/pki/tls/certs/ca-bundle.crt` to
+`/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, following the
+[droppingOfCertPemFile Fedora Change](https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile).
+These bundles are automatically synced into Mock chroots for specific targets
+(e.g., openSUSE).  The new bundle location is OK even for EPEL 8 hosts.
+Fixes [issue#1667][].


### PR DESCRIPTION
The change suggests us to use different bundle location:

| needs to preferably use the defaults of the library or if they must, | use the /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem file | instead.

Fixes: #1667

