### PR TITLE
fix: generate available_pkgs.log for dnf5/dnf4 package managers

### DIFF
--- a/mock/py/mockbuild/plugins/package_state.py
+++ b/mock/py/mockbuild/plugins/package_state.py
@@ -52,11 +52,11 @@ class PackageState(object):
                 self.state.start("Outputting list of available packages")
                 out_file = self.buildroot.resultdir + '/available_pkgs.log'
                 chrootpath = self.buildroot.make_chroot_path()
-                if self.buildroot.config['package_manager'] in ['dnf', 'microdnf']:
-                    cmd = "/usr/bin/dnf --installroot={0} repoquery -c {0}/etc/dnf/dnf.conf {1} | sort > {2}".format(
+                if self.buildroot.config['package_manager'] == 'yum':
+                    cmd = "/usr/bin/repoquery --installroot={0} -c {0}/etc/yum.conf {1} | sort > {2}".format(
                         chrootpath, repoquery_avail_opts, out_file)
                 else:
-                    cmd = "/usr/bin/repoquery --installroot={0} -c {0}/etc/yum.conf {1} | sort > {2}".format(
+                    cmd = "/usr/bin/dnf --installroot={0} repoquery -c {0}/etc/dnf/dnf.conf {1} | sort > {2}".format(
                         chrootpath, repoquery_avail_opts, out_file)
                 mockbuild.util.do(cmd, shell=True, env=self.buildroot.env)
                 self.avail_done = True

--- a/releng/release-notes-next/package-state-available-pkgs.bugfix.md
+++ b/releng/release-notes-next/package-state-available-pkgs.bugfix.md
@@ -1,0 +1,3 @@
+Fix the package_state plugin so `available_pkgs.log` is generated when
+`package_manager` is set to `dnf5` or `dnf4`, not only `dnf` or `microdnf`
+([#1190][]).


### PR DESCRIPTION
The package_state plugin only checked for 'dnf' and 'microdnf' when choosing the repoquery command, so dnf5 and dnf4 fell through to the legacy /usr/bin/repoquery path which doesn't exist on modern systems. Invert the logic to default to dnf repoquery for all non-yum managers.

Fixes: #1190
