### PR TITLE
fix: preserve readable permissions when copying spec files into chroot (#1300)

### DIFF
--- a/.github/workflows/fedora-tox.yml
+++ b/.github/workflows/fedora-tox.yml
@@ -15,6 +15,7 @@ jobs:
         uses: fedora-python/tox-github-action@main
         with:
           tox_env: ${{ matrix.tox_env }}
+          dnf_install: python3-rpm
     strategy:
       matrix:
         tox_env:

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -635,7 +635,7 @@ class Commands(object):
         specFilename = os.path.basename(spec_path)
         dest = self.buildroot.make_chroot_path(self.buildroot.builddir, 'originals')
         dest_path = os.path.join(dest, specFilename)
-        shutil.copyfile(spec_path, dest_path)
+        shutil.copy2(spec_path, dest_path)
         os.chmod(dest_path, 0o644)
         return os.path.join(self.buildroot.builddir, 'originals', specFilename)
 

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -634,7 +634,9 @@ class Commands(object):
     def copy_spec_into_chroot(self, spec_path):
         specFilename = os.path.basename(spec_path)
         dest = self.buildroot.make_chroot_path(self.buildroot.builddir, 'originals')
-        shutil.copy2(spec_path, os.path.join(dest, specFilename))
+        dest_path = os.path.join(dest, specFilename)
+        shutil.copyfile(spec_path, dest_path)
+        os.chmod(dest_path, 0o644)
         return os.path.join(self.buildroot.builddir, 'originals', specFilename)
 
     @traceLog()

--- a/mock/tests/test_backend.py
+++ b/mock/tests/test_backend.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for mockbuild.backend — copy helpers."""
+
+import os
+import stat
+from unittest.mock import MagicMock
+
+from mockbuild.backend import Commands
+
+
+def _make_commands(tmp_path):
+    """Return a Commands instance with a stubbed-out buildroot."""
+    originals = tmp_path / "chroot" / "builddir" / "originals"
+    originals.mkdir(parents=True)
+
+    br = MagicMock()
+    br.builddir = "/builddir"
+    br.make_chroot_path = lambda *parts: str(tmp_path / "chroot" / os.path.join(*parts).lstrip("/"))
+
+    cmd = Commands.__new__(Commands)
+    cmd.buildroot = br
+    return cmd
+
+
+class TestCopySpecIntoChroot:
+    """copy_spec_into_chroot must not preserve restrictive permissions."""
+
+    def test_restrictive_permissions_not_preserved(self, tmp_path):
+        """A 0600 spec file must become 0644 after copy (#1300)."""
+        spec = tmp_path / "test.spec"
+        spec.write_text("Name: test\n")
+        spec.chmod(0o600)
+
+        cmd = _make_commands(tmp_path)
+        cmd.copy_spec_into_chroot(str(spec))
+
+        dest = tmp_path / "chroot" / "builddir" / "originals" / "test.spec"
+        mode = stat.S_IMODE(dest.stat().st_mode)
+        assert mode == 0o644, f"file should be 0644, got {oct(mode)}"
+
+    def test_content_copied(self, tmp_path):
+        """File content must be faithfully copied."""
+        spec = tmp_path / "hello.spec"
+        spec.write_text("Name: hello\nVersion: 1\n")
+
+        cmd = _make_commands(tmp_path)
+        cmd.copy_spec_into_chroot(str(spec))
+
+        dest = tmp_path / "chroot" / "builddir" / "originals" / "hello.spec"
+        assert dest.read_text() == "Name: hello\nVersion: 1\n"
+
+    def test_return_value(self, tmp_path):
+        """Returned path must be the in-chroot (non-host) path."""
+        spec = tmp_path / "foo.spec"
+        spec.write_text("")
+
+        cmd = _make_commands(tmp_path)
+        result = cmd.copy_spec_into_chroot(str(spec))
+        assert result == "/builddir/originals/foo.spec"
+
+
+class TestCopySrpmIntoChroot:
+    """copy_srpm_into_chroot basic behavior."""
+
+    def test_content_copied(self, tmp_path):
+        """File content must be faithfully copied."""
+        srpm = tmp_path / "test.src.rpm"
+        srpm.write_bytes(b"\x00" * 16)
+
+        cmd = _make_commands(tmp_path)
+        cmd.copy_srpm_into_chroot(str(srpm))
+
+        dest = tmp_path / "chroot" / "builddir" / "originals" / "test.src.rpm"
+        assert dest.read_bytes() == b"\x00" * 16
+
+    def test_return_value(self, tmp_path):
+        """Returned path must be the in-chroot (non-host) path."""
+        srpm = tmp_path / "test.src.rpm"
+        srpm.write_bytes(b"")
+
+        cmd = _make_commands(tmp_path)
+        result = cmd.copy_srpm_into_chroot(str(srpm))
+        assert result == "/builddir/originals/test.src.rpm"

--- a/releng/release-notes-next/spec-file-permissions.bugfix.md
+++ b/releng/release-notes-next/spec-file-permissions.bugfix.md
@@ -1,0 +1,4 @@
+The `--spec` option now works with spec files that have restrictive
+permissions (e.g. `0600`).  Previously, `shutil.copy2()` preserved the
+source permissions inside the chroot, making the file unreadable by the
+`mockbuild` user ([#1300][]).

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     jsonschema
     pytest
     pytest-cov
+    rpm
 setenv =
     PYTHONPATH = ./mock/py
 commands =


### PR DESCRIPTION
 Use shutil.copyfile() instead of shutil.copy2() so that restrictive
source permissions (e.g., 0600) are not carried into the chroot, which
previously made the spec file unreadable by the mockbuild user.
    
Fixes: #1300

