### PR TITLE
confnigs: new release 44.3

### DIFF
--- a/.tito/packages/mock-core-configs
+++ b/.tito/packages/mock-core-configs
@@ -1,1 +1,1 @@
-44.2-1 mock-core-configs/
+44.3-1 mock-core-configs/

--- a/docs/Release-Notes-Configs-44.3.md
+++ b/docs/Release-Notes-Configs-44.3.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: Release Notes - Mock Core Configs 44.3
+---
+
+## [Release 44.3](https://rpm-software-management.github.io/mock/Release-Notes-Configs-44.3) - 2026-06-10
+
+### Mock Core Configs changes
+
+- Set `bootstrap_image_ready=True` for AlmaLinux configs.  AlmaLinux container
+  images now have `python3-dnf-plugins-core` available by default, so Mock skips
+  updating the bootstrap chroot after extracting the image.
+
+- The `fedora-release-eln` package was renamed to `fedora-eln-release`; the Mock
+  configuration that explicitly lists this package in `chroot_setup_cmd` has been
+  adjusted accordingly.
+
+- Re-enabled container-based bootstrap for AlmaLinux 10 and AlmaLinux Kitten 10
+  x86_64_v2 configs.  The `use_bootstrap_image = False` workaround is no longer
+  needed and has been removed.
+
+- Added RISC-V 64-bit architecture support for Fedora 44.  The config uses the
+  RISC-V Koji infrastructure at `riscv-koji.fedoraproject.org`.
+
+#### The following contributors have contributed to this release:
+
+- Andrew Lukoshko
+- cheese1
+- Marcin Juszkiewicz
+- Miroslav Suchý
+
+Thank You!

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ Versions in Linux distributions:
 
 
 ## Release Notes
+* [Configs 44.3](Release-Notes-Configs-44.3) (2026-06-10) - AlmaLinux bootstrap_image_ready, ELN package rename, AlmaLinux x86_64_v2 bootstrap re-enabled, RISC-V 64-bit for Fedora 44.
 * [6.7 and Configs 44.2](Release-Notes-6.7) (2026-03-02) - New plugin `expand_spec`, yum support for `--calculate-dependencies`, bugfixes.
 * [Configs 44.1](Release-Notes-Configs-44.1) (2026-02-03) - Fedora 44 branched from Rawhide.
 * [Configs 43.5](Release-Notes-Configs-43.5) (2026-01-27) - Fedora 41 EOL, PQ keys for RHEL9+, DNF5 for Mageia

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -3,7 +3,7 @@
 %endif
 
 Name:       mock-core-configs
-Version:    44.2
+Version:    44.3
 Release:    1%{?dist}
 Summary:    Mock core config files basic chroots
 
@@ -156,6 +156,13 @@ fi
 %ghost %config(noreplace,missingok) %{_sysconfdir}/mock/default.cfg
 
 %changelog
+* Wed Jun 10 2026 Pavel Raiskup <pavel@raiskup.cz> 44.3-1
+- the fedora-release-eln renamed to fedora-eln-release
+- Add config for Fedora 44 version of RISC-V port (marcin@juszkiewicz.com.pl)
+- set bootstrap_image_ready=True for AlmaLinux configs (andrew.lukoshko@gmail.com)
+- re-enable bootstrap images for x86_64_v2 AlmaLinux configs (andrew.lukoshko@gmail.com)
+- remove dependency on python3-dnf (msuchy@redhat.com)
+
 * Tue Mar 03 2026 Pavel Raiskup <pavel@raiskup.cz> 44.2-1
 - Switch openSUSE Tumbleweed to DNF5 (ngompa@opensuse.org)
 

--- a/releng/generate-release-notes
+++ b/releng/generate-release-notes
@@ -55,7 +55,13 @@ def _main():  # pylint: disable=too-many-locals
     else:
         tc_opts.append("--yes")
 
-    output_file = os.path.join(f"docs/Release-Notes-{options.version}.md")
+    subject_cfgs = ""
+    release_type = "Release-Notes"
+    if options.config_only:
+        release_type += "-Configs"
+        subject_cfgs = " and Configs ???"
+
+    output_file = os.path.join(f"docs/{release_type}-{options.version}.md")
 
     found = set()
     pattern = "|".join(TRANSFORM.keys())
@@ -64,12 +70,6 @@ def _main():  # pylint: disable=too-many-locals
     cmd = ["towncrier", "build", "--version", options.version] + tc_opts
     print(f"Calling {cmd}")
     subprocess.check_call(cmd)
-
-    subject_cfgs = ""
-    release_type = "Release-Notes"
-    if options.configs_only:
-        release_type += "-Configs"
-        subject_cfgs = " and Configs ???"
     index_md_snippet = (
         "## Release Notes\\n"
         f"* [{options.version}{subject_cfgs}]"

--- a/releng/release-notes-next/almalinux-bootstrap-image-ready.config.md
+++ b/releng/release-notes-next/almalinux-bootstrap-image-ready.config.md
@@ -1,3 +1,0 @@
-Set bootstrap_image_ready=True for AlmaLinux configs.  AlmaLinux container
-images now have python3-dnf-plugins-core available by default, so Mock skips
-updating the bootstrap chroot after extracting the image.

--- a/releng/release-notes-next/almalinux-x86_64_v2-bootstrap.config.md
+++ b/releng/release-notes-next/almalinux-x86_64_v2-bootstrap.config.md
@@ -1,3 +1,0 @@
-Re-enable container-based bootstrap for AlmaLinux 10 and AlmaLinux Kitten 10
-x86_64_v2 configs.  The `use_bootstrap_image = False` workaround has been
-removed now that mock supports OCI platform-aware pulls.

--- a/releng/release-notes-next/eln-fixed.config.md
+++ b/releng/release-notes-next/eln-fixed.config.md
@@ -1,3 +1,0 @@
-The fedora-release-eln package was renamed to fedora-eln-release; hence, we
-needed to adjust the Mock configuration which explicitly lists this package in
-chroot_setup_cmd.

--- a/releng/release-notes-next/riscv64-fedora-44.config
+++ b/releng/release-notes-next/riscv64-fedora-44.config
@@ -1,2 +1,0 @@
-Added RISC-V 64-bit architecture support for Fedora 44. Config uses the RISC-V
-Koji infrastructure at `riscv-koji.fedoraproject.org`.


### PR DESCRIPTION
Also fix two bugs in releng/generate-release-notes:
- configs_only typo (should be config_only)
- output filename missing "Configs" prefix for --config-only releases

Assisted-By: Claude Code