### PR TITLE
configs: opensuse: Forcibly disable repo_gpgcheck for now

### DIFF
--- a/mock-core-configs/etc/mock/templates/opensuse-leap-15.6.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-15.6.tpl
@@ -24,6 +24,7 @@ logfile=/var/log/yum.log
 retries=20
 obsoletes=1
 gpgcheck=0
+repo_gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=

--- a/mock-core-configs/etc/mock/templates/opensuse-leap-16.0.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-leap-16.0.tpl
@@ -26,6 +26,7 @@ logfile=/var/log/yum.log
 retries=20
 obsoletes=1
 gpgcheck=0
+repo_gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=

--- a/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
+++ b/mock-core-configs/etc/mock/templates/opensuse-tumbleweed.tpl
@@ -24,6 +24,7 @@ logfile=/var/log/yum.log
 retries=20
 obsoletes=1
 gpgcheck=0
+repo_gpgcheck=0
 assumeyes=1
 syslog_ident=mock
 syslog_device=

--- a/releng/release-notes-next/disable-repo_gpgcheck-for-opensuse.config
+++ b/releng/release-notes-next/disable-repo_gpgcheck-for-opensuse.config
@@ -1,0 +1,2 @@
+Forcibly disable repo_gpgcheck for openSUSE chroots for now,
+since COPR does not yet sign its own produced repositories.


### PR DESCRIPTION
openSUSE Tumbleweed's dnf5 package defaults to pkg_gpgcheck and repo_gpgcheck being enabled since openSUSE and OBS repositories have PGP signatures for repository metadata by convention.

However, COPR does not yet produce metadata signatures, so until COPR does, this needs to be turned off.
