### PR TITLE
tests: automatically test against the latest stable Fedora

### DIFF
--- a/mock/integration-tests/setup-playbook/tasks/main.yml
+++ b/mock/integration-tests/setup-playbook/tasks/main.yml
@@ -19,6 +19,7 @@
       - nosync.i686
       - podman
       - python3-behave
+      - python3-fedora-distro-aliases
       - python3-hamcrest
       - rpm-sign
       - subscription-manager

--- a/mock/integration-tests/testenvironment
+++ b/mock/integration-tests/testenvironment
@@ -8,7 +8,7 @@ VERBOSE=--verbose
 #
 # most tests below will use this mock command line
 #
-testConfig=fedora-42-x86_64
+testConfig=$(resolve-fedora-aliases fedora-latest-stable)-x86_64
 uniqueext="$$-$RANDOM"
 outdir=${TOPDIR}/mock-unit-test
 cfgdir=${TOPDIR}/../mock-core-configs/etc/mock


### PR DESCRIPTION
Right now it means a move from Fedora 42 to Fedora 43, and on 2026-04-28 a move to F44