### PR TITLE
fix: preserve dnf.conf/yum.conf timestamps when content is unchanged

### DIFF
--- a/mock/py/mockbuild/file_util.py
+++ b/mock/py/mockbuild/file_util.py
@@ -30,6 +30,19 @@ def touch(fileName):
     open(fileName, 'a').close()
 
 
+def write_if_changed(filepath, content):
+    """Write content to file only if it differs from the current content,
+    preserving the file timestamp when unchanged."""
+    try:
+        with open(filepath, 'r', encoding="utf-8") as f:
+            if f.read() == content:
+                return
+    except FileNotFoundError:
+        pass
+    with open(filepath, 'w', encoding="utf-8") as f:
+        f.write(content)
+
+
 @traceLog()
 def rmtree(path, selinux=False, exclude=()):
     """Version of shutil.rmtree that ignores no-such-file-or-directory errors,

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -636,8 +636,7 @@ class Yum(_PackageManager):
         dnfconf_path = os.path.join('etc', 'dnf', 'dnf.conf')
         for conf_path in (yumconf_path, dnfconf_path):
             chroot_conf_path = self.buildroot.make_chroot_path(conf_path)
-            with open(chroot_conf_path, 'w+') as conf_file:
-                conf_file.write(config_content)
+            file_util.write_if_changed(chroot_conf_path, config_content)
             if os.path.exists(conf_path):
                 shutil.copystat(conf_path, chroot_conf_path)
 
@@ -704,8 +703,7 @@ class Dnf(_PackageManager):
         check_yum_config(config_content, self.buildroot.root_log)
         file_util.mkdirIfAbsent(self.buildroot.make_chroot_path('etc', 'dnf'))
         dnfconf_path = self.buildroot.make_chroot_path('etc', 'dnf', 'dnf.conf')
-        with open(dnfconf_path, 'w+') as dnfconf_file:
-            dnfconf_file.write(config_content)
+        file_util.write_if_changed(dnfconf_path, config_content)
         self.initialize_vars()
 
     def builddep(self, *pkgs, **kwargs):

--- a/mock/tests/test_file_util.py
+++ b/mock/tests/test_file_util.py
@@ -56,6 +56,53 @@ def chattr_works_or_skip(path: Path):
         pytest.skip(e.stderr.rstrip())
 
 
+class TestWriteIfChanged:
+    """Tests for file_util.write_if_changed"""
+
+    def test_creates_new_file(self, temp_dir):
+        """Should create the file when it does not exist."""
+        path = temp_dir / "new.conf"
+        file_util.write_if_changed(str(path), "new content")
+        assert path.read_text() == "new content"
+
+    def test_overwrites_when_content_differs(self, temp_dir):
+        """Should overwrite the file when content changes."""
+        path = temp_dir / "existing.conf"
+        path.write_text("old content")
+        file_util.write_if_changed(str(path), "new content")
+        assert path.read_text() == "new content"
+
+    def test_preserves_timestamp_when_unchanged(self, temp_dir):
+        """Should not rewrite the file when content is identical."""
+        path = temp_dir / "stable.conf"
+        path.write_text("same content")
+        mtime_before = path.stat().st_mtime_ns
+        file_util.write_if_changed(str(path), "same content")
+        mtime_after = path.stat().st_mtime_ns
+        assert mtime_before == mtime_after
+
+    def test_updates_timestamp_when_changed(self, temp_dir):
+        """Should update the file timestamp when content differs."""
+        path = temp_dir / "changing.conf"
+        path.write_text("version 1")
+        # Set mtime to the past so we can detect a change
+        old_time = path.stat().st_mtime_ns - 1_000_000_000
+        os.utime(str(path), ns=(old_time, old_time))
+        mtime_before = path.stat().st_mtime_ns
+        file_util.write_if_changed(str(path), "version 2")
+        mtime_after = path.stat().st_mtime_ns
+        assert mtime_after > mtime_before
+
+    def test_handles_empty_content(self, temp_dir):
+        """Should handle empty string content correctly."""
+        path = temp_dir / "empty.conf"
+        file_util.write_if_changed(str(path), "")
+        assert path.read_text() == ""
+        mtime_before = path.stat().st_mtime_ns
+        file_util.write_if_changed(str(path), "")
+        assert path.stat().st_mtime_ns == mtime_before
+
+
 class TestRmtree:
     """Integration-style tests for file_util.rmtree using real files and directories"""
 

--- a/releng/release-notes-next/preserve-config-timestamp.bugfix.md
+++ b/releng/release-notes-next/preserve-config-timestamp.bugfix.md
@@ -1,0 +1,7 @@
+Mock now preserves the timestamp of `dnf.conf` and `yum.conf` inside the
+chroot when their content has not changed.  Previously, every mock invocation
+rewrote these files unconditionally, which — combined with DNF's default
+`check_config_file_age=True` — caused repository metadata to be re-downloaded
+even when it was still valid ([issue#216][]).
+
+[issue#216]: https://github.com/rpm-software-management/mock/issues/216


### PR DESCRIPTION
Mock always rewrote these config files unconditionally, giving them a fresh timestamp on every invocation. Combined with DNF's default check_config_file_age=True, this caused repository metadata to be re-downloaded even when still valid (issue #216).

Add file_util.write_if_changed() that skips the write when the file already contains the desired content, and use it in both Dnf.initialize_config() and Yum.initialize_config().

Fixes: #216

