### PR TITLE
fix: resolve #1611 — Produce a `BUILD` directory snapshot for SBOM generators

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -33,7 +33,7 @@ PLUGIN_LIST = ['tmpfs', 'root_cache', 'yum_cache', 'mount', 'bind_mount',
                'lvm_root', 'compress_logs', 'sign', 'pm_request',
                'hw_info', 'procenv', 'showrc', 'rpkg_preprocessor',
                'rpmautospec', 'buildroot_lock', 'export_buildroot_image',
-               'unbreq', 'expand_spec', 'system_monitor']
+               'unbreq', 'expand_spec', 'system_monitor', 'build_snapshot']
 
 def nspawn_supported():
     """Detect some situations where the systemd-nspawn chroot code won't work"""

--- a/mock/py/mockbuild/plugins/build_snapshot.py
+++ b/mock/py/mockbuild/plugins/build_snapshot.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# vim: noai:ts=4:sw=4:expandtab
+
+import os
+import tarfile
+
+from mockbuild.trace_decorator import getLog, traceLog
+
+requires_api_version = "1.1"
+
+
+class BuildSnapshot(object):
+    """Tar rpmbuild/BUILD into resultdir for external SBOM tools."""
+    @traceLog()
+    def __init__(self, plugins, conf, buildroot):
+        self.buildroot = buildroot
+        self.state = conf
+        plugins.add_hook("postbuild", self._make_snapshot)
+        getLog().info("build_snapshot: initialized")
+
+    @traceLog()
+    def _make_snapshot(self):
+        log = getLog()
+        build_path = os.path.join(
+            self.buildroot.make_chroot_path(self.buildroot.builddir), "BUILD"
+        )
+        if not os.path.isdir(build_path):
+            log.warning("build_snapshot: BUILD dir not found: %s", build_path)
+            return
+
+        name = self.state.get("name", "build-snapshot.tar.gz")
+        compress = self.state.get("compress", "gz")
+        mode = "w" if compress == "none" else "w:" + compress
+        outfile = os.path.join(self.buildroot.resultdir, name)
+
+        log.info("build_snapshot: creating %s", outfile)
+        with tarfile.open(outfile, mode) as tar:
+            tar.add(build_path, arcname="BUILD")
+        log.info("build_snapshot: done")


### PR DESCRIPTION
## Summary

fix: resolve #1611 — Produce a `BUILD` directory snapshot for SBOM generators

## Problem

**Severity**: `High` | **File**: `mock/py/mockbuild/plugins/build_snapshot.py`

Core deliverable. When enabled, after dynamic BR calc, produce a resultdir artifact (tarball of rpmbuild/BUILD) for external SBOM tools (syft). Must not run syft inside mock. Keep plugin thin: enable flag, optional name/compression, copy/tar out, done.

## Solution

|

## Changes

- `mock/py/mockbuild/plugins/build_snapshot.py` (new)
- `mock/py/mockbuild/config.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
_Note: this change was drafted with AI assistance and reviewed locally before submission._