### PR TITLE
Add config for Fedora 44 version of RISC-V port

### DIFF
--- a/mock-core-configs/etc/mock/fedora-44-riscv64.cfg
+++ b/mock-core-configs/etc/mock/fedora-44-riscv64.cfg
@@ -1,0 +1,5 @@
+config_opts['releasever'] = '44'
+config_opts['target_arch'] = 'riscv64'
+config_opts['legal_host_arches'] = ('riscv64',)
+
+include('templates/fedora-riscv64.tpl')

--- a/releng/release-notes-next/riscv64-fedora-44.config
+++ b/releng/release-notes-next/riscv64-fedora-44.config
@@ -1,0 +1,2 @@
+Added RISC-V 64-bit architecture support for Fedora 44. Config uses the RISC-V
+Koji infrastructure at `riscv-koji.fedoraproject.org`.


### PR DESCRIPTION
As we started building Fedora 44 it would be good to have config available for it.