### PR TITLE
unbreq plugin: disable SRPM caching

### DIFF
--- a/mock/py/mockbuild/plugins/unbreq.py
+++ b/mock/py/mockbuild/plugins/unbreq.py
@@ -81,7 +81,6 @@ class Unbreq:
         self.exclude_accessed_files = [re.compile(r) for r in config_exclude_accessed_files]
         self.accessed_files = AtimeDict()
         self.mount_options: list[str] = []
-        self.srpms: set[str] = set()
         self.rpm_files: dict[str, list[str]] = {}
         self.buildrequires_providers: dict[str, list[str]] = {}
         self.buildrequires_deptype: dict[str, str] = {}
@@ -366,9 +365,7 @@ class Unbreq:
         srpm_dir = self.buildroot.make_chroot_path(self.buildroot.builddir, "SRPMS")
         with self.do_with_chroot():
             for srpm in os.scandir(srpm_dir):
-                if srpm.path not in self.srpms:
-                    self.srpms.add(srpm.path)
-                    self.get_buildrequires(srpm.path)
+                self.get_buildrequires(srpm.path)
 
     @traceLog()
     def _PostDepsHook(self) -> None:

--- a/releng/release-notes-next/unbreq-disable-srpm-caching.bugfix.md
+++ b/releng/release-notes-next/unbreq-disable-srpm-caching.bugfix.md
@@ -1,0 +1,9 @@
+The `unbreq` plugin now no longer caches the mapping of a source RPM file to its
+`BuildRequires` fields, fixing a logic error where it would ignore later
+automatically generated `BuildRequires` fields if `BuildRequires` autogeneration
+is used.
+
+The original reason for implementing caching was to avoid scanning the same
+`src.rpm` file multiple times. This is not a performance issue though and the
+simplest correct solution is to scan source RPMs after each installation of
+`BuildRequires` fields.


### PR DESCRIPTION
This is an actual logic error which causes the plugin to miss BuildRequires fields in case multiple runs of generate BuildRequires are executed.