### PR TITLE
fix: nspawn_host_dev - restore /dev/pts and /dev/shm after devtmpfs remount

### DIFF
--- a/mock/docs/mock.1
+++ b/mock/docs/mock.1
@@ -360,6 +360,15 @@ chroot() call.  The \fInspawn\fR  method utilizes systemd-nspawn(1) and runs the
 commands inside container.  The \fIauto\fR tries to use \fInspawn\fR, and falls
 back to \fIsimple\fR if system-nspawn can not be used (e.g. if mock is run in
 container).  The default is \fIauto\fR.
+.IP
+When using \fInspawn\fR isolation, dynamically\-created loop partition device
+nodes (e.g. /dev/loop0p1) are not visible inside the container by default.
+If your build requires partitioning loop\-backed block devices (e.g. kiwi or
+osbuild image builds), set \fBconfig_opts['nspawn_host_dev'] = True\fR in your
+configuration.  This remounts /dev as devtmpfs inside the container (restoring
+/dev/pts and /dev/shm afterwards) so that kernel\-created device nodes appear
+automatically, and adds the CAP_SYS_ADMIN capability with a relaxed device
+cgroup policy.
 .TP
 \fB\-\-localrepo\fR=\fIREPO\fR\fR
 Set the path to put the results/repo in (works only in \fB\-\-chain\fR mode).

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -85,6 +85,17 @@
 # config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
 # If you want to speed up Mock and you do not sync() during %check you can use
 # config_opts['nspawn_args'] = ['--capability=cap_ipc_lock', '--suppress-sync=yes']
+#
+# Remount /dev as devtmpfs inside the nspawn container so that
+# dynamically-created device nodes (such as loop partition devices
+# /dev/loop0p1, etc.) are visible inside the build environment.  This is
+# required for image-building tools like kiwi, osbuild, or any workflow
+# that partitions loop-backed block devices.  Enabling this adds the
+# CAP_SYS_ADMIN capability, relaxes the device cgroup policy, and
+# restores /dev/pts and /dev/shm after the remount.
+# Only enable when needed.
+# config_opts['nspawn_host_dev'] = False
+#
 ## When RPM is build in container then build hostname is set to name of
 ## container. This sets the build hostname to name of container's host.
 ## Works only in F25+ chroots

--- a/mock/integration-tests/28-nspawn-host-dev.tst
+++ b/mock/integration-tests/28-nspawn-host-dev.tst
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+. ${TESTDIR}/functions
+
+header "Test nspawn_host_dev: loop partition devices visible"
+runcmd "$MOCKCMD --isolation=nspawn --no-bootstrap-image \
+    --config-opts=nspawn_host_dev=True \
+    --install util-linux \
+    --shell '
+        truncate -s 100M /tmp/test.img &&
+        dev=\$(losetup -fP --show /tmp/test.img) &&
+        echo \",,L\" | sfdisk \$dev &&  # create one Linux partition spanning the whole disk
+        test -b \${dev}p1 &&
+        echo HOST_DEV_OK;
+        losetup -d \$dev;
+        rm -f /tmp/test.img
+    '" || die "nspawn_host_dev: loop partition device not visible"

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -837,12 +837,16 @@ class Buildroot(object):
     def _setup_nspawn_btrfs_device(self):
         if not util.USE_NSPAWN or self.is_bootstrap:
             return
+        if self.config['nspawn_host_dev']:
+            return
         if os.path.exists('/dev/btrfs-control'):
             self.config['nspawn_args'].append('--bind=/dev/btrfs-control')
 
     @traceLog()
     def _setup_nspawn_devicemapper_device(self):
         if not util.USE_NSPAWN or self.is_bootstrap:
+            return
+        if self.config['nspawn_host_dev']:
             return
         if os.path.exists('/dev/mapper/control'):
             self.config['nspawn_args'].append('--bind=/dev/mapper/control')
@@ -851,12 +855,21 @@ class Buildroot(object):
     def _setup_nspawn_fuse_device(self):
         if not util.USE_NSPAWN or self.is_bootstrap:
             return
+        if self.config['nspawn_host_dev']:
+            return
         if os.path.exists('/dev/fuse'):
             self.config['nspawn_args'].append('--bind=/dev/fuse')
 
     @traceLog()
     def _setup_nspawn_loop_devices(self):
         if not util.USE_NSPAWN or self.is_bootstrap:
+            return
+
+        if self.config['nspawn_host_dev']:
+            self.config['nspawn_args'].extend([
+                '--capability=cap_sys_admin',
+                '--property=DevicePolicy=auto',
+            ])
             return
 
         self.config['nspawn_args'].append('--bind=/dev/loop-control')

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -98,6 +98,7 @@ def setup_default_config_opts():
     # FIXME disable as default because of https://github.com/rpm-software-management/mock/issues/1641
     # if check_nspawn_has_suppress_sync_option():
     #    config_opts['nspawn_args'] += ['--suppress-sync=yes']
+    config_opts['nspawn_host_dev'] = False
     config_opts['use_container_host_hostname'] = True
 
     config_opts['use_bootstrap'] = True

--- a/mock/py/mockbuild/mounts.py
+++ b/mock/py/mockbuild/mounts.py
@@ -231,6 +231,19 @@ class Mounts(object):
                                options="nodev,noexec,nosuid,readonly,rprivate"),
             ]
 
+        if rootObj.config.get('nspawn_host_dev') and util.USE_NSPAWN:
+            # Remount /dev as devtmpfs so dynamically-created device nodes (such as
+            # loop partition devices /dev/loop0p1) are visible inside the container.
+            # The remount masks submounts like /dev/pts and /dev/shm, so they must
+            # be restored explicitly afterwards.
+            self.essential_mounts.append(
+                FileSystemMountPoint(
+                    filetype='devtmpfs',
+                    device='devtmpfs',
+                    path=rootObj.make_chroot_path('/dev')
+                )
+            )
+
         if rootObj.config['internal_dev_setup']:
             self.essential_mounts.append(
                 FileSystemMountPoint(
@@ -319,7 +332,7 @@ class Mounts(object):
 
     @traceLog()
     def mountall_managed(self):
-        if not util.USE_NSPAWN:
+        if not util.USE_NSPAWN or self.rootObj.config.get('nspawn_host_dev'):
             self.mountall_essential()
         for m in self.managed_mounts:
             m.mount()


### PR DESCRIPTION
systemd-nspawn sets up /dev as tmpfs, so dynamically created device
nodes (e.g. /dev/loop0p1) never appear inside the container.
This is a known kernel limitation. Block devices are not virtualized
for containers (https://github.com/systemd/systemd/issues/21987, Poettering on systemd-devel:
https://lists.freedesktop.org/archives/systemd-devel/2017-August/039453.html).

The nspawn_host_dev option works around this by remounting /dev as
devtmpfs inside the container.  Since devtmpfs is a single kernel-wide
instance, all device nodes (including those created dynamically by)
become visible. The osbuild/image-builder uses the same approach
(see osbuild/image-builder-cli pkg/setup/setup.go and https://github.com/rpm-software-management/mock/issues/1554 discussion).

When nspawn_host_dev is enabled:
- CAP_SYS_ADMIN is granted and DevicePolicy set to auto.
- /dev is remounted as devtmpfs before each command, then /dev/pts
  and /dev/shm are restored (the remount masks these submounts).
- The remount is skipped in bootstrap chroots where CAP_SYS_ADMIN
  is not granted.

Fixes: https://github.com/rpm-software-management/mock/issues/1554