### PR TITLE
No --allowerasing for `dnf5 list`

### DIFF
--- a/mock/py/mockbuild/config.py
+++ b/mock/py/mockbuild/config.py
@@ -394,6 +394,7 @@ def setup_default_config_opts():
         "search": ["--allowerasing"],
         "info": ["--allowerasing"],
         "download": ["--allowerasing"],
+        "list": ["--allowerasing"],
     }
 
     config_opts['microdnf_command'] = '/usr/bin/microdnf'

--- a/releng/release-notes-next/dnf5-list-allowerasing.bugfix.md
+++ b/releng/release-notes-next/dnf5-list-allowerasing.bugfix.md
@@ -1,0 +1,2 @@
+Mock defaults were changed to not pass `--allowerasing` option to `dnf5 list`
+command.


### PR DESCRIPTION
Relates to: https://github.com/rpm-software-management/mock/issues/894#issuecomment-4982505976
