### PR TITLE
configs: branch Fedora 45 from Rawhide

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,5 +1,6 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 
+RUN dnf copr enable @mock/mock-deps -y
 RUN dnf -y install fedpkg tito argparse-manpage bash-completion python3-devel python3-jsonschema python3-pytest
 RUN useradd -m -G mock -u 1001 user
 WORKDIR /home/user

--- a/mock-core-configs/etc/mock/fedora-45-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-45-aarch64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-aarch64.cfg
+config_opts['releasever'] = '45'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-45-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-45-i386.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-i386.cfg
+config_opts['releasever'] = '45'
+config_opts['target_arch'] = 'i686'
+config_opts['legal_host_arches'] = ('i386', 'i586', 'i686', 'x86_64')
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-45-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-45-ppc64le.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-ppc64le.cfg
+config_opts['releasever'] = '45'
+config_opts['target_arch'] = 'ppc64le'
+config_opts['legal_host_arches'] = ('ppc64le',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-45-riscv64.cfg
+++ b/mock-core-configs/etc/mock/fedora-45-riscv64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-riscv64.cfg
+config_opts['releasever'] = '45'
+config_opts['target_arch'] = 'riscv64'
+config_opts['legal_host_arches'] = ('riscv64',)
+
+include('templates/fedora-branched-riscv64.tpl')

--- a/mock-core-configs/etc/mock/fedora-45-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-45-s390x.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-s390x.cfg
+config_opts['releasever'] = '45'
+config_opts['target_arch'] = 's390x'
+config_opts['legal_host_arches'] = ('s390x',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-45-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-45-x86_64.cfg
@@ -1,1 +1,5 @@
-fedora-rawhide-x86_64.cfg
+config_opts['releasever'] = '45'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+
+include('templates/fedora-branched.tpl')

--- a/mock-core-configs/etc/mock/fedora-46-aarch64.cfg
+++ b/mock-core-configs/etc/mock/fedora-46-aarch64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-aarch64.cfg

--- a/mock-core-configs/etc/mock/fedora-46-i386.cfg
+++ b/mock-core-configs/etc/mock/fedora-46-i386.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-i386.cfg

--- a/mock-core-configs/etc/mock/fedora-46-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/fedora-46-ppc64le.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-ppc64le.cfg

--- a/mock-core-configs/etc/mock/fedora-46-riscv64.cfg
+++ b/mock-core-configs/etc/mock/fedora-46-riscv64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-riscv64.cfg

--- a/mock-core-configs/etc/mock/fedora-46-s390x.cfg
+++ b/mock-core-configs/etc/mock/fedora-46-s390x.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-s390x.cfg

--- a/mock-core-configs/etc/mock/fedora-46-x86_64.cfg
+++ b/mock-core-configs/etc/mock/fedora-46-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-rawhide-x86_64.cfg

--- a/mock-core-configs/etc/mock/templates/fedora-eln.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-eln.tpl
@@ -1,5 +1,5 @@
 config_opts['releasever'] = 'eln'
-config_opts['eln_rawhide_releasever'] = '45'
+config_opts['eln_rawhide_releasever'] = '46'
 
 config_opts['root'] = 'fedora-eln-{{ target_arch }}'
 

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide-riscv64.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide-riscv64.tpl
@@ -5,7 +5,7 @@ config_opts['chroot_setup_cmd'] = 'install @build'
 
 config_opts['dist'] = 'rawhide'
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['releasever'] = '45'
+config_opts['releasever'] = '46'
 
 config_opts['package_manager'] = 'dnf5'
 

--- a/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
+++ b/mock-core-configs/etc/mock/templates/fedora-rawhide.tpl
@@ -7,7 +7,7 @@ config_opts['chroot_setup_cmd'] = 'install @{% if mirrored %}buildsys-{% endif %
 
 config_opts['dist'] = 'rawhide'  # only useful for --resultdir variable subst
 config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
-config_opts['releasever'] = '45'
+config_opts['releasever'] = '46'
 
 # https://fedoraproject.org/wiki/Changes/BuildWithDNF5
 config_opts['package_manager'] = 'dnf5'

--- a/mock-core-configs/mock-core-configs.spec
+++ b/mock-core-configs/mock-core-configs.spec
@@ -3,7 +3,7 @@
 %endif
 
 Name:       mock-core-configs
-Version:    44.4
+Version:    45.0
 Release:    1%{?dist}
 Summary:    Mock core config files basic chroots
 
@@ -22,7 +22,7 @@ BuildArch:  noarch
 Provides: mock-configs
 
 # distribution-gpg-keys contains GPG keys used by mock configs
-Requires:   distribution-gpg-keys >= 1.117
+Requires:   distribution-gpg-keys >= 1.121
 # specify minimal compatible version of mock
 Requires:   mock >= 6.1.test
 Requires:   mock-filesystem

--- a/releng/release-notes-next/fedora-45-branching.config
+++ b/releng/release-notes-next/fedora-45-branching.config
@@ -1,0 +1,2 @@
+Configuration files for Fedora 45 have been branched from Rawhide,
+according to the [Fedora 45 Schedule](https://fedorapeople.org/groups/schedule/f-45/f-45-all-tasks.html).


### PR DESCRIPTION
Rawhide is now Fedora 46.  Bump mock-core-configs version to 45.0 and require distribution-gpg-keys >= 1.121.

Fixes: #1793
Assisted-By: Claude Code


