### PR TITLE
Drop pull_digest from hermetic boostrap image

### DIFF
--- a/mock/py/mock-hermetic-repo.py
+++ b/mock/py/mock-hermetic-repo.py
@@ -128,7 +128,7 @@ def prepare_image(image_specification, bootstrap_data, outputdir):
     Store the tarball into the same directory where the RPMs are
     """
     pull_cmd = ["podman", "pull"]
-    if "pull_digest" in bootstrap_data:
+    if bootstrap_data.get("pull_digest"):
         image_specification +=  "@" + bootstrap_data["pull_digest"]
     if "architecture" in bootstrap_data:
         pull_cmd += ["--arch", bootstrap_data["architecture"]]

--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -251,13 +251,15 @@ class Podman:
         """
         Get the image metadata needed for the subsequent hermetic build.
         """
-        get_query = '{"pull_digest": "{{ .Digest }}", "id": "{{.Id}}", "architecture": "{{ .Architecture }}"}'
+        get_query = '{"id": "{{.Id}}", "architecture": "{{ .Architecture }}"}'
         getLog().info("Reading image %s from %s", get_query, self.image)
         cmd = ["podman", "image", "inspect", "--format", get_query, self.image]
         res = subprocess.run(cmd, env=self.buildroot.env,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              check=True)
-        return json.loads(res.stdout.decode("utf-8").strip())
+        res = json.loads(res.stdout.decode("utf-8").strip())
+        res['pull_digest'] = None
+        return res
 
 
     def __repr__(self):

--- a/releng/release-notes-next/hermetic-repo-bootstrap-image-digest.bugfix.md
+++ b/releng/release-notes-next/hermetic-repo-bootstrap-image-digest.bugfix.md
@@ -1,0 +1,5 @@
+Image has one Digest and many RepoDigests. So, we can hit situation when these
+two values don't match and podman will refuse to load such tarball later with
+error like described [here](https://github.com/containers/podman/issues/27323).
+
+We should move to different mechanism (probably skopeo) in the near future.


### PR DESCRIPTION
Image has one Digest and many RepoDigests. So, we can hit situation when these two values don't match and podman will refuse to load such tarball later with error like described here:
https://github.com/containers/podman/issues/27323

We should move to different mechanism (porbably skopeo) in the near future.