### PR TITLE
fix: resolve #1622 — RFE: point `local` repo for rawhide chroots at `fNN-build` instead of `rawhide`

### DIFF
--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -48,14 +48,14 @@ file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-$releasever-pr
 
 [local]
 name=local
-baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/$basearch/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f{{ releasever }}-build/latest/$basearch/
 cost=2000
 enabled={{ not mirrored }}
 skip_if_unavailable=False
 
 [local-source]
 name=local-source
-baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/src/
+baseurl=https://kojipkgs.fedoraproject.org/repos/f{{ releasever }}-build/latest/src/
 cost=2000
 enabled=0
 skip_if_unavailable=False


### PR DESCRIPTION
## Summary

fix: resolve #1622 — RFE: point `local` repo for rawhide chroots at `fNN-build` instead of `rawhide`

## Problem

**Severity**: `Medium` | **File**: `mock-core-configs/etc/mock/templates/fedora-rawhide.tpl`

rawhide koji buildroot no longer symlink to fNN-build; lags 1-2h. local repo baseurl still uses /rawhide/latest/ so chroots get stale packages. Branched templates already use f{{ releasever }}-build. Align rawhide.

## Solution

In [local] section change baseurl from

## Changes

- `mock-core-configs/etc/mock/templates/fedora-rawhide.tpl` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._