### PR TITLE
fix: respect update_before_build=False during builddep (issue#1420)

### DIFF
--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -193,18 +193,41 @@ class Commands(object):
 
         return spec_path
 
+    def _get_update_exclude_opts(self):
+        """
+        When update_before_build is disabled, return --exclude options for all
+        installed packages so that builddep/install won't upgrade them.
+        Works around https://github.com/rpm-software-management/dnf5/issues/1747
+        """
+        if self.config.get('update_before_build', True):
+            return []
+
+        if self.buildroot.pkg_manager.name != "dnf5":
+            return []
+
+        command = [self.config['rpm_command'], "-qa", "--queryformat", "%{NAME}\\n",
+                   "--root", self.buildroot.make_chroot_path()]
+        out, _ = self.buildroot.doOutChroot(command, returnOutput=True,
+                                            printOutput=False, shell=False)
+        pkg_names = set(filter(None, out.strip().splitlines()))
+        if not pkg_names:
+            return []
+        return ['--exclude=' + ','.join(sorted(pkg_names))]
+
     @traceLog()
     def installSrpmDeps(self, *srpms):
         """Figure out deps from srpm. Call package manager to install them"""
         try:
             self.uid_manager.becomeUser(0, 0)
 
+            exclude_opts = self._get_update_exclude_opts()
+
             deps = self.getPreconfiguredDeps(srpms)
             if deps:
-                self.buildroot.pkg_manager.install(*deps, check=True)
+                self.buildroot.pkg_manager.install(*exclude_opts, *deps, check=True)
 
             # install actual build dependencies
-            self.buildroot.pkg_manager.builddep(*srpms, check=True)
+            self.buildroot.pkg_manager.builddep(*exclude_opts, *srpms, check=True)
         finally:
             self.uid_manager.restorePrivs()
 

--- a/releng/release-notes-next/update-before-build-respected.bugfix.md
+++ b/releng/release-notes-next/update-before-build-respected.bugfix.md
@@ -1,0 +1,6 @@
+The `config_opts['update_before_build'] = False` option is now respected
+during build dependency installation with dnf5. Previously, `dnf5 builddep`
+would upgrade already-installed packages even when this option was disabled,
+as reported in [issue#1420][]. When dnf5 is the package manager, Mock now
+excludes installed packages during `builddep`/`install`, preventing unwanted
+upgrades.


### PR DESCRIPTION
dnf5 builddep upgrades already-installed packages even when update_before_build is disabled. Work around this by excluding all installed package names from repo lookups during dependency installation, so only genuinely missing packages are pulled in.

Fixes: #1420


