### PR TITLE
configs: set bootstrap_image_ready=True for AlmaLinux configs

### DIFF
--- a/mock-core-configs/etc/mock/templates/almalinux-10.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-10.tpl
@@ -5,6 +5,7 @@ config_opts['releasever_major'] = '10'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:10'
+config_opts['bootstrap_image_ready'] = True
 
 # deal with special handling for x86_64_v2 variant
 config_opts['mirrorlist_arch'] = "{% if repo_arch == 'x86_64_v2' %}?arch=x86_64_v2{% endif %}"

--- a/mock-core-configs/etc/mock/templates/almalinux-8.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-8.tpl
@@ -4,7 +4,7 @@ config_opts['releasever'] = '8'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:8'
-
+config_opts['bootstrap_image_ready'] = True
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/almalinux-9.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-9.tpl
@@ -4,7 +4,7 @@ config_opts['releasever'] = '9'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:9'
-
+config_opts['bootstrap_image_ready'] = True
 
 config_opts['dnf.conf'] = """
 [main]

--- a/mock-core-configs/etc/mock/templates/almalinux-kitten-10.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-kitten-10.tpl
@@ -5,6 +5,7 @@ config_opts['releasever_major'] = '10'
 config_opts['package_manager'] = 'dnf'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
 config_opts['bootstrap_image'] = 'quay.io/almalinuxorg/almalinux:10-kitten'
+config_opts['bootstrap_image_ready'] = True
 
 # deal with special handling for x86_64_v2 variant
 config_opts['mirrorlist_arch'] = "{% if repo_arch == 'x86_64_v2' %}?arch=x86_64_v2{% endif %}"

--- a/releng/release-notes-next/almalinux-bootstrap-image-ready.config.md
+++ b/releng/release-notes-next/almalinux-bootstrap-image-ready.config.md
@@ -1,0 +1,3 @@
+Set bootstrap_image_ready=True for AlmaLinux configs.  AlmaLinux container
+images now have python3-dnf-plugins-core available by default, so Mock skips
+updating the bootstrap chroot after extracting the image.


### PR DESCRIPTION
Set bootstrap_image_ready = True for almalinux-8, almalinux-9, almalinux-10,
and almalinux-kitten-10 templates.

AlmaLinux container images now have python3-dnf-plugins-core available
by default, so there is no need to update the bootstrap chroot after
extracting the image.

See AlmaLinux/container-images#88