### PR TITLE
Decode percent-escaped file:// repo paths before bootstrap bind mount

### DIFF
--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import time
 import re
+from urllib.parse import unquote
 from textwrap import dedent
 from configparser import ConfigParser
 
@@ -512,6 +513,7 @@ Error:      Neither dnf-utils nor yum-utils are installed. Dnf-utils or yum-util
                         continue
 
                     srcpath = self.expand_url_vars(srcpath)
+                    srcpath = unquote(srcpath)
 
                     if srcpath in tried:
                         continue

--- a/mock/tests/test_package_manager.py
+++ b/mock/tests/test_package_manager.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import shutil
+from pathlib import Path
 
 import pytest
 from unittest import mock
@@ -111,6 +112,22 @@ class TestPackageManager:
         [fedora]
         baseurl = file://{}
         """.format(repo_directory)
+        mounts = self.get_user_bind_mounts_from_config(config)
+        assert len(mounts) == 1
+        assert mounts[0].srcpath == repo_directory
+        assert mounts[0].bindpath.startswith(self.workdir)
+        assert mounts[0].bindpath.endswith(repo_directory)
+
+    def test_urlencoded_file_path_name_in_baseurl(self):
+        repo_directory = os.path.join(self.workdir, 'repo@2')
+        os.mkdir(repo_directory)
+        config = """
+        [main]
+        something = 1
+
+        [fedora]
+        baseurl = {}
+        """.format(Path(repo_directory).as_uri())
         mounts = self.get_user_bind_mounts_from_config(config)
         assert len(mounts) == 1
         assert mounts[0].srcpath == repo_directory

--- a/releng/release-notes-next/decode-percent-escaped-bootstrap-file-repos.bugfix.md
+++ b/releng/release-notes-next/decode-percent-escaped-bootstrap-file-repos.bugfix.md
@@ -1,0 +1,4 @@
+Mock now decodes percent-escaped local `file://` repository paths before
+checking them for bootstrap bind mounts. This fixes bootstrap package-manager
+access to host-local repositories whose paths contain characters such as `@`
+and therefore appear escaped in file URIs, as in [PR#1728][].


### PR DESCRIPTION
## Summary

When Mock scans package-manager config for host-local repositories to bind-mount into the bootstrap chroot, it currently strips the `file:///` prefix and uses the remaining string as a filesystem path directly.

That breaks valid file URIs containing percent-escaped path characters, for example paths generated by `Path(...).as_uri()`:

  - host path: `/tmp/workspace/job@2/results/bootstrap-repo`
  - file URI: `file:///tmp/workspace/job%402/results/bootstrap-repo`

Mock then checks `/tmp/workspace/job%402/results/bootstrap-repo` on the host, does not find it, skips the bind mount, and the bootstrap package manager later fails to read the local repository.

## Fix

Decode the local filesystem path with `urllib.parse.unquote()` after variable expansion and before the existence checks / bind mount setup.

This keeps existing behavior for plain absolute paths and unescaped `file://` URLs, while making percent-escaped file URIs work correctly.

## Tests

Added a regression test that uses `Path(repo_directory).as_uri()` for a path containing `@` and verifies that the repository is bind-mounted into the bootstrap chroot.

## Reproducer

A config like this should now work correctly:

```ini
[fedora]
baseurl = file:///tmp/workspace/job%402/results/bootstrap-repo
```