### PR TITLE
Add NAT network isolation for build environments

### DIFF
--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -82,8 +82,8 @@
 #config_opts['rpmbuild_networking'] = False
 
 # Network isolation mode.  Requires the host to have IPv4 and IPv6 forwarding
-# enabled (e.g. net.ipv4.ip_forward=1 and net.ipv6.conf.all.forwarding=1), which
-# mock will enable automatically when 'nat' or 'auto' is used.  Other system-wide
+# enabled (e.g. net.ipv4.ip_forward=1 and net.ipv6.conf.all.forwarding=1).
+# Mock checks these at startup and fails fast if they are not enabled.  Other system-wide
 # resources used by NAT mode (iptables rules, ip6tables rules, veth interfaces,
 # network namespaces and /run/mock-nat/subnet.lock) are removed when each build
 # command finishes; orphaned resources from killed mock processes are cleaned up

--- a/mock/docs/site-defaults.cfg
+++ b/mock/docs/site-defaults.cfg
@@ -80,6 +80,26 @@
 # If you're using isolation='nspawn', then by default networking will be turned
 # off for rpmbuild.  This helps ensure more reproducible builds.
 #config_opts['rpmbuild_networking'] = False
+
+# Network isolation mode.  Requires the host to have IPv4 and IPv6 forwarding
+# enabled (e.g. net.ipv4.ip_forward=1 and net.ipv6.conf.all.forwarding=1), which
+# mock will enable automatically when 'nat' or 'auto' is used.  Other system-wide
+# resources used by NAT mode (iptables rules, ip6tables rules, veth interfaces,
+# network namespaces and /run/mock-nat/subnet.lock) are removed when each build
+# command finishes; orphaned resources from killed mock processes are cleaned up
+# at the start of each Buildroot.
+#   'loopback' - isolated loopback-only network (default, current behavior)
+#   'shared'   - full host network (legacy, insecure)
+#   'nat'      - isolated namespace with veth + NAT/masquerading
+#   'auto'     - use 'nat' for commands that need network, 'loopback' otherwise
+#config_opts['network_isolation'] = 'loopback'
+# IPv4 CIDR block auto-subdivided into /30 subnets for NAT veth pairs.
+#config_opts['network_veth_subnet_block'] = '192.168.200.0/24'
+# IPv6 CIDR block auto-subdivided into /64 subnets.  Leave empty to disable IPv6.
+#config_opts['network_veth_subnet_block_v6'] = ''
+# Fallback DNS servers when the host's /etc/resolv.conf only has loopback entries.
+#config_opts['network_fallback_dns'] = ['8.8.8.8', '1.1.1.1']
+
 # Additional args for nspawn
 # suppress-sync is added only on system with systemd 250+ (RHEL9, Fedoras)
 # config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -60,6 +60,7 @@ class Commands(object):
         self.no_root_shells = config['no_root_shells']
 
         self.private_network = not config['rpmbuild_networking']
+        self.network_isolation = config.get('network_isolation', 'loopback')
         self.rpmbuild_noclean_option = None
 
         # on-demand buildroot properties
@@ -366,12 +367,23 @@ class Commands(object):
 
         try:
             self.state.start("shell")
+
+            # NAT network isolation for interactive shell
+            nat_network = None
+            if not self.private_network:
+                if self.network_isolation != 'loopback':
+                    from .network import create_nat_network
+                    nat_network = create_nat_network(
+                        self.config, log, self.buildroot.make_chroot_path(),
+                        util.USE_NSPAWN)
+
             ret = util.doshell(chrootPath=self.buildroot.make_chroot_path(),
                                environ=self.buildroot.env, uid=uid, gid=gid,
                                cwd=cwd,
                                nspawn_args=self.config.get("nspawn_args", []),
                                unshare_net=self.private_network,
-                               cmd=cmd)
+                               cmd=cmd,
+                               nat_network=nat_network)
         finally:
             log.debug("shell: unmounting all filesystems")
             self.state.finish("shell")

--- a/mock/py/mockbuild/buildroot.py
+++ b/mock/py/mockbuild/buildroot.py
@@ -145,6 +145,7 @@ class Buildroot(object):
         self._setup_nspawn_devicemapper_device()
         self._setup_nspawn_fuse_device()
         self._setup_nspawn_loop_devices()
+        self._cleanup_orphaned_nat_networks()
 
 
     def set_package_manager(self, fallback=None):
@@ -435,6 +436,31 @@ class Buildroot(object):
         kargs.setdefault("nspawn_args", [])
         kargs["nspawn_args"].extend(self.config.get("nspawn_args", []))
 
+        # NAT network isolation: when network_isolation='nat' (or 'auto'
+        # resolving to 'nat') and the command currently gets shared host
+        # network (unshare_net=False), create a veth pair + NAT instead.
+        nat_network = None
+        unshare_net = kargs.get('unshare_net', False)
+        network_isolation = self.config.get('network_isolation', 'loopback')
+        use_nat = False
+        if network_isolation == 'nat':
+            use_nat = True
+        elif network_isolation == 'auto':
+            # In auto mode, use NAT for commands that currently share the
+            # host network (unshare_net=False). Commands that are already
+            # isolated (unshare_net=True) keep loopback-only.
+            use_nat = not unshare_net
+
+        if use_nat:
+            from .network import create_nat_network
+            nat_network = create_nat_network(
+                self.config, self.root_log, self.make_chroot_path(),
+                util.USE_NSPAWN)
+            if nat_network is not None:
+                kargs['nat_network'] = nat_network
+            else:
+                use_nat = False
+
         try:
             result = util.do_with_status(command, chrootPath=self.make_chroot_path(),
                                          env=env, *args, **kargs)
@@ -449,6 +475,7 @@ class Buildroot(object):
         buildroot  in `cwd`, as a non-privileged user.  Used by plugins.
         """
         private_network = not self.config.get('rpmbuild_networking', False)
+        # doChroot handles network_isolation resolution, including NAT setup
         return self.doChroot(
             command,
             shell=False,
@@ -869,6 +896,23 @@ class Buildroot(object):
                 if e.errno != errno.EEXIST:
                     raise
             self.config['nspawn_args'].append('--bind={0}'.format(loop_file))
+
+    @traceLog()
+    def _cleanup_orphaned_nat_networks(self):
+        """Clean up NAT network resources left behind by killed mock processes."""
+        if not util.USE_NSPAWN or self.is_bootstrap:
+            return
+        network_isolation = self.config.get('network_isolation', 'loopback')
+        if network_isolation == 'loopback':
+            return
+        try:
+            from .network import cleanup_orphaned_networks
+            cleanup_orphaned_networks(
+                pool_v4=self.config.get('network_veth_subnet_block', ''),
+                pool_v6=self.config.get('network_veth_subnet_block_v6', ''),
+            )
+        except Exception as e:
+            self.root_log.debug("NAT orphan cleanup skipped: %s", e)
 
     @traceLog()
     def _setup_devices(self):

--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -94,6 +94,24 @@ def setup_default_config_opts():
     config_opts['isolation'] = None
     config_opts['use_nspawn'] = None
     config_opts['rpmbuild_networking'] = False
+    config_opts['network_isolation'] = 'loopback'
+    # 'loopback': current behavior (isolated loopback only)
+    # 'shared': full host network (legacy, insecure)
+    # 'nat': isolated namespace with veth + NAT
+    # 'auto': use 'nat' for commands needing network, 'loopback' otherwise
+    config_opts['network_veth_subnet_block'] = '192.168.200.0/24'
+    # IPv4 CIDR block subdivided into /30 subnets for build namespaces.
+    # A /30 uses exactly 4 addresses (host .1, container .2, network, broadcast).
+    # A /24 provides 64 concurrent build slots. Use a /22 for 256 slots.
+    config_opts['network_veth_subnet_block_v6'] = ''
+    # IPv6 CIDR block subdivided into /64 subnets. Leave empty to disable IPv6.
+    # Example: 'fd00:dead:beef::/48'
+    config_opts['network_fallback_dns'] = ['8.8.8.8', '1.1.1.1']
+    # DNS servers written to the build environment's resolv.conf when the
+    # host's /etc/resolv.conf only contains loopback addresses
+    # (e.g. 127.0.0.53 from systemd-resolved, which is unreachable from
+    # inside the NAT namespace). Override if these servers are not reachable
+    # from your network.
     config_opts['nspawn_args'] = ['--capability=cap_ipc_lock']
     # FIXME disable as default because of https://github.com/rpm-software-management/mock/issues/1641
     # if check_nspawn_has_suppress_sync_option():

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -1,0 +1,878 @@
+# -*- coding: utf-8 -*-
+# vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:textwidth=0:
+# License: GPL2 or later see COPYING
+# Copyright (C) 2025
+
+"""
+NAT-based network isolation for Mock build environments.
+
+Creates a veth pair between the host and an isolated network namespace,
+configures iptables/ip6tables NAT rules, and tears everything down
+cleanly after the build command completes.
+"""
+
+import ctypes
+import fcntl
+import ipaddress
+import os
+import subprocess
+import uuid
+
+from pyroute2 import IPRoute
+from pyroute2 import netns
+
+from .trace_decorator import getLog, traceLog
+
+# setns() for entering a pre-created namespace in child processes
+_libc = ctypes.CDLL(None, use_errno=True)
+_libc.setns.argtypes = [ctypes.c_int, ctypes.c_int]
+_libc.setns.restype = ctypes.c_int
+
+CLONE_NEWNET = 0x40000000
+
+# Lock file for subnet pool allocation
+_LOCK_DIR = "/run/mock-nat"
+_LOCK_FILE = os.path.join(_LOCK_DIR, "subnet.lock")
+
+# Default fallback DNS servers used when the host's resolv.conf only contains
+# loopback addresses (e.g. systemd-resolved 127.0.0.53) which are
+# unreachable from inside the NAT namespace.
+_DEFAULT_FALLBACK_DNS = ['8.8.8.8', '1.1.1.1']
+
+
+def _read_host_nameservers(fallback_dns=None):
+    """
+    Read nameserver addresses from the host's /etc/resolv.conf.
+
+    Returns a list of nameserver IP strings, filtering out loopback
+    addresses (127.x.x.x, ::1) that are unreachable from a NAT namespace.
+    If no non-loopback nameservers are found, returns fallback_dns
+    (or the built-in default if not specified).
+    """
+    if fallback_dns is None:
+        fallback_dns = _DEFAULT_FALLBACK_DNS
+
+    nameservers = []
+    try:
+        with open('/etc/resolv.conf', 'r') as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('nameserver'):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        ns = parts[1]
+                        # Filter out loopback addresses — they refer to the
+                        # host's own resolver stub (e.g. systemd-resolved)
+                        # which is not reachable from the NAT namespace.
+                        if not ns.startswith('127.') and ns != '::1':
+                            nameservers.append(ns)
+    except IOError:
+        pass
+
+    if not nameservers:
+        nameservers = list(fallback_dns)
+        getLog().info("NAT: no non-loopback nameservers found, using fallback: %s",
+                      nameservers)
+    return nameservers
+
+
+def _ensure_lock_dir():
+    """Create the lock directory if it doesn't exist."""
+    try:
+        os.makedirs(_LOCK_DIR, mode=0o755, exist_ok=True)
+    except OSError:
+        pass
+
+
+def _subdivide(cidr_str, prefixlen):
+    """
+    Subdivide a CIDR block into subnets of the given prefix length.
+
+    Args:
+        cidr_str: e.g. '192.168.200.0/24' or 'fd00:dead::/48'
+        prefixlen: e.g. 29 (IPv4) or 64 (IPv6)
+
+    Returns:
+        list of ipaddress.IPv4Network or IPv6Network objects
+    """
+    if not cidr_str:
+        return []
+    try:
+        net = ipaddress.ip_network(cidr_str, strict=False)
+    except ValueError as e:
+        raise ValueError("Invalid network_veth_subnet_block value %r: %s" % (cidr_str, e))
+    if net.prefixlen >= prefixlen:
+        raise ValueError(
+            "network_veth_subnet_block %r prefix /%d is not larger than "
+            "the subdivision prefix /%d" % (cidr_str, net.prefixlen, prefixlen))
+    return list(net.subnets(new_prefix=prefixlen))
+
+
+class SubnetPool:
+    """
+    Thread-safe and process-safe allocator for veth subnets.
+
+    Uses file locking to prevent concurrent builds from receiving
+    the same subnet.
+
+    Accepts a single CIDR block string which is automatically subdivided
+    into /30 slices for IPv4 or /64 slices for IPv6.
+    """
+
+    # Subdivision prefix lengths.
+    # /30 gives exactly 4 addresses: network, host (.1), container (.2),
+    # broadcast — the minimum needed for a point-to-point veth pair.
+    _V4_PREFIX = 30
+    _V6_PREFIX = 64
+
+    def __init__(self, pool_v4, pool_v6=None):
+        """
+        Args:
+            pool_v4: A CIDR block string (e.g. '192.168.200.0/24') that
+                will be subdivided into /30 subnets.
+            pool_v6: A CIDR block string (e.g. 'fd00:dead:beef::/48') that
+                will be subdivided into /64 subnets, or None to disable IPv6.
+        """
+        self.pool_v4 = _subdivide(pool_v4, self._V4_PREFIX)
+        self.pool_v6 = _subdivide(pool_v6, self._V6_PREFIX) if pool_v6 else []
+
+    @staticmethod
+    def _parse_line(line):
+        """Parse a lock file line into (subnet_str, pid, ns_name).
+
+        Lock file format::
+            192.168.200.0/30 pid=12345 ns=m-a1b2c3d4
+        """
+        parts = line.split()
+        subnet = parts[0] if parts else ''
+        pid = None
+        ns_name = None
+        for p in parts[1:]:
+            if p.startswith('pid='):
+                try:
+                    pid = int(p[4:])
+                except ValueError:
+                    pass
+            elif p.startswith('ns='):
+                ns_name = p[3:]
+        return subnet, pid, ns_name
+
+    @staticmethod
+    def _is_pid_alive(pid):
+        """Check whether a process PID still exists."""
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Process exists but we lack permission to signal it
+            return True
+        except OSError:
+            return False
+
+    def _read_lock_file(self, lock_fd):
+        """Read the lock file and return a list of parsed entries."""
+        os.lseek(lock_fd, 0, os.SEEK_SET)
+        data = os.read(lock_fd, 65536).decode('utf-8')
+        entries = []
+        for line in data.splitlines():
+            line = line.strip()
+            if line and not line.startswith('#'):
+                entries.append(self._parse_line(line))
+        return entries
+
+    def _write_lock_file(self, lock_fd, entries):
+        """Write parsed entries back to the lock file."""
+        lines = []
+        for subnet, pid, ns_name in entries:
+            parts = [subnet]
+            if pid is not None:
+                parts.append('pid=%d' % pid)
+            if ns_name is not None:
+                parts.append('ns=%s' % ns_name)
+            lines.append(' '.join(parts))
+        os.ftruncate(lock_fd, 0)
+        os.lseek(lock_fd, 0, os.SEEK_SET)
+        content = '\n'.join(sorted(lines))
+        if content:
+            content += '\n'
+        os.write(lock_fd, content.encode('utf-8'))
+
+    def reap_dead(self):
+        """Release subnets belonging to dead processes.
+
+        Scans the lock file for entries whose PID no longer exists and
+        removes them.  Returns a list of namespace names (``ns=`` values)
+        of the reaped entries so callers can clean up orphaned resources.
+        """
+        reaped_ns = []
+        _ensure_lock_dir()
+        lock_fd = os.open(_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            entries = self._read_lock_file(lock_fd)
+            alive = []
+            for subnet, pid, ns_name in entries:
+                if pid is not None and not self._is_pid_alive(pid):
+                    # Process is dead — release the subnet
+                    reaped_ns.append(ns_name)
+                    getLog().info(
+                        "NAT SubnetPool: reaping dead entry pid=%d ns=%s "
+                        "subnet=%s", pid, ns_name, subnet)
+                else:
+                    alive.append((subnet, pid, ns_name))
+            self._write_lock_file(lock_fd, alive)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+        return reaped_ns
+
+    def allocate(self, ns_name=None):
+        """
+        Allocate a unique subnet pair (v4, v6) from the pool.
+
+        Returns:
+            (ipv4_network, ipv6_network_or_None)
+        """
+        _ensure_lock_dir()
+        lock_fd = os.open(_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+            # Reap subnets belonging to dead processes before allocating.
+            # This prevents pool exhaustion when mock processes are killed
+            # (SIGKILL) without running teardown.
+            entries = self._read_lock_file(lock_fd)
+            alive = []
+            for subnet, pid, entry_ns in entries:
+                if pid is not None and not self._is_pid_alive(pid):
+                    getLog().info(
+                        "NAT SubnetPool: reaping dead entry pid=%d ns=%s "
+                        "subnet=%s", pid, entry_ns, subnet)
+                else:
+                    alive.append((subnet, pid, entry_ns))
+
+            allocated = set(e[0] for e in alive)
+
+            # Find an unallocated v4 subnet
+            for net in self.pool_v4:
+                key = str(net)
+                if key not in allocated:
+                    # Find matching v6 subnet (same index)
+                    v6_net = None
+                    idx = self.pool_v4.index(net)
+                    if idx < len(self.pool_v6):
+                        v6_net = self.pool_v6[idx]
+                        v6_key = str(v6_net)
+                        if v6_key in allocated:
+                            # v6 already taken, skip this pair
+                            continue
+                        alive.append((v6_key, None, None))
+
+                    pid = os.getpid()
+                    alive.append((key, pid, ns_name))
+                    self._write_lock_file(lock_fd, alive)
+                    return net, v6_net
+
+            raise RuntimeError("No available subnets in NAT pool. "
+                               "Increase network_veth_subnet_block size.")
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+    def release(self, v4_net, v6_net=None):
+        """Release a previously allocated subnet pair."""
+        _ensure_lock_dir()
+        lock_fd = os.open(_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            entries = self._read_lock_file(lock_fd)
+            v4_str = str(v4_net)
+            v6_str = str(v6_net) if v6_net else None
+            kept = []
+            for subnet, pid, ns_name in entries:
+                if subnet == v4_str or (v6_str and subnet == v6_str):
+                    continue
+                kept.append((subnet, pid, ns_name))
+            self._write_lock_file(lock_fd, kept)
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+
+class NatNetwork:
+    """
+    Manages a veth pair + NAT for a single build command.
+
+    Usage:
+        net = NatNetwork(config)
+        ns_path = net.setup()         # parent process, before fork
+        # ... fork child, pass ns_path to ChildPreExec ...
+        net.teardown()                # parent process, after child exits
+    """
+
+    def __init__(self, config, chroot_path=None):
+        """
+        Args:
+            config: Mock config_opts dict containing:
+                network_veth_subnet_block: IPv4 CIDR block (auto-subdivided
+                    into /30 subnets), e.g. '192.168.200.0/24'
+                network_veth_subnet_block_v6: IPv6 CIDR block (auto-subdivided
+                    into /64 subnets), e.g. 'fd00:dead:beef::/48' (optional)
+                network_fallback_dns: list of DNS server IPs used when the
+                    host resolv.conf only has loopback entries (optional)
+            chroot_path: Path to the chroot root directory, used for
+                writing DNS configuration (resolv.conf) when the NAT
+                namespace needs network access.
+        """
+        self.config = config
+        self.chroot_path = chroot_path
+        self.ns_name = "m-" + uuid.uuid4().hex[:8]
+        self.host_if = "vm-" + self.ns_name
+        self.cont_if = "host0"
+        self.ns_path = "/var/run/netns/" + self.ns_name
+
+        self.v4_net = None
+        self.v6_net = None
+        self.host_ip_v4 = None
+        self.cont_ip_v4 = None
+        self.host_ip_v6 = None
+        self.cont_ip_v6 = None
+        self.mask_v4 = None
+        self.mask_v6 = None
+
+        # For DNS resolv.conf save/restore
+        self._resolv_backup = None
+
+        self._pool = SubnetPool(
+            config.get('network_veth_subnet_block', ''),
+            config.get('network_veth_subnet_block_v6', ''),
+        )
+
+    @traceLog()
+    def setup(self):
+        """
+        Create and configure the NAT network. Called in the PARENT process
+        before forking the child.
+
+        Returns:
+            ns_path (str): Path to the network namespace, e.g.
+                           /var/run/netns/mock-a1b2c3d4
+        """
+        log = getLog()
+        self.v4_net, self.v6_net = self._pool.allocate(ns_name=self.ns_name)
+
+        # Derive host/container IPs from the subnet
+        # For a /29, we use .1 for host and .2 for container
+        hosts_v4 = list(self.v4_net.hosts())
+        self.host_ip_v4 = str(hosts_v4[0])
+        self.cont_ip_v4 = str(hosts_v4[1])
+        self.mask_v4 = self.v4_net.prefixlen
+
+        if self.v6_net:
+            # For IPv6, use ::1 for host and ::2 for container
+            self.host_ip_v6 = str(self.v6_net.network_address + 1)
+            self.cont_ip_v6 = str(self.v6_net.network_address + 2)
+            self.mask_v6 = self.v6_net.prefixlen
+
+        log.info("NAT network: namespace=%s, v4=%s, host_if=%s",
+                 self.ns_name, self.v4_net, self.host_if)
+
+        # 1. Create network namespace
+        netns.create(self.ns_name)
+
+        # 2. Create veth pair in host namespace
+        ipr = IPRoute()
+        ipr.link('add', ifname=self.host_if, kind='veth', peer=self.cont_if)
+
+        # 3. Move container end into the new namespace
+        cont_idx = ipr.link_lookup(ifname=self.cont_if)[0]
+        ipr.link('set', index=cont_idx, net_ns_fd=self.ns_name)
+
+        # 4. Configure host end
+        host_idx = ipr.link_lookup(ifname=self.host_if)[0]
+        ipr.link('set', index=host_idx, state='up')
+        ipr.addr('add', index=host_idx, address=self.host_ip_v4,
+                 mask=self.mask_v4)
+
+        # 5. Configure IPv6 on host end
+        if self.host_ip_v6:
+            ipr.addr('add', index=host_idx, address=self.host_ip_v6,
+                     mask=self.mask_v6)
+
+        # 6. Set up iptables NAT for IPv4
+        self._setup_iptables_nat()
+
+        # 7. Set up ip6tables NAT for IPv6
+        if self.v6_net:
+            self._setup_ip6tables_nat()
+
+        # 8. Enable IP forwarding (idempotent)
+        self._enable_forwarding()
+
+        # 9. Set up DNS resolution in the chroot
+        if self.chroot_path:
+            self._setup_dns()
+
+        return self.ns_path
+
+    @traceLog()
+    def _setup_iptables_nat(self):
+        """Add iptables MASQUERADE rule for the v4 subnet."""
+        subprocess.run(
+            ['iptables', '-t', 'nat', '-I', 'POSTROUTING',
+             '-s', str(self.v4_net),
+             '-j', 'MASQUERADE',
+             '-m', 'comment', '--comment', 'mock-' + self.ns_name],
+            check=True,
+        )
+        # Allow forwarding from the veth subnet
+        subprocess.run(
+            ['iptables', '-I', 'FORWARD',
+             '-i', self.host_if,
+             '-j', 'ACCEPT'],
+            check=True,
+        )
+        subprocess.run(
+            ['iptables', '-I', 'FORWARD',
+             '-o', self.host_if,
+             '-j', 'ACCEPT'],
+            check=True,
+        )
+
+    @traceLog()
+    def _setup_ip6tables_nat(self):
+        """Add ip6tables MASQUERADE rule for the v6 subnet."""
+        subprocess.run(
+            ['ip6tables', '-t', 'nat', '-I', 'POSTROUTING',
+             '-s', str(self.v6_net),
+             '-j', 'MASQUERADE',
+             '-m', 'comment', '--comment', 'mock-' + self.ns_name],
+            check=True,
+        )
+        subprocess.run(
+            ['ip6tables', '-I', 'FORWARD',
+             '-i', self.host_if,
+             '-j', 'ACCEPT'],
+            check=True,
+        )
+        subprocess.run(
+            ['ip6tables', '-I', 'FORWARD',
+             '-o', self.host_if,
+             '-j', 'ACCEPT'],
+            check=True,
+        )
+
+    @traceLog()
+    def _enable_forwarding(self):
+        """Enable IPv4 and IPv6 forwarding (idempotent)."""
+        subprocess.run(['sysctl', '-w', 'net.ipv4.ip_forward=1'],
+                       check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(['sysctl', '-w', 'net.ipv6.conf.all.forwarding=1'],
+                       check=True, stdout=subprocess.DEVNULL)
+
+    @traceLog()
+    def configure_container_ns(self):
+        """
+        Configure the container-side network interface.
+
+        Called INSIDE the child process, after entering the network namespace
+        (via setns), before exec'ing nspawn.
+        """
+        ipr = IPRoute()
+
+        # Bring up loopback
+        lo_idx = ipr.link_lookup(ifname='lo')[0]
+        ipr.link('set', index=lo_idx, state='up')
+
+        # Configure container-side veth
+        cont_idx = ipr.link_lookup(ifname=self.cont_if)
+        if not cont_idx:
+            # Interface not found — this can happen if the namespace
+            # setup failed silently
+            getLog().warning("NAT: container interface %s not found in namespace",
+                             self.cont_if)
+            return
+
+        cont_idx = cont_idx[0]
+        ipr.link('set', index=cont_idx, state='up')
+
+        # IPv4 address and default route
+        ipr.addr('add', index=cont_idx, address=self.cont_ip_v4,
+                 mask=self.mask_v4)
+        ipr.route('add', dst='default', gateway=self.host_ip_v4)
+
+        # IPv6 address and default route
+        if self.cont_ip_v6:
+            ipr.addr('add', index=cont_idx, address=self.cont_ip_v6,
+                     mask=self.mask_v6)
+            ipr.route('add', dst='default', gateway=self.host_ip_v6)
+
+    @traceLog()
+    def teardown(self):
+        """
+        Tear down the NAT network. Called in the PARENT process after
+        the child exits.
+
+        Safe to call after partial setup (idempotent) — if setup()
+        failed partway through, this will release the subnet and skip
+        any resources that were never created.
+        """
+        log = getLog()
+
+        # If allocate() was never called, nothing to clean up
+        if self.v4_net is None:
+            return
+
+        # Restore the original resolv.conf
+        if self.chroot_path:
+            self._teardown_dns()
+
+        # Remove iptables rules by comment marker
+        self._remove_iptables_rules()
+
+        # Remove ip6tables rules
+        if self.v6_net:
+            self._remove_ip6tables_rules()
+
+        # Delete the veth pair (deleting the host end removes both ends)
+        try:
+            ipr = IPRoute()
+            host_idx = ipr.link_lookup(ifname=self.host_if)
+            if host_idx:
+                ipr.link('del', index=host_idx[0])
+        except Exception as e:
+            log.warning("NAT: failed to delete veth %s: %s", self.host_if, e)
+
+        # Delete the network namespace
+        try:
+            netns.remove(self.ns_name)
+        except Exception as e:
+            log.warning("NAT: failed to remove namespace %s: %s", self.ns_name, e)
+
+        # Release the subnet back to the pool
+        self._pool.release(self.v4_net, self.v6_net)
+
+        # Mark as torn down so a second teardown() is a no-op
+        self.v4_net = None
+
+        log.info("NAT network torn down: namespace=%s", self.ns_name)
+
+    @traceLog()
+    def _setup_dns(self):
+        """
+        Write a working resolv.conf into the chroot for NAT namespace DNS.
+
+        When the build environment is behind NAT, it can reach the same DNS
+        servers the host uses (via NAT routing).  However, the chroot's
+        resolv.conf may be empty (when rpmbuild_networking=False).  We
+        back up the original and write one with usable nameservers.
+
+        Loopback nameservers (127.x.x.x, ::1) from the host are filtered
+        out because they are unreachable from the NAT namespace.  If no
+        non-loopback nameservers are found, public fallback servers are
+        used instead.
+        """
+        log = getLog()
+        resolv_path = os.path.join(self.chroot_path, 'etc', 'resolv.conf')
+
+        # Back up the existing resolv.conf
+        try:
+            with open(resolv_path, 'rb') as f:
+                self._resolv_backup = f.read()
+        except (IOError, OSError):
+            self._resolv_backup = None
+
+        # Build a new resolv.conf with reachable nameservers
+        fallback_dns = self.config.get('network_fallback_dns', None)
+        nameservers = _read_host_nameservers(fallback_dns=fallback_dns)
+        lines = ['# Generated by mock NAT network isolation']
+        for ns in nameservers:
+            lines.append('nameserver {}'.format(ns))
+
+        try:
+            os.makedirs(os.path.dirname(resolv_path), exist_ok=True)
+            with open(resolv_path, 'w') as f:
+                f.write('\n'.join(lines) + '\n')
+            log.debug("NAT: wrote resolv.conf with nameservers: %s", nameservers)
+        except (IOError, OSError) as e:
+            log.warning("NAT: failed to write resolv.conf: %s", e)
+
+    @traceLog()
+    def _teardown_dns(self):
+        """
+        Restore the original resolv.conf that was backed up during _setup_dns.
+        """
+        log = getLog()
+        if self._resolv_backup is None:
+            return
+
+        resolv_path = os.path.join(self.chroot_path, 'etc', 'resolv.conf')
+        try:
+            with open(resolv_path, 'wb') as f:
+                f.write(self._resolv_backup)
+            log.debug("NAT: restored original resolv.conf")
+        except (IOError, OSError) as e:
+            log.warning("NAT: failed to restore resolv.conf: %s", e)
+        finally:
+            self._resolv_backup = None
+
+    @traceLog()
+    def _remove_iptables_rules(self):
+        """Remove iptables rules matching our comment marker."""
+        marker = 'mock-' + self.ns_name
+        try:
+            # Delete NAT rule
+            subprocess.run(
+                ['iptables', '-t', 'nat', '-D', 'POSTROUTING',
+                 '-s', str(self.v4_net),
+                 '-j', 'MASQUERADE',
+                 '-m', 'comment', '--comment', marker],
+                check=False,  # don't fail if rule doesn't exist
+            )
+            # Delete FORWARD rules
+            subprocess.run(
+                ['iptables', '-D', 'FORWARD',
+                 '-i', self.host_if,
+                 '-j', 'ACCEPT'],
+                check=False,
+            )
+            subprocess.run(
+                ['iptables', '-D', 'FORWARD',
+                 '-o', self.host_if,
+                 '-j', 'ACCEPT'],
+                check=False,
+            )
+        except Exception as e:
+            getLog().warning("NAT: iptables cleanup failed: %s", e)
+
+    @traceLog()
+    def _remove_ip6tables_rules(self):
+        """Remove ip6tables rules matching our comment marker."""
+        marker = 'mock-' + self.ns_name
+        try:
+            subprocess.run(
+                ['ip6tables', '-t', 'nat', '-D', 'POSTROUTING',
+                 '-s', str(self.v6_net),
+                 '-j', 'MASQUERADE',
+                 '-m', 'comment', '--comment', marker],
+                check=False,
+            )
+            subprocess.run(
+                ['ip6tables', '-D', 'FORWARD',
+                 '-i', self.host_if,
+                 '-j', 'ACCEPT'],
+                check=False,
+            )
+            subprocess.run(
+                ['ip6tables', '-D', 'FORWARD',
+                 '-o', self.host_if,
+                 '-j', 'ACCEPT'],
+                check=False,
+            )
+        except Exception as e:
+            getLog().warning("NAT: ip6tables cleanup failed: %s", e)
+
+
+def setns(ns_path, netns_type=CLONE_NEWNET):
+    """
+    Enter an existing network namespace. Used by the child process
+    before exec'ing nspawn.
+
+    Args:
+        ns_path: Path to the network namespace, e.g. /var/run/netns/mock-xxx
+        netns_type: Namespace type flag (default: CLONE_NEWNET)
+    """
+    log = getLog()
+    try:
+        fd = os.open(ns_path, os.O_RDONLY)
+        ret = _libc.setns(fd, netns_type)
+        if ret != 0:
+            err = ctypes.get_errno()
+            raise OSError(err, os.strerror(err))
+        os.close(fd)
+        log.debug("setns: entered namespace %s", ns_path)
+    except Exception as e:
+        log.error("setns: failed to enter namespace %s: %s", ns_path, e)
+        raise
+
+
+def cleanup_orphaned_networks(pool_v4='', pool_v6=''):
+    """
+    Clean up NAT network resources left behind by killed mock processes.
+
+    When a mock process is killed (SIGKILL), it cannot run its teardown
+    code, leaving behind: allocated subnets in the lock file, veth
+    interfaces on the host, network namespaces, and iptables NAT rules.
+
+    This function:
+      1. Reaps dead-process entries from the subnet lock file.
+      2. Removes veth interfaces, namespaces, and iptables rules for
+         the reaped namespaces.
+      3. Scans for any remaining ``vm-m-*`` interfaces whose namespace
+         is not in the lock file and cleans those up too.
+
+    Should be called early in mock startup (before any builds) so that
+    resources from previous killed builds are reclaimed.
+    """
+    log = getLog()
+    pool = SubnetPool(pool_v4, pool_v6)
+
+    # Step 1: Reap dead-process entries from the lock file
+    reaped_ns = pool.reap_dead()
+
+    # Step 2: For each reaped namespace, remove leftover resources
+    for ns_name in reaped_ns:
+        if ns_name is None:
+            continue
+        host_if = 'vm-' + ns_name
+        log.info("NAT: cleaning up orphaned resources for ns=%s", ns_name)
+
+        # Remove iptables NAT rules (find by comment marker)
+        marker = 'mock-' + ns_name
+        try:
+            rules = subprocess.run(
+                ['iptables', '-t', 'nat', '-S', 'POSTROUTING'],
+                capture_output=True, text=True, check=False)
+            for rule in rules.stdout.splitlines():
+                if marker in rule:
+                    # Convert "-A" to "-D" to delete the rule
+                    delete_rule = rule.replace('-A POSTROUTING',
+                                               '-D POSTROUTING', 1)
+                    subprocess.run(
+                        ['iptables', '-t', 'nat'] + delete_rule.split(),
+                        check=False)
+                    log.info("NAT: removed iptables rule: %s", delete_rule)
+        except Exception as e:
+            log.warning("NAT: failed to clean iptables for ns=%s: %s",
+                        ns_name, e)
+
+        # Remove ip6tables NAT rules
+        try:
+            rules = subprocess.run(
+                ['ip6tables', '-t', 'nat', '-S', 'POSTROUTING'],
+                capture_output=True, text=True, check=False)
+            for rule in rules.stdout.splitlines():
+                if marker in rule:
+                    delete_rule = rule.replace('-A POSTROUTING',
+                                               '-D POSTROUTING', 1)
+                    subprocess.run(
+                        ['ip6tables', '-t', 'nat'] + delete_rule.split(),
+                        check=False)
+                    log.info("NAT: removed ip6tables rule: %s", delete_rule)
+        except Exception as e:
+            log.warning("NAT: failed to clean ip6tables for ns=%s: %s",
+                        ns_name, e)
+
+        # Remove FORWARD rules
+        try:
+            subprocess.run(
+                ['iptables', '-D', 'FORWARD', '-i', host_if, '-j', 'ACCEPT'],
+                check=False)
+            subprocess.run(
+                ['iptables', '-D', 'FORWARD', '-o', host_if, '-j', 'ACCEPT'],
+                check=False)
+            subprocess.run(
+                ['ip6tables', '-D', 'FORWARD', '-i', host_if, '-j', 'ACCEPT'],
+                check=False)
+            subprocess.run(
+                ['ip6tables', '-D', 'FORWARD', '-o', host_if, '-j', 'ACCEPT'],
+                check=False)
+        except Exception:
+            pass
+
+        # Delete the veth interface
+        try:
+            ipr = IPRoute()
+            host_idx = ipr.link_lookup(ifname=host_if)
+            if host_idx:
+                ipr.link('del', index=host_idx[0])
+                log.info("NAT: removed orphaned veth %s", host_if)
+        except Exception as e:
+            log.warning("NAT: failed to delete veth %s: %s", host_if, e)
+
+        # Delete the network namespace
+        try:
+            netns.remove(ns_name)
+            log.info("NAT: removed orphaned namespace %s", ns_name)
+        except Exception as e:
+            log.warning("NAT: failed to remove namespace %s: %s", ns_name, e)
+
+    # Step 3: Scan for any vm-m-* interfaces whose namespace is NOT
+    # in the lock file — these are truly orphaned.
+    try:
+        ipr = IPRoute()
+        for link in ipr.get_links():
+            ifname = link.get_attr('IFLA_IFNAME', '')
+            if not ifname.startswith('vm-m-'):
+                continue
+            ns_name = ifname[3:]  # strip "vm-" prefix to get namespace name
+            # Check if this namespace is still tracked in the lock file
+            _ensure_lock_dir()
+            lock_fd = os.open(_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_SH)
+                entries = pool._read_lock_file(lock_fd)
+                ns_in_use = any(e[2] == ns_name for e in entries)
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                os.close(lock_fd)
+
+            if not ns_in_use:
+                log.info("NAT: cleaning up truly orphaned interface %s "
+                         "(ns=%s not in lock file)", ifname, ns_name)
+                try:
+                    ipr.link('del', index=link['index'])
+                except Exception as e:
+                    log.warning("NAT: failed to delete orphaned veth %s: %s",
+                                ifname, e)
+                try:
+                    netns.remove(ns_name)
+                except Exception as e:
+                    log.warning("NAT: failed to remove orphaned ns %s: %s",
+                                ns_name, e)
+    except Exception as e:
+        log.warning("NAT: orphan interface scan failed: %s", e)
+
+
+def create_nat_network(config, logger, chroot_path, use_nspawn):
+    """Create, set up, and return a NatNetwork for a build command.
+
+    Checks that systemd-nspawn supports --network-namespace-path (systemd >=
+    242) before attempting setup.  On any failure the partially-created
+    network is torn down and None is returned so the caller can fall back
+    gracefully.
+
+    Args:
+        config: Mock config dict containing network_veth_subnet_block, etc.
+        logger: Logger instance for warnings.
+        chroot_path: Path to the chroot root, used for DNS setup.
+        use_nspawn: Whether systemd-nspawn will be used for this command.
+
+    Returns:
+        A fully configured NatNetwork ready for use, or None if NAT
+        should not be used (unsupported systemd or setup failure).
+    """
+    # Lazy import to avoid circular dependency (util.py imports network.py
+    # lazily inside functions).
+    from .util import check_nspawn_has_network_namespace_path_option
+    if use_nspawn and not check_nspawn_has_network_namespace_path_option():
+        logger.warning(
+            "NAT network isolation requires systemd-nspawn with "
+            "--network-namespace-path (systemd >= 242).  "
+            "Falling back to the default network mode.")
+        return None
+
+    try:
+        nat_network = NatNetwork(config, chroot_path=chroot_path)
+        nat_network.setup()
+        return nat_network
+    except Exception as e:
+        logger.warning("NAT network setup failed: %s", e)
+        try:
+            if nat_network is not None:
+                nat_network.teardown()
+        except Exception:
+            pass
+        return None

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -256,19 +256,19 @@ class SubnetPool:
             allocated = set(e[0] for e in alive)
 
             # Find an unallocated v4 subnet
-            for net in self.pool_v4:
+            for idx, net in enumerate(self.pool_v4):
                 key = str(net)
                 if key not in allocated:
                     # Find matching v6 subnet (same index)
                     v6_net = None
-                    idx = self.pool_v4.index(net)
                     if idx < len(self.pool_v6):
                         v6_net = self.pool_v6[idx]
                         v6_key = str(v6_net)
                         if v6_key in allocated:
                             # v6 already taken, skip this pair
                             continue
-                        alive.append((v6_key, None, None))
+                        pid = os.getpid()
+                        alive.append((v6_key, pid, ns_name))
 
                     pid = os.getpid()
                     alive.append((key, pid, ns_name))

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -173,8 +173,11 @@ class SubnetPool:
 
     def _read_lock_file(self, lock_fd):
         """Read the lock file and return a list of parsed entries."""
+        size = os.fstat(lock_fd).st_size
+        if size == 0:
+            return []
         os.lseek(lock_fd, 0, os.SEEK_SET)
-        data = os.read(lock_fd, 65536).decode('utf-8')
+        data = os.read(lock_fd, size).decode('utf-8')
         entries = []
         for line in data.splitlines():
             line = line.strip()

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -408,8 +408,8 @@ class NatNetwork:
         if self.v6_net:
             self._setup_ip6tables_nat()
 
-        # 8. Enable IP forwarding (idempotent)
-        self._enable_forwarding()
+        # 8. Verify IP forwarding is enabled (required for NAT)
+        self._check_forwarding()
 
         # 9. Set up DNS resolution in the chroot
         if self.chroot_path:
@@ -465,12 +465,26 @@ class NatNetwork:
         )
 
     @traceLog()
-    def _enable_forwarding(self):
-        """Enable IPv4 and IPv6 forwarding (idempotent)."""
-        subprocess.run(['sysctl', '-w', 'net.ipv4.ip_forward=1'],
-                       check=True, stdout=subprocess.DEVNULL)
-        subprocess.run(['sysctl', '-w', 'net.ipv6.conf.all.forwarding=1'],
-                       check=True, stdout=subprocess.DEVNULL)
+    def _check_forwarding(self):
+        """Verify that IP forwarding is enabled on the host.
+
+        NAT-based network isolation requires the host kernel to forward
+        packets between the veth interface and the external network.
+        This is a read-only check — the operator is responsible for
+        enabling forwarding (see site-defaults.cfg for details).
+        """
+        with open('/proc/sys/net/ipv4/ip_forward') as f:
+            if f.read().strip() != '1':
+                raise RuntimeError(
+                    "IPv4 forwarding is not enabled. Set net.ipv4.ip_forward=1 "
+                    "on the host or use a configuration that does not require NAT.")
+        if self.v6_net:
+            with open('/proc/sys/net/ipv6/conf/all/forwarding') as f:
+                if f.read().strip() != '1':
+                    raise RuntimeError(
+                        "IPv6 forwarding is not enabled. Set "
+                        "net.ipv6.conf.all.forwarding=1 on the host or disable "
+                        "IPv6 NAT by omitting network_veth_subnet_block_v6.")
 
     @traceLog()
     def configure_container_ns(self):

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -383,23 +383,23 @@ class NatNetwork:
         netns.create(self.ns_name)
 
         # 2. Create veth pair in host namespace
-        ipr = IPRoute()
-        ipr.link('add', ifname=self.host_if, kind='veth', peer=self.cont_if)
+        with IPRoute() as ipr:
+            ipr.link('add', ifname=self.host_if, kind='veth', peer=self.cont_if)
 
-        # 3. Move container end into the new namespace
-        cont_idx = ipr.link_lookup(ifname=self.cont_if)[0]
-        ipr.link('set', index=cont_idx, net_ns_fd=self.ns_name)
+            # 3. Move container end into the new namespace
+            cont_idx = ipr.link_lookup(ifname=self.cont_if)[0]
+            ipr.link('set', index=cont_idx, net_ns_fd=self.ns_name)
 
-        # 4. Configure host end
-        host_idx = ipr.link_lookup(ifname=self.host_if)[0]
-        ipr.link('set', index=host_idx, state='up')
-        ipr.addr('add', index=host_idx, address=self.host_ip_v4,
-                 mask=self.mask_v4)
+            # 4. Configure host end
+            host_idx = ipr.link_lookup(ifname=self.host_if)[0]
+            ipr.link('set', index=host_idx, state='up')
+            ipr.addr('add', index=host_idx, address=self.host_ip_v4,
+                     mask=self.mask_v4)
 
-        # 5. Configure IPv6 on host end
-        if self.host_ip_v6:
-            ipr.addr('add', index=host_idx, address=self.host_ip_v6,
-                     mask=self.mask_v6)
+            # 5. Configure IPv6 on host end
+            if self.host_ip_v6:
+                ipr.addr('add', index=host_idx, address=self.host_ip_v6,
+                         mask=self.mask_v6)
 
         # 6. Set up iptables NAT for IPv4
         self._setup_iptables_nat()
@@ -480,34 +480,33 @@ class NatNetwork:
         Called INSIDE the child process, after entering the network namespace
         (via setns), before exec'ing nspawn.
         """
-        ipr = IPRoute()
+        with IPRoute() as ipr:
+            # Bring up loopback
+            lo_idx = ipr.link_lookup(ifname='lo')[0]
+            ipr.link('set', index=lo_idx, state='up')
 
-        # Bring up loopback
-        lo_idx = ipr.link_lookup(ifname='lo')[0]
-        ipr.link('set', index=lo_idx, state='up')
+            # Configure container-side veth
+            cont_idx = ipr.link_lookup(ifname=self.cont_if)
+            if not cont_idx:
+                # Interface not found — this can happen if the namespace
+                # setup failed silently
+                getLog().warning("NAT: container interface %s not found in namespace",
+                                 self.cont_if)
+                return
 
-        # Configure container-side veth
-        cont_idx = ipr.link_lookup(ifname=self.cont_if)
-        if not cont_idx:
-            # Interface not found — this can happen if the namespace
-            # setup failed silently
-            getLog().warning("NAT: container interface %s not found in namespace",
-                             self.cont_if)
-            return
+            cont_idx = cont_idx[0]
+            ipr.link('set', index=cont_idx, state='up')
 
-        cont_idx = cont_idx[0]
-        ipr.link('set', index=cont_idx, state='up')
+            # IPv4 address and default route
+            ipr.addr('add', index=cont_idx, address=self.cont_ip_v4,
+                     mask=self.mask_v4)
+            ipr.route('add', dst='default', gateway=self.host_ip_v4)
 
-        # IPv4 address and default route
-        ipr.addr('add', index=cont_idx, address=self.cont_ip_v4,
-                 mask=self.mask_v4)
-        ipr.route('add', dst='default', gateway=self.host_ip_v4)
-
-        # IPv6 address and default route
-        if self.cont_ip_v6:
-            ipr.addr('add', index=cont_idx, address=self.cont_ip_v6,
-                     mask=self.mask_v6)
-            ipr.route('add', dst='default', gateway=self.host_ip_v6)
+            # IPv6 address and default route
+            if self.cont_ip_v6:
+                ipr.addr('add', index=cont_idx, address=self.cont_ip_v6,
+                         mask=self.mask_v6)
+                ipr.route('add', dst='default', gateway=self.host_ip_v6)
 
     @traceLog()
     def teardown(self):
@@ -538,10 +537,10 @@ class NatNetwork:
 
         # Delete the veth pair (deleting the host end removes both ends)
         try:
-            ipr = IPRoute()
-            host_idx = ipr.link_lookup(ifname=self.host_if)
-            if host_idx:
-                ipr.link('del', index=host_idx[0])
+            with IPRoute() as ipr:
+                host_idx = ipr.link_lookup(ifname=self.host_if)
+                if host_idx:
+                    ipr.link('del', index=host_idx[0])
         except Exception as e:
             log.warning("NAT: failed to delete veth %s: %s", self.host_if, e)
 
@@ -786,11 +785,11 @@ def cleanup_orphaned_networks(pool_v4='', pool_v6=''):
 
         # Delete the veth interface
         try:
-            ipr = IPRoute()
-            host_idx = ipr.link_lookup(ifname=host_if)
-            if host_idx:
-                ipr.link('del', index=host_idx[0])
-                log.info("NAT: removed orphaned veth %s", host_if)
+            with IPRoute() as ipr:
+                host_idx = ipr.link_lookup(ifname=host_if)
+                if host_idx:
+                    ipr.link('del', index=host_idx[0])
+                    log.info("NAT: removed orphaned veth %s", host_if)
         except Exception as e:
             log.warning("NAT: failed to delete veth %s: %s", host_if, e)
 
@@ -804,36 +803,36 @@ def cleanup_orphaned_networks(pool_v4='', pool_v6=''):
     # Step 3: Scan for any vm-m-* interfaces whose namespace is NOT
     # in the lock file — these are truly orphaned.
     try:
-        ipr = IPRoute()
-        for link in ipr.get_links():
-            ifname = link.get_attr('IFLA_IFNAME', '')
-            if not ifname.startswith('vm-m-'):
-                continue
-            ns_name = ifname[3:]  # strip "vm-" prefix to get namespace name
-            # Check if this namespace is still tracked in the lock file
-            _ensure_lock_dir()
-            lock_fd = os.open(_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_SH)
-                entries = pool._read_lock_file(lock_fd)
-                ns_in_use = any(e[2] == ns_name for e in entries)
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-                os.close(lock_fd)
+        with IPRoute() as ipr:
+            for link in ipr.get_links():
+                ifname = link.get_attr('IFLA_IFNAME', '')
+                if not ifname.startswith('vm-m-'):
+                    continue
+                ns_name = ifname[3:]  # strip "vm-" prefix to get namespace name
+                # Check if this namespace is still tracked in the lock file
+                _ensure_lock_dir()
+                lock_fd = os.open(_LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_SH)
+                    entries = pool._read_lock_file(lock_fd)
+                    ns_in_use = any(e[2] == ns_name for e in entries)
+                finally:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    os.close(lock_fd)
 
-            if not ns_in_use:
-                log.info("NAT: cleaning up truly orphaned interface %s "
-                         "(ns=%s not in lock file)", ifname, ns_name)
-                try:
-                    ipr.link('del', index=link['index'])
-                except Exception as e:
-                    log.warning("NAT: failed to delete orphaned veth %s: %s",
-                                ifname, e)
-                try:
-                    netns.remove(ns_name)
-                except Exception as e:
-                    log.warning("NAT: failed to remove orphaned ns %s: %s",
-                                ns_name, e)
+                if not ns_in_use:
+                    log.info("NAT: cleaning up truly orphaned interface %s "
+                             "(ns=%s not in lock file)", ifname, ns_name)
+                    try:
+                        ipr.link('del', index=link['index'])
+                    except Exception as e:
+                        log.warning("NAT: failed to delete orphaned veth %s: %s",
+                                    ifname, e)
+                    try:
+                        netns.remove(ns_name)
+                    except Exception as e:
+                        log.warning("NAT: failed to remove orphaned ns %s: %s",
+                                    ns_name, e)
     except Exception as e:
         log.warning("NAT: orphan interface scan failed: %s", e)
 

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -687,11 +687,13 @@ def setns(ns_path, netns_type=CLONE_NEWNET):
     log = getLog()
     try:
         fd = os.open(ns_path, os.O_RDONLY)
-        ret = _libc.setns(fd, netns_type)
-        if ret != 0:
-            err = ctypes.get_errno()
-            raise OSError(err, os.strerror(err))
-        os.close(fd)
+        try:
+            ret = _libc.setns(fd, netns_type)
+            if ret != 0:
+                err = ctypes.get_errno()
+                raise OSError(err, os.strerror(err))
+        finally:
+            os.close(fd)
         log.debug("setns: entered namespace %s", ns_path)
     except Exception as e:
         log.error("setns: failed to enter namespace %s: %s", ns_path, e)

--- a/mock/py/mockbuild/network.py
+++ b/mock/py/mockbuild/network.py
@@ -591,11 +591,14 @@ class NatNetwork:
         resolv_path = os.path.join(self.chroot_path, 'etc', 'resolv.conf')
 
         # Back up the existing resolv.conf
-        try:
-            with open(resolv_path, 'rb') as f:
-                self._resolv_backup = f.read()
-        except (IOError, OSError):
-            self._resolv_backup = None
+        if os.path.exists(resolv_path):
+            try:
+                with open(resolv_path, 'rb') as f:
+                    self._resolv_backup = f.read()
+            except OSError:
+                self._resolv_backup = None
+        else:
+            self._resolv_backup = False
 
         # Build a new resolv.conf with reachable nameservers
         fallback_dns = self.config.get('network_fallback_dns', None)
@@ -616,12 +619,29 @@ class NatNetwork:
     def _teardown_dns(self):
         """
         Restore the original resolv.conf that was backed up during _setup_dns.
+
+        If resolv.conf did not exist before setup (``_resolv_backup is
+        False``), the temporary file is deleted to restore the chroot to
+        its original state.
         """
         log = getLog()
         if self._resolv_backup is None:
             return
 
         resolv_path = os.path.join(self.chroot_path, 'etc', 'resolv.conf')
+        if self._resolv_backup is False:
+            # resolv.conf did not exist before setup — remove the temporary file
+            try:
+                os.remove(resolv_path)
+                log.debug("NAT: removed temporary resolv.conf")
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                log.warning("NAT: failed to remove temporary resolv.conf: %s", e)
+            finally:
+                self._resolv_backup = None
+            return
+
         try:
             with open(resolv_path, 'wb') as f:
                 f.write(self._resolv_backup)

--- a/mock/py/mockbuild/package_manager.py
+++ b/mock/py/mockbuild/package_manager.py
@@ -301,6 +301,12 @@ class _PackageManager(object):
             kwargs.setdefault("pty", True)
         self.buildroot.nuke_rpm_db()
 
+        # NAT network isolation for package manager commands.
+        # Package manager commands (dnf install, dnf builddep) always need
+        # network access, so use NAT when network_isolation is not 'loopback'.
+        network_isolation = self.config.get('network_isolation', 'loopback')
+        use_nat = (network_isolation != 'loopback')
+
         error = None
         max_attempts = int(self.config['package_manager_max_attempts'])
         for attempt in range(max(max_attempts, 1)):
@@ -312,6 +318,19 @@ class _PackageManager(object):
                 time.sleep(sleep_seconds)
 
             try:
+                # Set up NAT network for this attempt if needed.
+                # Each attempt gets a fresh NatNetwork since do_with_status
+                # tears it down in its finally block.
+                if use_nat:
+                    from .network import create_nat_network
+                    nat_network = create_nat_network(
+                        self.config, self.buildroot.root_log,
+                        self.buildroot.make_chroot_path(), util.USE_NSPAWN)
+                    if nat_network is not None:
+                        kwargs['nat_network'] = nat_network
+                    else:
+                        kwargs.pop('nat_network', None)
+
                 # either it does not support --installroot (microdnf) or
                 # it is bootstrap image made by container with incomaptible dnf/rpm
                 personality = kwargs.pop("personality", None)
@@ -323,8 +342,18 @@ class _PackageManager(object):
                                   chrootPath=self.buildroot.make_chroot_path(),
                                   personality=personality, **kwargs)
                 elif self.bootstrap_buildroot is None:
-
-
+                    # Running DNF with --installroot on the host (no
+                    # chrootPath, no nspawn).  NAT network isolation
+                    # does not work here because the host's resolv.conf
+                    # may point to 127.0.0.53 (systemd-resolved) which
+                    # is unreachable from a network namespace.  Tear down
+                    # the NAT network and run with host network instead.
+                    nat_net = kwargs.pop('nat_network', None)
+                    if nat_net is not None:
+                        try:
+                            nat_net.teardown()
+                        except Exception:
+                            pass
                     out = util.do(invocation, env=env,
                                   personality=personality, **kwargs)
                 else:

--- a/mock/py/mockbuild/util.py
+++ b/mock/py/mockbuild/util.py
@@ -526,7 +526,7 @@ def do(*args, **kargs):
 def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, raiseExc=True,
                    returnOutput=0, uid=None, gid=None, user=None, personality=None,
                    printOutput=False, env=None, pty=False, nspawn_args=None, unshare_net=False,
-                   returnStderr=True, *_, **kargs):
+                   returnStderr=True, nat_network=None, *_, **kargs):
     logger = kargs.get("logger", getLog())
     if timeout == 0:
         timeout = _OPS_TIMEOUT
@@ -536,8 +536,16 @@ def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, r
         lead_pty, sub_pty = os.openpty()
         resize_pty(sub_pty)
         reader = os.fdopen(lead_pty, 'rb')
+
+    # Determine effective network mode
+    nat_ns_path = None
+    if nat_network is not None:
+        # NAT network was set up by the caller — use it
+        nat_ns_path = nat_network.ns_path
+
     preexec = ChildPreExec(personality, chrootPath, cwd, uid, gid,
-                           unshare_ipc=bool(chrootPath), unshare_net=unshare_net)
+                           unshare_ipc=bool(chrootPath), unshare_net=unshare_net,
+                           nat_ns_path=nat_ns_path, nat_network=nat_network)
     if env is None:
         env = clean_env()
     stdout = None
@@ -552,7 +560,8 @@ def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, r
             logger.debug("Using nspawn with args %s", nspawn_args)
             command = _prepare_nspawn_command(chrootPath, user, command,
                                               nspawn_args=nspawn_args,
-                                              env=env, cwd=cwd, shell=shell)
+                                              env=env, cwd=cwd, shell=shell,
+                                              nat_ns_path=nat_ns_path)
             shell = False
         logger.debug("Executing command: %s with env %s and shell %s", command, env, shell)
         with open(os.devnull, "r") as stdin:
@@ -591,6 +600,12 @@ def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, r
             reader.close()
         if stdout:
             stdout.close()
+        # Teardown NAT network after child exits (even on error)
+        if nat_network is not None:
+            try:
+                nat_network.teardown()
+            except Exception as e:
+                logger.warning("NAT teardown failed: %s", e)
 
     # wait until child is done, kill it if it passes timeout
     niceExit = 1
@@ -616,11 +631,13 @@ def do_with_status(command, shell=False, chrootPath=None, cwd=None, timeout=0, r
 class ChildPreExec(object):
     def __init__(self, personality, chrootPath, cwd, uid, gid, env=None,
                  shell=False, unshare_ipc=False, unshare_net=False,
-                 no_setsid=False):
+                 no_setsid=False, nat_ns_path=None, nat_network=None):
         """
         Params:
         - no_setsid - assure we don't call os.setsid(), as the process we run
             calls that itself
+        - nat_ns_path - path to a pre-created network namespace for NAT mode
+        - nat_network - NatNetwork object for configuring container-side interface
         """
         self.personality = personality
         self.chrootPath = chrootPath
@@ -632,13 +649,25 @@ class ChildPreExec(object):
         self.unshare_ipc = unshare_ipc
         self.unshare_net = unshare_net
         self.no_setsid = no_setsid
+        self.nat_ns_path = nat_ns_path
+        self.nat_network = nat_network
         getLog().debug("child environment: %s", env)
 
     def __call__(self, *args, **kargs):
         if not self.shell and not self.no_setsid:
             os.setsid()
         os.umask(DEFAULT_UMASK)
-        condUnshareNet(self.unshare_net)
+
+        if self.nat_ns_path:
+            # NAT mode: enter the pre-created namespace and configure
+            # the container-side interface, instead of creating a new one
+            from .network import setns
+            setns(self.nat_ns_path)
+            if self.nat_network:
+                self.nat_network.configure_container_ns()
+        else:
+            condUnshareNet(self.unshare_net)
+
         condPersonality(self.personality)
         condEnvironment(self.env)
         # Even if nspawn is allowed to be used, it won't be used unless there
@@ -744,8 +773,17 @@ def check_nspawn_has_suppress_sync_option():
     """
     return '--suppress-sync' in systemd_nspawn_help_output()
 
+def check_nspawn_has_network_namespace_path_option():
+    """
+    The --network-namespace-path option was added in systemd 242.
+    Without it, NAT network isolation cannot use a pre-created network namespace
+    with nspawn.  When systemd 242 is everywhere we can remove this.
+    """
+    return '--network-namespace-path' in systemd_nspawn_help_output()
+
 def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None,
-                            cwd=None, interactive=False, shell=False):
+                            cwd=None, interactive=False, shell=False,
+                            nat_ns_path=None):
     nspawn_argv = ['/usr/bin/systemd-nspawn', '-q', '-M', uuid.uuid4().hex, '-D', chrootPath]
     distro_label = distro.id()
     try:
@@ -759,6 +797,11 @@ def _prepare_nspawn_command(chrootPath, user, cmd, nspawn_args=None, env=None,
     if user:
         # user can be either id or name
         nspawn_argv += ['-u', str(user)]
+
+    # When using a pre-created network namespace for NAT, tell nspawn
+    # to use it instead of creating its own network configuration
+    if nat_ns_path:
+        nspawn_argv.append('--network-namespace-path={0}'.format(nat_ns_path))
 
     if nspawn_args:
         nspawn_argv.extend(nspawn_args)
@@ -799,7 +842,8 @@ def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
             cwd=None,
             nspawn_args=None,
             unshare_ipc=True,
-            unshare_net=False):
+            unshare_net=False,
+            nat_network=None):
     log = getLog()
     log.debug("doshell: chrootPath:%s, uid:%d, gid:%d", chrootPath, uid, gid)
     if environ is None:
@@ -811,6 +855,11 @@ def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
     if 'SHELL' not in environ:
         environ['SHELL'] = '/bin/sh'
     log.debug("doshell environment: %s", environ)
+
+    # Determine NAT namespace path for ChildPreExec
+    nat_ns_path = None
+    if nat_network is not None:
+        nat_ns_path = nat_network.ns_path
 
     no_setsid = False
     shell = True
@@ -824,17 +873,26 @@ def doshell(chrootPath=None, environ=None, uid=None, gid=None, cmd=None,
     preexec = ChildPreExec(personality=None, chrootPath=chrootPath, cwd=cwd,
                            uid=uid, gid=gid, env=environ, shell=shell,
                            unshare_ipc=unshare_ipc, unshare_net=unshare_net,
-                           no_setsid=no_setsid)
+                           no_setsid=no_setsid,
+                           nat_ns_path=nat_ns_path, nat_network=nat_network)
 
     if USE_NSPAWN:
         # nspawn cannot set gid
         log.debug("Using nspawn with args %s", nspawn_args)
         cmd = _prepare_nspawn_command(chrootPath, uid, cmd, nspawn_args=nspawn_args, env=environ,
-                                      interactive=True, cwd=cwd)
+                                      interactive=True, cwd=cwd,
+                                      nat_ns_path=nat_ns_path)
         shell = False
 
     log.debug("doshell: command: %s", cmd_pretty(cmd))
-    return subprocess.call(cmd, preexec_fn=preexec, env=environ, shell=shell)
+    try:
+        return subprocess.call(cmd, preexec_fn=preexec, env=environ, shell=shell)
+    finally:
+        if nat_network is not None:
+            try:
+                nat_network.teardown()
+            except Exception as e:
+                log.warning("NAT teardown failed after shell: %s", e)
 
 
 def run(cmd, isShell=True):

--- a/mock/tests/test_network.py
+++ b/mock/tests/test_network.py
@@ -1,0 +1,236 @@
+"""Unit tests for mockbuild.network subnet allocation helpers."""
+
+import ipaddress
+import os
+import fcntl
+import subprocess
+
+import pytest
+
+from mockbuild import network
+
+
+@pytest.fixture(autouse=True)
+def isolate_lock_dir(tmp_path, monkeypatch):
+    """Use a per-test temporary directory for the subnet lock file."""
+    lock_dir = tmp_path / "nat-lock"
+    lock_dir.mkdir()
+    monkeypatch.setattr(network, "_LOCK_DIR", str(lock_dir))
+    monkeypatch.setattr(network, "_LOCK_FILE", str(lock_dir / "subnet.lock"))
+
+
+def _write_lock_file_from_entries(pool, entries):
+    """Seed the lock file with the given entries, taking a real lock."""
+    network._ensure_lock_dir()
+    lock_fd = os.open(network._LOCK_FILE, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        pool._write_lock_file(lock_fd, entries)
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+class TestSubdivide:
+    """Tests for the _subdivide helper."""
+
+    def test_ipv4_subdivision(self):
+        subnets = network._subdivide("192.168.200.0/24", 30)
+        assert len(subnets) == 64
+        assert subnets[0] == ipaddress.ip_network("192.168.200.0/30")
+        assert subnets[-1] == ipaddress.ip_network("192.168.200.252/30")
+
+    def test_ipv6_subdivision(self):
+        subnets = network._subdivide("fd00:dead:beef::/56", 64)
+        assert len(subnets) == 256
+        assert subnets[0] == ipaddress.ip_network("fd00:dead:beef::/64")
+        assert subnets[-1] == ipaddress.ip_network("fd00:dead:beef:ff::/64")
+
+    def test_empty_string_returns_empty_list(self):
+        assert network._subdivide("", 30) == []
+
+    def test_invalid_cidr_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid network_veth_subnet_block"):
+            network._subdivide("not-a-network", 30)
+
+    def test_prefix_too_large_raises_value_error(self):
+        with pytest.raises(ValueError, match="prefix /30 is not larger than"):
+            network._subdivide("192.168.200.0/30", 30)
+
+
+class TestSubnetPoolInit:
+    """Tests for SubnetPool construction."""
+
+    def test_ipv4_only(self):
+        pool = network.SubnetPool("192.168.200.0/24")
+        assert len(pool.pool_v4) == 64
+        assert pool.pool_v6 == []
+
+    def test_ipv4_and_ipv6(self):
+        pool = network.SubnetPool("192.168.200.0/24", "fd00:dead:beef::/48")
+        assert len(pool.pool_v4) == 64
+        assert len(pool.pool_v6) == 65536
+
+    def test_invalid_pool_raises(self):
+        with pytest.raises(ValueError):
+            network.SubnetPool("bad-cidr")
+
+
+class TestParseLine:
+    """Tests for SubnetPool._parse_line."""
+
+    def test_full_line(self):
+        subnet, pid, ns_name = network.SubnetPool._parse_line(
+            "192.168.200.0/30 pid=12345 ns=m-a1b2c3d4"
+        )
+        assert subnet == "192.168.200.0/30"
+        assert pid == 12345
+        assert ns_name == "m-a1b2c3d4"
+
+    def test_missing_ns(self):
+        subnet, pid, ns_name = network.SubnetPool._parse_line(
+            "192.168.200.0/30 pid=12345"
+        )
+        assert subnet == "192.168.200.0/30"
+        assert pid == 12345
+        assert ns_name is None
+
+    def test_missing_pid(self):
+        subnet, pid, ns_name = network.SubnetPool._parse_line(
+            "192.168.200.0/30 ns=m-abc"
+        )
+        assert subnet == "192.168.200.0/30"
+        assert pid is None
+        assert ns_name == "m-abc"
+
+    def test_malformed_pid_ignored(self):
+        subnet, pid, ns_name = network.SubnetPool._parse_line(
+            "192.168.200.0/30 pid=abc ns=m-abc"
+        )
+        assert subnet == "192.168.200.0/30"
+        assert pid is None
+        assert ns_name == "m-abc"
+
+    def test_empty_line(self):
+        subnet, pid, ns_name = network.SubnetPool._parse_line("")
+        assert subnet == ""
+        assert pid is None
+        assert ns_name is None
+
+
+class TestIsPidAlive:
+    """Tests for SubnetPool._is_pid_alive."""
+
+    def test_current_process_is_alive(self):
+        assert network.SubnetPool._is_pid_alive(os.getpid()) is True
+
+    def test_dead_process(self):
+        proc = subprocess.Popen(
+            ["python3", "-c", "exit(0)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        proc.wait()
+        assert network.SubnetPool._is_pid_alive(proc.pid) is False
+
+    def test_permission_error_treated_as_alive(self, monkeypatch):
+        def raise_permission_error(*_args, **_kwargs):
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr(os, "kill", raise_permission_error)
+        assert network.SubnetPool._is_pid_alive(1) is True
+
+
+class TestAllocateRelease:
+    """Tests for SubnetPool.allocate and SubnetPool.release."""
+
+    def test_allocate_ipv4_only(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        v4_net, v6_net = pool.allocate()
+        assert v4_net == ipaddress.ip_network("192.168.200.0/30")
+        assert v6_net is None
+
+    def test_allocate_ipv4_ipv6_pair(self):
+        pool = network.SubnetPool("192.168.200.0/29", "fd00:dead:beef::/48")
+        v4_net, v6_net = pool.allocate()
+        assert v4_net == ipaddress.ip_network("192.168.200.0/30")
+        assert v6_net == ipaddress.ip_network("fd00:dead:beef::/64")
+
+    def test_allocate_writes_lock_file(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        v4_net, _ = pool.allocate(ns_name="m-test")
+        content = open(network._LOCK_FILE).read()
+        assert "192.168.200.0/30" in content
+        assert f"pid={os.getpid()}" in content
+        assert "ns=m-test" in content
+
+    def test_release_removes_lock_entry(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        v4_net, _ = pool.allocate()
+        pool.release(v4_net)
+        content = open(network._LOCK_FILE).read()
+        assert "192.168.200.0/30" not in content
+
+    def test_allocate_after_release_reuses_subnet(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        v4_net, _ = pool.allocate()
+        pool.release(v4_net)
+        v4_net_2, _ = pool.allocate()
+        assert v4_net == v4_net_2
+
+    def test_pool_exhaustion_raises(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        pool.allocate()
+        pool.allocate()
+        with pytest.raises(RuntimeError, match="No available subnets"):
+            pool.allocate()
+
+    def test_allocate_reaps_dead_entries(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        proc = subprocess.Popen(
+            ["python3", "-c", "exit(0)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        proc.wait()
+        _write_lock_file_from_entries(pool, [
+            ("192.168.200.0/30", proc.pid, "m-dead"),
+        ])
+
+        v4_net, _ = pool.allocate()
+        assert v4_net == ipaddress.ip_network("192.168.200.0/30")
+        content = open(network._LOCK_FILE).read()
+        assert "m-dead" not in content
+
+
+class TestReapDead:
+    """Tests for SubnetPool.reap_dead."""
+
+    def test_reap_dead_removes_dead_entries(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        proc = subprocess.Popen(
+            ["python3", "-c", "exit(0)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        proc.wait()
+        _write_lock_file_from_entries(pool, [
+            ("192.168.200.0/30", proc.pid, "m-dead"),
+        ])
+
+        reaped = pool.reap_dead()
+        assert reaped == ["m-dead"]
+        content = open(network._LOCK_FILE).read()
+        assert "192.168.200.0/30" not in content
+
+    def test_reap_dead_keeps_alive_entries(self):
+        pool = network.SubnetPool("192.168.200.0/29")
+        _write_lock_file_from_entries(pool, [
+            ("192.168.200.0/30", os.getpid(), "m-alive"),
+        ])
+
+        reaped = pool.reap_dead()
+        assert reaped == []
+        content = open(network._LOCK_FILE).read()
+        assert "192.168.200.0/30" in content
+        assert "m-alive" in content

--- a/releng/release-notes-next/nat-network-isolation.feature.md
+++ b/releng/release-notes-next/nat-network-isolation.feature.md
@@ -1,0 +1,1 @@
+Add NAT-based network isolation for build environments


### PR DESCRIPTION
Implement optional NAT-based network isolation for mock build chroots using Linux network namespaces, veth pairs, and iptables/ip6tables MASQUERADE rules. Builds are executed inside isolated network namespaces with controlled outbound internet access via NAT.

Key components:
- SubnetPool: file-locked allocator that subdivides configurable CIDR blocks into /30 (IPv4) and /64 (IPv6) slices, with dead-process reaping to prevent pool exhaustion.
- NatNetwork: lifecycle manager for a single build's namespace, veth pair, NAT rules, and DNS configuration.
- Integration with buildroot, package manager, backend, and util for consistent network-isolation decisions across all build paths.
- Orphaned resource cleanup (cleanup_orphaned_networks) to reclaim subnets, interfaces, and namespaces after killed processes.

Configuration options (site-defaults.cfg):
- network_isolation: 'loopback' | 'nat' | 'auto'
- network_veth_subnet_block: IPv4 CIDR block for subdivision
- network_veth_subnet_block_v6: optional IPv6 CIDR block
- network_fallback_dns: fallback DNS servers for loopback-only hosts

Includes unit tests for the SubnetPool allocator covering CIDR subdivision, lock-file parsing, PID liveness checks, allocate/release semantics, pool exhaustion, and dead-entry reaping.

Assisted-By: Qoder


> Add a reference to related issue - preferably in the git commit message
Fixes: #NUMBER

> Add release note. See https://rpm-software-management.github.io/mock/Release-Notes-New-Entry
> or let us know to add `label no-release-notes` if you think the change does
> not deserve a release note.
