### PR TITLE
fix: add timeout to podman pull to prevent indefinite hangs (#1680)

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -179,6 +179,10 @@
 # full jitter, see python-backoff docs for more info).
 #config_opts['bootstrap_image_keep_getting'] = 120  # seconds
 
+# Timeout in seconds for a single "podman pull" attempt.  If the pull hangs
+# longer than this, it is killed and retried (within the keep_getting window).
+#config_opts['bootstrap_image_pull_timeout'] = 120
+
 # Skip the "podman pull" and rely on the image already being in the local cache.
 #config_opts["bootstrap_image_skip_pull"] = False
 
@@ -443,6 +447,9 @@
 #config_opts['buildroot_image_fallback'] = False
 # Keep trying 'podman pull' for at most 120s.
 #config_opts['buildroot_image_keep_getting'] = 120
+# Timeout in seconds for a single "podman pull" attempt.  If the pull hangs
+# longer than this, it is killed and retried (within the keep_getting window).
+#config_opts['buildroot_image_pull_timeout'] = 120
 # If set, mock compares the OCI image digest with the one specified here.
 #config_opts['buildroot_image_assert_digest'] = None
 

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -117,6 +117,7 @@ class Buildroot(object):
         self.image_skip_pull = self.config[f"{image}_image_skip_pull"]
         self.image_assert_digest = self.config.get(f"{image}_image_assert_digest", None)
         self.image_keep_getting = self.config[f"{image}_image_keep_getting"]
+        self.image_pull_timeout = self.config[f"{image}_image_pull_timeout"]
 
         self.pkg_manager = None
         self.mounts = mounts.Mounts(self)
@@ -277,7 +278,8 @@ class Buildroot(object):
 
             with _fallback("Can't initialize from container image"):
                 if not self.image_skip_pull:
-                    podman.retry_image_pull(self.image_keep_getting)
+                    podman.retry_image_pull(self.image_keep_getting,
+                                            self.image_pull_timeout)
                 else:
                     podman.read_image_id()
                     getLog().info("Using local image %s (%s)",

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -107,6 +107,7 @@ def setup_default_config_opts():
     config_opts['bootstrap_image_ready'] = False
     config_opts['bootstrap_image_fallback'] = True
     config_opts['bootstrap_image_keep_getting'] = 120
+    config_opts['bootstrap_image_pull_timeout'] = 120
     config_opts['bootstrap_image_assert_digest'] = None
 
     config_opts['use_buildroot_image'] = False
@@ -115,6 +116,7 @@ def setup_default_config_opts():
     config_opts['buildroot_image_ready'] = False
     config_opts['buildroot_image_fallback'] = False
     config_opts['buildroot_image_keep_getting'] = 120
+    config_opts['buildroot_image_pull_timeout'] = 120
     config_opts['buildroot_image_assert_digest'] = None
 
     config_opts['internal_dev_setup'] = True

--- a/mock/py/mockbuild/podman.py
+++ b/mock/py/mockbuild/podman.py
@@ -113,8 +113,8 @@ class Podman:
         getLog().info("Using container image: %s", image)
 
     @traceLog()
-    def pull_image(self):
-        """ pull the latest image, return True if successful """
+    def pull_image(self, timeout=None):
+        """Pull the latest image, return True if successful."""
         logger = getLog()
         logger.info("Pulling image: %s", self.image)
         cmd = [self.podman_binary, "pull"]
@@ -124,9 +124,15 @@ class Podman:
             cmd += ["--platform", oci_platform]
         cmd.append(self.image)
 
-        res = subprocess.run(cmd, env=self.buildroot.env,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                             check=False)
+        try:
+            res = subprocess.run(cmd, env=self.buildroot.env,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 timeout=timeout, check=False)
+        except subprocess.TimeoutExpired:
+            logger.warning("Pulling image %s timed out after %s seconds",
+                           self.image, timeout)
+            return False
+
         if res.returncode != 0:
             logger.error("%s\n%s", res.stdout, res.stderr)
             return False
@@ -153,13 +159,13 @@ class Podman:
         subprocess.run(cmd, env=self.buildroot.env, stdout=subprocess.PIPE,
                        stderr=subprocess.PIPE, check=True)
 
-    def retry_image_pull(self, max_time):
-        """ Try pulling the image multiple times """
+    def retry_image_pull(self, max_time, timeout=None):
+        """Try pulling the image multiple times."""
         @backoff.on_predicate(backoff.expo, lambda x: not x,
                               max_time=max_time, jitter=backoff.full_jitter,
                               on_giveup=pull_fail_handler)
         def _keep_trying():
-            return self.pull_image()
+            return self.pull_image(timeout=timeout)
         _keep_trying()
 
     @contextmanager

--- a/mock/tests/test_podman.py
+++ b/mock/tests/test_podman.py
@@ -120,6 +120,36 @@ class TestArchCheck:
 # Negative / boundary tests
 # ===================================================================
 
+class TestPullImageTimeout:
+    """pull_image() must handle timeout correctly."""
+
+    @patch("mockbuild.podman.subprocess.run")
+    def test_timeout_passed_to_subprocess(self, mock_run):
+        """timeout parameter is forwarded to subprocess.run."""
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"sha256:abc")
+        br = _make_buildroot("x86_64")
+        pod = _make_podman(br)
+        assert pod.pull_image(timeout=60) is True
+        assert mock_run.call_args[1]["timeout"] == 60
+
+    @patch("mockbuild.podman.subprocess.run")
+    def test_timeout_expired_returns_false(self, mock_run):
+        """TimeoutExpired causes pull_image to return False."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="podman pull", timeout=60)
+        br = _make_buildroot("x86_64")
+        pod = _make_podman(br)
+        assert pod.pull_image(timeout=60) is False
+
+    @patch("mockbuild.podman.subprocess.run")
+    def test_no_timeout_by_default(self, mock_run):
+        """Without timeout argument, subprocess.run gets timeout=None."""
+        mock_run.return_value = MagicMock(returncode=0, stdout=b"sha256:abc")
+        br = _make_buildroot("x86_64")
+        pod = _make_podman(br)
+        pod.pull_image()
+        assert mock_run.call_args[1]["timeout"] is None
+
+
 class TestArchCheckErrorPaths:
     """Error handling in architecture check."""
 

--- a/releng/release-notes-next/podman-pull-timeout.bugfix.md
+++ b/releng/release-notes-next/podman-pull-timeout.bugfix.md
@@ -1,0 +1,3 @@
+Podman image pull now has a per-attempt timeout (configurable via
+`bootstrap_image_pull_timeout` and `buildroot_image_pull_timeout`, default
+120 seconds) to prevent indefinite hangs and allow the retry logic to work.


### PR DESCRIPTION
When podman pull hangs (e.g. due to network issues), the backoff retry logic never gets a chance to retry because subprocess.run blocks forever. Add a per-attempt timeout (default 120s) so that a hung pull is killed and retried.

New config options:
- bootstrap_image_pull_timeout
- buildroot_image_pull_timeout

Fixes: #1680
Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

