### PR TITLE
feat: remove pkgid from package_state plugin output

### DIFF
--- a/docs/Plugin-PackageState.md
+++ b/docs/Plugin-PackageState.md
@@ -9,7 +9,9 @@ This plugin optionally dumps additional metadata files into the result dir:
 
 Format of `installed_pkgs.log` file is:
 
-    %{nevra} %{buildtime} %{size} %{pkgid} installed
+    %{nevra} %{buildtime} %{size} installed
+
+Note: The `%{pkgid}` field was removed from the output in Mock 6.8.
 
 ## Configuration
 

--- a/mock/py/mockbuild/plugins/package_state.py
+++ b/mock/py/mockbuild/plugins/package_state.py
@@ -17,7 +17,7 @@ import mockbuild.util
 
 # repoquery used
 repoquery_avail_opts = \
-    "--qf '%{name}-%{epoch}:%{version}-%{release}.%{arch} %{buildtime} %{size} %{repoid}' '*'"
+    "--qf '%{name}-%{epoch}:%{version}-%{release}.%{arch} %{buildtime} %{size} %{repoid}\\n' '*'"
 
 # set up logging, module options
 requires_api_version = "1.1"

--- a/mock/py/mockbuild/plugins/package_state.py
+++ b/mock/py/mockbuild/plugins/package_state.py
@@ -17,7 +17,7 @@ import mockbuild.util
 
 # repoquery used
 repoquery_avail_opts = \
-    "--qf '%{name}-%{epoch}:%{version}-%{release}.%{arch} %{buildtime} %{size} %{pkgid} %{repoid}' '*'"
+    "--qf '%{name}-%{epoch}:%{version}-%{release}.%{arch} %{buildtime} %{size} %{repoid}' '*'"
 
 # set up logging, module options
 requires_api_version = "1.1"
@@ -71,7 +71,7 @@ class PackageState(object):
         self.state.start("Outputting list of installed packages")
 
         try:
-            cmd = "rpm -qa --root '%s' --qf '%%{nevra} %%{buildtime} %%{size} %%{pkgid} installed\\n'" % (
+            cmd = "rpm -qa --root '%s' --qf '%%{nevra} %%{buildtime} %%{size} installed\\n'" % (
                 self.buildroot.make_chroot_path())
             with self.buildroot.uid_manager:
                 output, _ = self.buildroot.doOutChroot(cmd, returnOutput=1, shell=True)

--- a/releng/release-notes-next/package-state-remove-pkgid.breaking.md
+++ b/releng/release-notes-next/package-state-remove-pkgid.breaking.md
@@ -1,0 +1,2 @@
+The `%{pkgid}` field has been removed from the `package_state` plugin output
+in both `available_pkgs.log` and `installed_pkgs.log`.


### PR DESCRIPTION
feat: remove pkgid from package_state plugin output
    
The %{pkgid} field is no longer useful (and do not work at all) and has been removed from both
available_pkgs.log and installed_pkgs.log output.

This is made on top of https://github.com/rpm-software-management/mock/pull/1739, which should be reviewed and merged first.