### PR TITLE
Don't use --allowerasing with 'dnf download'

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -387,6 +387,7 @@ def setup_default_config_opts():
         "makecache": ["--allowerasing"],
         "search": ["--allowerasing"],
         "info": ["--allowerasing"],
+        "download": ["--allowerasing"],
     }
 
     config_opts['microdnf_command'] = '/usr/bin/microdnf'

--- a/releng/release-notes-next/fix-dnf-download-command.bugfix.md
+++ b/releng/release-notes-next/fix-dnf-download-command.bugfix.md
@@ -1,0 +1,3 @@
+The dnf `download` command does not accept the `--allowerasing` argument
+in dnf5. This invalid argument is now excluded when invoking dnf `download`
+operations using `--dnf-cmd` or `--pm-cmd`.


### PR DESCRIPTION
This isn't a valid argument to the `download` verb.

Repro:
```console
$ mock --dnf-cmd -- download --source filesystem
...
Unknown argument "--allowerasing" for command "download". Add "--help" for more information about the arguments.
...
```