### PR TITLE
fix: --verbose no longer duplicates build log into root log (#1302)

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -539,7 +539,6 @@ def setup_logging(config_path, config_opts, options):
         log.handlers[0].setLevel(logging.INFO)
     elif options.verbose == 2:
         log.handlers[0].setLevel(logging.DEBUG)
-        logging.getLogger("mockbuild.Root.build").propagate = 1
         logging.getLogger("mockbuild").propagate = 1
 
     # enable tracing if requested

--- a/releng/release-notes-next/verbose-no-duplicate-build-log.bugfix.md
+++ b/releng/release-notes-next/verbose-no-duplicate-build-log.bugfix.md
@@ -1,0 +1,2 @@
+The `--verbose` option no longer duplicates the build log output into the root
+log.


### PR DESCRIPTION
When --verbose was used, the build logger's propagate flag was set to 1, causing build output to bubble up to the parent mockbuild logger which has a root.log FileHandler. This resulted in build.log content being entirely duplicated in root.log (and installed_packages log as well).

Console output during builds is already handled by direct stdout writes in logOutput(), so the propagation on the build logger was unnecessary.

Resolves: #1302



