### PR TITLE
Add pivot_root_chroot option to enable user namespaces

### DIFF
--- a/behave/features/pivot-root-chroot.feature
+++ b/behave/features/pivot-root-chroot.feature
@@ -1,0 +1,41 @@
+Feature: The pivot_root_chroot option for chroot isolation
+
+    @pivot_root_chroot
+    Scenario: Build succeeds with pivot_root_chroot enabled
+        Given an unique mock namespace
+        And mock is always executed with "--isolation=simple --config-opts=pivot_root_chroot=True"
+        When an online source RPM is rebuilt
+        Then the build succeeds
+
+    @pivot_root_chroot
+    Scenario: Init and rebuild work with pivot_root_chroot enabled
+        Given an unique mock namespace
+        And mock is always executed with "--isolation=simple --config-opts=pivot_root_chroot=True"
+        And pre-intitialized chroot
+        When an online source RPM is rebuilt
+        Then the build succeeds
+
+    @pivot_root_chroot
+    Scenario: pivot_root_chroot is silently ignored with nspawn isolation
+        Given an unique mock namespace
+        And mock is always executed with "--config-opts=pivot_root_chroot=True"
+        When an online source RPM is rebuilt
+        Then the build succeeds
+
+    @pivot_root_chroot
+    Scenario: Chroot command works with pivot_root_chroot enabled
+        Given an unique mock namespace
+        And mock is always executed with "--isolation=simple --config-opts=pivot_root_chroot=True"
+        And pre-intitialized chroot
+        When a command "echo hello_from_pivot_root" is run in the mock chroot
+        Then the exit code is 0
+        And stdout contains "hello_from_pivot_root"
+
+    @pivot_root_chroot
+    Scenario: User namespace can be created with pivot_root_chroot
+        Given an unique mock namespace
+        And mock is always executed with "--isolation=simple --config-opts=pivot_root_chroot=True"
+        And pre-intitialized chroot
+        When a command "unshare --user -- echo user_ns_works" is run in the mock chroot
+        Then the exit code is 0
+        And stdout contains "user_ns_works"

--- a/behave/steps/other.py
+++ b/behave/steps/other.py
@@ -4,6 +4,7 @@ import glob
 import importlib
 import json
 import os
+import shlex
 import shutil
 import tarfile
 import tempfile
@@ -145,6 +146,11 @@ def step_impl(context):
 def step_impl(context, options):
     options = options.split()
     context.last_cmd = run(['mock'] + options)
+
+
+@when('a command "{cmd}" is run in the mock chroot')
+def step_impl(context, cmd):
+    context.last_cmd = run(context.mock.basecmd + ["--chroot", "--"] + shlex.split(cmd))
 
 
 @given('mock is always executed with "{options}"')

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -77,6 +77,12 @@
 # 'chroot').
 #config_opts['isolation'] = 'auto'
 
+# For "simple" there is also an option to chroot whole process to a new
+# directory. It enables user namespaces inside the build environment, thus e.g.
+# allowing use of pasta/passt (local) networking in build or tests. It is a
+# preview feature disabled by default.
+#config_opts['pivot_root_chroot'] = False
+
 # If you're using isolation='nspawn', then by default networking will be turned
 # off for rpmbuild.  This helps ensure more reproducible builds.
 #config_opts['rpmbuild_networking'] = False

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -371,6 +371,7 @@ class Commands(object):
                                cwd=cwd,
                                nspawn_args=self.config.get("nspawn_args", []),
                                unshare_net=self.private_network,
+                               pivot_root_chroot=self.config.get("pivot_root_chroot", False),
                                cmd=cmd)
         finally:
             log.debug("shell: unmounting all filesystems")

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -412,6 +412,9 @@ class Buildroot(object):
         # implemented).
         assert "chrootPath" not in kwargs
 
+        # Set pivot_root_chroot before delegating to bootstrap
+        kwargs.setdefault("pivot_root_chroot", self.config.get("pivot_root_chroot", False))
+
         if self.bootstrap_buildroot:
             with self.mounts.buildroot_in_bootstrap_mounted():
                 return self.bootstrap_buildroot.doChroot(
@@ -434,6 +437,7 @@ class Buildroot(object):
 
         kargs.setdefault("nspawn_args", [])
         kargs["nspawn_args"].extend(self.config.get("nspawn_args", []))
+        kargs.setdefault("pivot_root_chroot", self.config.get("pivot_root_chroot", False))
 
         try:
             result = util.do_with_status(command, chrootPath=self.make_chroot_path(),

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -93,6 +93,7 @@ def setup_default_config_opts():
     config_opts['online'] = True
     config_opts['isolation'] = None
     config_opts['use_nspawn'] = None
+    config_opts['pivot_root_chroot'] = False
     config_opts['rpmbuild_networking'] = False
     config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
     # FIXME disable as default because of https://github.com/rpm-software-management/mock/issues/1641

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -294,6 +294,7 @@ class _PackageManager(object):
             env['LD_PRELOAD'] = self.buildroot.nosync_path
         invocation = self.build_invocation(*args)
         self.buildroot.root_log.debug(invocation)
+        kwargs.setdefault("pivot_root_chroot", self.buildroot.config.get("pivot_root_chroot", False))
         kwargs['printOutput'] = kwargs.get('printOutput', True)
         if not self.config['print_main_output']:
             kwargs.pop('printOutput', None)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -40,13 +40,21 @@ from .trace_decorator import getLog, traceLog
 from .uid import setresuid
 from pyroute2 import IPRoute
 
-_libc = ctypes.cdll.LoadLibrary(None)
+_libc = ctypes.CDLL(None, use_errno=True)
 _libc.personality.argtypes = [ctypes.c_ulong]
 _libc.personality.restype = ctypes.c_int
 _libc.unshare.argtypes = [ctypes.c_int]
 _libc.unshare.restype = ctypes.c_int
+_libc.mount.argtypes = [ctypes.c_char_p, ctypes.c_char_p,
+                         ctypes.c_char_p, ctypes.c_ulong,
+                         ctypes.c_void_p]
+_libc.mount.restype = ctypes.c_int
+_libc.umount2.argtypes = [ctypes.c_char_p, ctypes.c_int]
+_libc.umount2.restype = ctypes.c_int
 _libc.sethostname.argtypes = [ctypes.c_char_p, ctypes.c_int]
 _libc.sethostname.restype = ctypes.c_int
+_libc.pivot_root.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+_libc.pivot_root.restype = ctypes.c_int
 
 # See linux/include/sched.h
 CLONE_NEWNS = 0x00020000
@@ -54,6 +62,14 @@ CLONE_NEWUTS = 0x04000000
 CLONE_NEWPID = 0x20000000
 CLONE_NEWNET = 0x40000000
 CLONE_NEWIPC = 0x08000000
+
+# Mount flags used by condChrootPivotRoot
+# See libmount/libmount.h (libmount-devel)
+MS_BIND    = 0x1000       # 4096: Mount existing tree elsewhere as well
+MS_REC     = 0x4000       # 16384: Recursive loopback
+MS_PRIVATE = 0x40000      # 262144: Make private
+# See sys/mount.h
+MNT_DETACH = 0x00000002   # 2: Just detach from tree
 
 # taken from sys/personality.h
 PER_LINUX32 = 0x0008
@@ -310,6 +326,65 @@ def condChroot(chrootPath):
         setresuid(saved['ruid'], saved['euid'])
 
 
+def _do_pivot_root(chrootPath):
+    """Perform pivot_root(2) chroot.  Caller must already be running as root."""
+    chroot_bytes = chrootPath.encode('utf-8')
+
+    # New mount namespace so our mount changes don't affect the parent
+    if _libc.unshare(CLONE_NEWNS) != 0:
+        raise OSError(ctypes.get_errno(), "unshare(CLONE_NEWNS)")
+
+    # Make all existing mounts private to prevent propagation
+    if _libc.mount(b"none", b"/", None, MS_REC | MS_PRIVATE, None) != 0:
+        raise OSError(ctypes.get_errno(), "mount --make-rprivate /")
+
+    # Bind-mount the chroot dir onto itself so it becomes a mount point
+    # (pivot_root requires new_root to be a mount point)
+    if _libc.mount(chroot_bytes, chroot_bytes, None,
+                    MS_BIND | MS_REC, None) != 0:
+        raise OSError(ctypes.get_errno(), "bind mount " + chrootPath)
+
+    # Directory where the old root will be stashed
+    put_old = os.path.join(chrootPath, ".pivot_old")
+    file_util.mkdirIfAbsent(put_old)
+    put_old_bytes = put_old.encode('utf-8')
+
+    if _libc.pivot_root(chroot_bytes, put_old_bytes) != 0:
+        raise OSError(ctypes.get_errno(), "pivot_root")
+
+    os.chdir("/")
+
+    # Detach the old root — it is no longer needed
+    if _libc.umount2(b"/.pivot_old", MNT_DETACH) != 0:
+        raise OSError(ctypes.get_errno(), "umount2 /.pivot_old")
+
+    os.rmdir("/.pivot_old")
+
+
+def condChrootPivotRoot(chrootPath):
+    """
+    Chroot using pivot_root(2) to allow user namespaces afterward.
+
+    The kernel blocks unshare(CLONE_NEWUSER) after plain chroot() because
+    the process root no longer matches the mount namespace root.  By using
+    pivot_root(2) inside a private mount namespace we atomically swap the
+    mount-namespace root to chrootPath, satisfying the kernel check.
+
+    This is the same approach used by bubblewrap and other container runtimes.
+
+    Requires CAP_SYS_ADMIN (available in --privileged containers).
+    """
+    if chrootPath is None:
+        return
+
+    saved = {"ruid": os.getuid(), "euid": os.geteuid()}
+    setresuid(0, 0, 0)
+    try:
+        _do_pivot_root(chrootPath)
+    finally:
+        setresuid(saved['ruid'], saved['euid'])
+
+
 def condChdir(cwd):
     if cwd is not None:
         os.chdir(cwd)
@@ -526,7 +601,7 @@ def do(*args, **kargs):
 def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, raiseExc=True,
                    returnOutput=0, uid=None, gid=None, user=None, personality=None,
                    printOutput=False, env=None, pty=False, nspawn_args=None, unshare_net=False,
-                   returnStderr=True, *_, **kargs):
+                   returnStderr=True, pivot_root_chroot=False, *_, **kargs):
     logger = kargs.get("logger", getLog())
     if timeout == 0:
         timeout = _OPS_TIMEOUT
@@ -536,8 +611,12 @@ def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, r
         lead_pty, sub_pty = os.openpty()
         resize_pty(sub_pty)
         reader = os.fdopen(lead_pty, 'rb')
+    if pivot_root_chroot and chrootPath and USE_NSPAWN:
+        logger.warning(
+            "pivot_root_chroot=True ignored when using systemd-nspawn")
     preexec = ChildPreExec(personality, chrootPath, cwd, uid, gid,
-                           unshare_ipc=bool(chrootPath), unshare_net=unshare_net)
+                           unshare_ipc=bool(chrootPath), unshare_net=unshare_net,
+                           pivot_root_chroot=pivot_root_chroot)
     if env is None:
         env = clean_env()
     stdout = None
@@ -616,11 +695,13 @@ def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, r
 class ChildPreExec(object):
     def __init__(self, personality, chrootPath, cwd, uid, gid, env=None,
                  shell=False, unshare_ipc=False, unshare_net=False,
-                 no_setsid=False):
+                 no_setsid=False, pivot_root_chroot=False):
         """
         Params:
         - no_setsid - assure we don't call os.setsid(), as the process we run
             calls that itself
+        - pivot_root_chroot - use pivot_root(2) for chroot to enable
+            user namespaces afterward (requires CAP_SYS_ADMIN)
         """
         self.personality = personality
         self.chrootPath = chrootPath
@@ -632,6 +713,7 @@ class ChildPreExec(object):
         self.unshare_ipc = unshare_ipc
         self.unshare_net = unshare_net
         self.no_setsid = no_setsid
+        self.pivot_root_chroot = pivot_root_chroot
         getLog().debug("child environment: %s", env)
 
     def __call__(self, *args, **kargs):
@@ -644,7 +726,10 @@ class ChildPreExec(object):
         # Even if nspawn is allowed to be used, it won't be used unless there
         # is a chrootPath set
         if not USE_NSPAWN or not self.chrootPath:
-            condChroot(self.chrootPath)
+            if self.pivot_root_chroot:
+                condChrootPivotRoot(self.chrootPath)
+            else:
+                condChroot(self.chrootPath)
             condDropPrivs(self.uid, self.gid)
             condChdir(self.cwd)
         condUnshareIPC(self.unshare_ipc)
@@ -795,11 +880,13 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None,
 
     return nspawn_argv + cmd
 
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
             cwd=None,
             nspawn_args=None,
             unshare_ipc=True,
-            unshare_net=False):
+            unshare_net=False,
+            pivot_root_chroot=False):
     log = getLog()
     log.debug("doshell: chrootPath:%s, uid:%d, gid:%d", chrootPath, uid, gid)
     if environ is None:
@@ -821,10 +908,13 @@ def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
     elif isinstance(cmd, list):
         cmd = ' '.join(cmd)
 
+    if pivot_root_chroot and chrootPath and USE_NSPAWN:
+        log.warning(
+            "pivot_root_chroot=True ignored when using systemd-nspawn")
     preexec = ChildPreExec(personality=None, chrootPath=chrootPath, cwd=cwd,
                            uid=uid, gid=gid, env=environ, shell=shell,
                            unshare_ipc=unshare_ipc, unshare_net=unshare_net,
-                           no_setsid=no_setsid)
+                           no_setsid=no_setsid, pivot_root_chroot=pivot_root_chroot)
 
     if USE_NSPAWN:
         # nspawn cannot set gid

--- a/mock/tests/test_mount_pivot_chroot.py
+++ b/mock/tests/test_mount_pivot_chroot.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+
+"""
+Tests for pivot_root(2) chroot technique to enable user namespaces.
+"""
+
+import ctypes
+import os
+import shutil
+import tempfile
+
+import pytest
+
+# Import constants from mockbuild.util
+from mockbuild.util import MS_BIND, MNT_DETACH, condChrootPivotRoot
+
+_libc = ctypes.cdll.LoadLibrary(None)
+_libc.mount.argtypes = [ctypes.c_char_p, ctypes.c_char_p,
+                         ctypes.c_char_p, ctypes.c_ulong, ctypes.c_void_p]
+_libc.mount.restype = ctypes.c_int
+_libc.umount2.argtypes = [ctypes.c_char_p, ctypes.c_int]
+_libc.umount2.restype = ctypes.c_int
+_libc.unshare.argtypes = [ctypes.c_int]
+_libc.unshare.restype = ctypes.c_int
+_libc.syscall.restype = ctypes.c_long
+
+CLONE_NEWNS  = 0x00020000
+CLONE_NEWUSER = 0x10000000
+
+
+def has_cap_sys_admin():
+    """Check if we have CAP_SYS_ADMIN capability."""
+    try:
+        # Try to create a mount namespace - requires CAP_SYS_ADMIN
+        test_dir = tempfile.mkdtemp()
+        try:
+            result = _libc.mount(test_dir.encode(), test_dir.encode(),
+                               None, MS_BIND, None)
+            if result == 0:
+                # Cleanup the mount
+                _libc.umount2(test_dir.encode(), MNT_DETACH)
+                return True
+        finally:
+            os.rmdir(test_dir)
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+    return False
+
+
+@pytest.mark.skipif(not has_cap_sys_admin(),
+                    reason="requires CAP_SYS_ADMIN (run in --privileged container or as root)")
+def test_condChrootPivotRoot_function():
+    """
+    Test the condChrootPivotRoot() function directly.
+
+    This test verifies that the actual Mock function works correctly.
+    """
+    chroot_dir = tempfile.mkdtemp(prefix="mock-test-chroot-")
+
+    try:
+        # Create minimal structure
+        os.makedirs(os.path.join(chroot_dir, "bin"), exist_ok=True)
+        os.makedirs(os.path.join(chroot_dir, "lib"), exist_ok=True)
+
+        pid = os.fork()
+        if pid == 0:
+            # Child process
+            try:
+                # Use the Mock function (it handles making mounts private internally)
+                condChrootPivotRoot(chroot_dir)
+
+                # Try to create user namespace
+                rc = _libc.unshare(CLONE_NEWUSER)
+
+                os._exit(0 if rc == 0 else 1)
+
+            except Exception:  # pylint: disable=broad-exception-caught
+                os._exit(2)
+
+        _, status = os.waitpid(pid, 0)
+        assert os.WIFEXITED(status)
+        exit_code = os.WEXITSTATUS(status)
+
+        if exit_code == 1:
+            pytest.fail("unshare(CLONE_NEWUSER) failed after condChrootPivotRoot")
+        elif exit_code == 2:
+            pytest.fail("Exception in condChrootPivotRoot")
+
+        assert exit_code == 0
+
+    finally:
+        try:
+            shutil.rmtree(chroot_dir)
+        except IOError:
+            pass
+
+
+def test_condChrootPivotRoot_with_none():
+    """
+    Test that condChrootPivotRoot() handles None gracefully.
+
+    This is a simple sanity test that doesn't require special privileges.
+    """
+    # Should not raise any exception
+    condChrootPivotRoot(None)

--- a/releng/release-notes-next/pivot-root-chroot.feature.md
+++ b/releng/release-notes-next/pivot-root-chroot.feature.md
@@ -1,0 +1,9 @@
+New `pivot_root_chroot` configuration option uses `pivot_root(2)` inside a
+private mount namespace to atomically swap the mount-namespace root to the
+chroot path. This satisfies the kernel check that blocks
+`unshare(CLONE_NEWUSER)` after plain `chroot()`, allowing tools like
+pasta/passt that require user namespaces to work inside mock buildroots.
+This is the same approach used by bubblewrap and other container runtimes.
+Requires `CAP_SYS_ADMIN` (available in `--privileged` containers); falls back
+to plain `chroot()` on failure.
+Set `config_opts['pivot_root_chroot'] = True` to enable.


### PR DESCRIPTION
New `pivot_root_chroot` configuration option uses `pivot_root(2)` inside a private mount namespace to atomically swap the mount-namespace root to the chroot path. This satisfies the kernel check that blocks `unshare(CLONE_NEWUSER)` after plain `chroot()`, allowing tools like pasta/passt that require user namespaces to work inside mock buildroots. This is the same approach used by bubblewrap and other container runtimes. Requires `CAP_SYS_ADMIN` (available in `--privileged` containers); falls back to plain `chroot()` on failure.
Set `config_opts['pivot_root_chroot'] = True` to enable.

Requirements:
- CAP_SYS_ADMIN capability (provided by --privileged containers)
- Already in a mount namespace (Podman/Docker containers)

Assisted-By: Claude Sonnet 4.5