### PR TITLE
fix: reload uidManager with chrootuid/chrootgid from config

### DIFF
--- a/mock/py/mock.py
+++ b/mock/py/mock.py
@@ -675,20 +675,6 @@ def main():
     # initial sanity check for correct invocation method
     rootcheck()
 
-    # drop unprivileged to parse args, etc.
-    #   uidManager saves current real uid/gid which are unprivileged (callers)
-    #   due to suid helper, our current effective uid is 0
-    #   also supports being run by sudo
-    #
-    #   setuid wrapper has real uid = unpriv,  effective uid = 0
-    #   sudo sets real/effective = 0, and sets env vars
-    #   setuid wrapper clears environment, so there wont be any conflict between these two
-    uidManager = mockbuild.uid.setup_uid_manager()
-
-    # go unpriv only when root to make --help etc work for non-mock users
-    if os.geteuid() == 0:
-        uidManager.dropPrivsTemp()
-
     (options, args) = command_parse()
     if options.printrootpath or options.list_snapshots:
         options.verbose = 0
@@ -704,8 +690,19 @@ def main():
     if options.hermetic_build:
         options.chroot = "hermetic-build"
 
+    # Setup uidManager for privilege handling.  At this point:
+    #   - setuid wrapper: real uid = unpriv, effective uid = 0
+    #   - sudo: real/effective = 0, with env vars identifying the caller
+    # Load config unprivileged, then reload uidManager with the configured
+    # chrootuid/chrootgid so that subsequent privilege dropping uses the
+    # chroot identity instead of the calling user's.
+    uidManager = mockbuild.uid.setup_uid_manager()
     config_opts = uidManager.run_in_subprocess_without_privileges(
             config.load_config, config_path, options.chroot)
+
+    uidManager = mockbuild.uid.reload_uidmanager(uidManager, config_opts)
+    if os.geteuid() == 0:
+        uidManager.dropPrivsTemp()
 
     # cmdline options override config options
     config.set_config_opts_per_cmdline(config_opts, options, args)

--- a/mock/py/mockbuild/uid.py
+++ b/mock/py/mockbuild/uid.py
@@ -41,6 +41,14 @@ def setup_uid_manager():
     uidManager = UidManager(unprivUid, unprivGid)
     return uidManager
 
+
+def reload_uidmanager(uidmanager, config_opts):
+    """Re-create UidManager with chrootuid/chrootgid from config."""
+    unpriv_uid = config_opts["chrootuid"]
+    unpriv_gid = config_opts.get("chrootgid", uidmanager.unprivGid)
+    return UidManager(unpriv_uid, unpriv_gid)
+
+
 class UidManager(object):
     @traceLog()
     def __init__(self, unprivUid=-1, unprivGid=-1):

--- a/releng/release-notes-next/reload-uidmanager-from-config.bugfix.md
+++ b/releng/release-notes-next/reload-uidmanager-from-config.bugfix.md
@@ -1,0 +1,4 @@
+The `uidManager` is now reloaded with `chrootuid`/`chrootgid` from
+config after the configuration is loaded.  Previously, privilege
+dropping always used the calling user's identity, ignoring the
+configured chroot user ([#1731][]).


### PR DESCRIPTION
The uidManager was initialized before config was loaded, so it always used the calling user's UID/GID for privilege dropping.  When config specifies a different chrootuid/chrootgid, the uidManager needs to be reloaded with those values — otherwise operations run under the wrong identity, leading to permission errors in the chroot.

Move uidManager initialization after command_parse() (which doesn't need to drop privileges) and reload it with chrootuid/chrootgid from config_opts right after config is loaded (loaded with dropped privileges).

Fixes: #1731

Assisted-By: Claude Code (claude-opus-4-6)