### PR TITLE
Allow access to the buildroot repo

### DIFF
--- a/docs/feature-hermetic-builds.md
+++ b/docs/feature-hermetic-builds.md
@@ -131,6 +131,9 @@ that Mock performs.
    components from the internet and places them into a single local
    directory—let's call it an *offline repository*.
 
+   This repository is also available during the build for inspection or use
+   inside the buildroot in the `/hermetic_repo` directory.
+
    **Note:** This step doesn't necessarily have to be done by the Mock project
    itself.  The *lockfile* is concise enough for further processing and
    validation (e.g., ensuring the set of RPMs and the buildroot image come from

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -811,6 +811,12 @@ def process_hermetic_build_config(cmdline_opts, config_opts):
 
     config_opts["offline_local_repository"] = final_offline_repo
 
+    # Provide build access to buildroot packages solving same issue as
+    # https://lists.fedorahosted.org/archives/list/koji-devel@lists.fedorahosted.org/thread/ZIBY53JAURLT3QRBBJIJJ7EZWLZDE3TI/
+    # keepcache=1 for local repos work only in dnf5 not dnf4
+    config_opts['plugin_conf']['bind_mount_enable'] = True
+    config_opts['plugin_conf']['bind_mount_opts']['dirs'].append((final_offline_repo, '/hermetic_repo' ))
+
     # We install all the packages at once (for now?).  We could inherit the
     # command from the previous "online" run, but it often employs a group
     # installation command - and we have no groups in the offline repo.

--- a/releng/release-notes-next/hermetic-repo-in-buildroot.bugfix.md
+++ b/releng/release-notes-next/hermetic-repo-in-buildroot.bugfix.md
@@ -1,0 +1,7 @@
+Hermetic build [now|PR#1712] provides access to buildroot repo in
+`/hermetic_repo` directory. Normal behaviour for package maintainers is to
+expect that `/var/cache/{dnf|yum}` is populated by these packages. Anyway, in
+case of "offline" repo which is used by hermetic builds, `dnf4` doesn't
+populate that directory, while `dnf5` yes (with `keepcache=1`). Providing also
+`/hermetic_repo` in every case would make looking for buildroot packages a bit
+easier.


### PR DESCRIPTION
Workaround for keepcache=1 not working with dnf4/local repos.