### PR TITLE
Add cgroup device isolation for build environments

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -80,6 +80,15 @@
 # If you're using isolation='nspawn', then by default networking will be turned
 # off for rpmbuild.  This helps ensure more reproducible builds.
 #config_opts['rpmbuild_networking'] = False
+
+# Device isolation.  When enabled, mock wraps nspawn in a systemd-run scope
+# with DevicePolicy=closed so that root inside the container cannot open real
+# host hardware devices (/dev/mem, /dev/kvm, physical disks, GPUs, etc.).  Only
+# virtual/interface devices that legitimate builds need are allowed
+# (/dev/null, /dev/urandom, /dev/fuse, /dev/loop*, /dev/mapper/*, etc.).
+# Disabled by default; set to True to enable this additional isolation.
+#config_opts['device_isolation'] = False
+
 # Additional args for nspawn
 # suppress-sync is added only on system with systemd 250+ (RHEL9, Fedoras)
 # config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -94,6 +94,10 @@ def setup_default_config_opts():
     config_opts['isolation'] = None
     config_opts['use_nspawn'] = None
     config_opts['rpmbuild_networking'] = False
+    config_opts['device_isolation'] = False
+    # When True, restrict the build environment to a whitelist of devices
+    # by running systemd-nspawn inside a systemd-run --scope with
+    # DevicePolicy=closed.  This is only effective when use_nspawn is True.
     config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
     # FIXME disable as default because of https://github.com/rpm-software-management/mock/issues/1641
     # if check_nspawn_has_suppress_sync_option():

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -81,6 +81,7 @@ personality_defs = {
 
 USE_NSPAWN = False
 USE_NSPAWN_SECCOMP = False
+_DEVICE_ISOLATION = False
 
 _NSPAWN_HELP_OUTPUT = None
 
@@ -518,6 +519,64 @@ def do(*args, **kargs):
 # logger =
 # output = [1|0]
 # chrootPath
+def _device_isolation_scope_args():
+    """
+    Build the systemd-run --scope arguments for device isolation.
+
+    Instead of racing to write cgroup device policy after nspawn starts
+    (which leaves a window where the payload has full device access),
+    we pre-create a restricted scope using systemd-run.  nspawn then
+    runs inside this scope with --keep-unit, so the payload process is
+    born into an already-restricted cgroup — zero race window.
+
+    On cgroup v1, systemd's DevicePolicy=closed is enforced via BPF_DEVCG
+    (eBPF device control) when the scope is created by systemd-run, but
+    NOT when nspawn creates its own scope via D-Bus.  This approach
+    eliminates that inconsistency.
+
+    On cgroup v2, systemd enforces DevicePolicy natively via eBPF in
+    all cases, so this is equally effective.
+
+    Returns a list of arguments to prepend to the nspawn command,
+    e.g. ['systemd-run', '--scope', '--property=DevicePolicy=closed', ...]
+    or an empty list if device isolation is disabled.
+    """
+    if not _DEVICE_ISOLATION:
+        return []
+
+    args = ['systemd-run', '--scope']
+
+    # DevicePolicy=closed denies all devices by default
+    args.append('--property=DevicePolicy=closed')
+
+    # --- Pseudo-devices: char major 1 ---
+    # Enumerate individually to exclude /dev/mem (1:1) and /dev/kmem (1:2)
+    args.append('--property=DeviceAllow=/dev/null rwm')
+    args.append('--property=DeviceAllow=/dev/zero rwm')
+    args.append('--property=DeviceAllow=/dev/full rwm')
+    args.append('--property=DeviceAllow=/dev/random rwm')
+    args.append('--property=DeviceAllow=/dev/urandom rwm')
+
+    # --- Terminal devices ---
+    args.append('--property=DeviceAllow=/dev/tty rwm')
+    args.append('--property=DeviceAllow=/dev/console rwm')
+    args.append('--property=DeviceAllow=/dev/ptmx rwm')
+    args.append('--property=DeviceAllow=char-pts rw')
+
+    # --- Filesystem interface devices ---
+    args.append('--property=DeviceAllow=/dev/fuse rwm')
+    args.append('--property=DeviceAllow=/dev/btrfs-control rwm')
+    args.append('--property=DeviceAllow=/dev/mapper/control rwm')
+    args.append('--property=DeviceAllow=/dev/loop-control rwm')
+
+    # --- Loop block devices ---
+    args.append('--property=DeviceAllow=block-loop rwm')
+
+    # --- Device-mapper block devices ---
+    args.append('--property=DeviceAllow=block-device-mapper rwm')
+
+    return args
+
 #
 # The "Not-as-complicated" version
 #
@@ -659,8 +718,10 @@ def setup_operations_timeout(config_opts):
 def set_use_nspawn(value, config_opts):
     global USE_NSPAWN
     global USE_NSPAWN_SECCOMP
+    global _DEVICE_ISOLATION
     USE_NSPAWN = value
     USE_NSPAWN_SECCOMP = config_opts["seccomp"]
+    _DEVICE_ISOLATION = config_opts.get('device_isolation', False)
 
 
 class BindMountedFile(str):
@@ -793,7 +854,21 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None,
     if isinstance(cmd, str):
         cmd = ['/bin/sh', '-c', cmd]
 
-    return nspawn_argv + cmd
+    full_cmd = nspawn_argv + cmd
+
+    # When device isolation is active, wrap nspawn in a systemd-run scope
+    # with DevicePolicy=closed.  This pre-creates a restricted scope so
+    # nspawn's payload process is born into an already-restricted cgroup —
+    # no race window where the process has full device access.
+    # nspawn must use --keep-unit to stay in our pre-created scope instead
+    # of creating its own.
+    if _DEVICE_ISOLATION:
+        scope_args = _device_isolation_scope_args()
+        if scope_args:
+            # Insert --keep-unit after the nspawn binary path
+            full_cmd[0:1] = scope_args + full_cmd[:1] + ['--keep-unit']
+
+    return full_cmd
 
 def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
             cwd=None,

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -718,7 +718,7 @@ def setup_operations_timeout(config_opts):
 def set_use_nspawn(value, config_opts):
     global USE_NSPAWN
     global USE_NSPAWN_SECCOMP
-    global _DEVICE_ISOLATION
+    global _DEVICE_ISOLATION  # pylint: disable=global-statement
     USE_NSPAWN = value
     USE_NSPAWN_SECCOMP = config_opts["seccomp"]
     _DEVICE_ISOLATION = config_opts.get('device_isolation', False)

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -866,7 +866,7 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None,
         scope_args = _device_isolation_scope_args()
         if scope_args:
             # Insert --keep-unit after the nspawn binary path
-            full_cmd[0:1] = scope_args + full_cmd[:1] + ['--keep-unit']
+            full_cmd = scope_args + [full_cmd[0], '--keep-unit'] + full_cmd[1:]
 
     return full_cmd
 

--- a/releng/release-notes-next/cgroup-device-isolation.feature.md
+++ b/releng/release-notes-next/cgroup-device-isolation.feature.md
@@ -1,0 +1,1 @@
+Add cgroup device isolation for build environments


### PR DESCRIPTION
Enforce a strict cgroup device allowlist (DevicePolicy=closed) on every nspawn invocation by wrapping it in a transient systemd-run --scope with --property=DeviceAllow=... flags, and passing --keep-unit so nspawn stays inside the pre-created restricted scope.

Without this, the container's cgroup inherits 'a *:* rwm' from its parent, meaning root inside the container (e.g. after a privilege escalation exploit) can mknod and open arbitrary host hardware: raw disks (/dev/sda), physical memory (/dev/mem), the KVM hypervisor (/dev/kvm), GPUs, etc.

The allowlist mirrors exactly what mock already deliberately bind-mounts into the chroot — all virtual/interface devices that legitimate builds need:

  - /dev/null, /dev/zero, /dev/full, /dev/random, /dev/urandom  (pseudo)
  - /dev/tty, /dev/console, /dev/ptmx, /dev/pts/*               (terminals)
  - /dev/fuse                 (FUSE mounts: libguestfs, squashfuse, etc.)
  - /dev/btrfs-control        (btrfs-progs test suite)
  - /dev/mapper/control       (lvm2, device-mapper tools)
  - /dev/loop-control         (loop device allocator)
  - block-loop                (/dev/loop0-N: filesystem image tests)
  - block-device-mapper       (/dev/mapper/*: virtual LVM volumes)

Real hardware devices (/dev/mem, /dev/kmem, /dev/kvm, /dev/sd*, /dev/dri/*, /dev/input/*, /dev/net/tun) are deliberately omitted. No legitimate package %check needs them; a build accessing real host hardware is a strong signal of a malicious or severely misconfigured package.

This is analogous to network isolation: rather than blocking all devices, we carve out the specific virtual interfaces builds legitimately need while making real hardware unreachable even to root.

Controlled by config_opts['device_isolation'] (default False). Set to True to enable this additional isolation for builds that do not need raw hardware.

Assisted-By: Qoder


> Add a reference to related issue - preferably in the git commit message
Fixes: #NUMBER

> Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
> or let us know to add `label no-release-notes` if you think the change does
> not deserve a release note.
