### PR TITLE
ci: use fedora:latest in Docker test

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:rawhide
+FROM registry.fedoraproject.org/fedora:latest
 
 RUN dnf copr enable @mock/mock-deps -y
 RUN dnf -y install fedpkg tito argparse-manpage bash-completion python3-devel python3-jsonschema python3-pytest


### PR DESCRIPTION
The fedora:rawhide image is known to cause issues with openh264 from the Cisco repository around branching time (Cisco seems to lag slightly behind Fedora when updating to N+1 release keys).

