### PR TITLE
system_monitor: extend the sampler with more data

### DIFF
--- a/docs/Plugin-SystemMonitor.md
+++ b/docs/Plugin-SystemMonitor.md
@@ -3,23 +3,53 @@ layout: default
 title: Plugin SystemMonitor
 ---
 
-This plugin activates per-interval collection of various statistics
-based on the kernels cgroupv2 controllers during the build phase and
-dumps a json file 'system_monitor.json' with the collected statistics
-in the result dir
+This plugin continuously samples resource usage (memory and CPU)
+throughout the whole build using the kernel's cgroup v2 controllers.
+Every sample is tagged with the build phase that was active at the time
+it was taken, so the collected data can later be broken down per-phase
+(e.g. "how much memory did dependency resolution need" vs. "how much
+memory did the actual build need").
 
-Currently dumped statistics include total maximum memory usage for the
-build, the process with maximum memory RSS and max swap usage
+The plugin requires cgroup v2 and `systemd-nspawn` as the build container
+runner.
 
-The plugin requires the use of systemd-nspawn as build container runner
+## Output
+
+This plugin writes its data as a single file in the result dir:
+
+* `system_monitor_samples.jsonl` - one raw sample per line, appended as
+  soon as it is collected.
+
+Each line of `system_monitor_samples.jsonl` is a JSON object with:
+
+* `phase` - the build phase active when this sample was taken (e.g.
+  `chroot_init`, `resolving_deps`, `build`, `check`)
+* `t` - wall-clock timestamp (seconds since the epoch) when the sample
+  was taken
+* `rss_bytes`, `swap_bytes` - memory (RSS) and swap usage at this instant
+  (`memory.current`/`memory.swap.current`), not a delta
+* `cpu_usage_delta_usec`, `cpu_user_delta_usec`, `cpu_system_delta_usec` -
+  CPU time consumed since the previous sample, in microseconds
+* `pids` - number of processes/threads in the monitored cgroups at this
+  instant
 
 ## Configuration
 
 The module is disabled by default and needs to be activated by:
 
-    config_opts['plugin_conf']['system_monitor_enable'] = True
+```python
+config_opts['plugin_conf']['system_monitor_enable'] = True
+```
 
-The following sub-options may be specified:
+The following sub-option may be specified:
 
-    # the interval between statistics collection runs in seconds, default 2
-    config_opts['plugin_conf']['system_monitor_opts']['interval'] = 10
+```python
+# the interval between statistics collection runs in seconds, default 5
+config_opts['plugin_conf']['system_monitor_opts']['interval'] = 5
+```
+
+## Accuracy notes
+
+* Monitoring relies on the current process' own cgroup plus a dedicated
+  `systemd-nspawn` slice. If `systemd-nspawn` does not support the
+  `--slice` option, the plugin disables itself entirely.

--- a/mock/mock.spec
+++ b/mock/mock.spec
@@ -213,6 +213,7 @@ install -d %{buildroot}%{_libexecdir}/mock
 install mockchain %{buildroot}%{_bindir}/mockchain
 install py/mock-hermetic-repo.py %{buildroot}%{_bindir}/mock-hermetic-repo
 install py/mock-parse-buildlog.py %{buildroot}%{_bindir}/mock-parse-buildlog
+install py/mock-system-monitor-collector.py %{buildroot}%{_bindir}/mock-system-monitor-collector
 install py/mock.py %{buildroot}%{_libexecdir}/mock/mock
 %if %{with polkit}
 install etc/polkit/mock-pkexec.sh %{buildroot}%{_bindir}/mock
@@ -305,6 +306,7 @@ pylint-3 py/mockbuild/ py/*.py py/mockbuild/plugins/* || :
 %{_bindir}/mockchain
 %{_bindir}/mock-hermetic-repo
 %{_bindir}/mock-parse-buildlog
+%{_bindir}/mock-system-monitor-collector
 %{_libexecdir}/mock
 
 # python stuff

--- a/mock/py/mock-system-monitor-collector.py
+++ b/mock/py/mock-system-monitor-collector.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python3
+# License: GPL2 or later see COPYING
+"""
+Standalone resource-usage collector for mock's system_monitor plugin.
+
+Periodically reads a set of cgroup v2 files under given cgroup directories
+and sends them to STDOUT as JSONL.
+
+See https://docs.kernel.org/admin-guide/cgroup-v2.html for the cgroup v2
+file formats and semantics used below.
+"""
+
+# pylint: disable=invalid-name
+
+import argparse
+import json
+import os
+import sys
+import time
+
+# Cgroup parser helpers, check the docs above for the file formats.
+# OSError/ValueError are swallowed; a file may not exist on this
+# distro/kernel or vanish mid-sample.
+
+
+def _read_int(path):
+    try:
+        with open(path, 'r', encoding="utf-8") as f:
+            text = f.read().strip()
+            if text in ("", "max"):
+                return 0
+
+            return int(text)
+    except (OSError, ValueError):
+        return 0
+
+
+def _read_stat_fields(path, fields):
+    result = dict.fromkeys(fields, 0)
+    try:
+        with open(path, 'r', encoding="utf-8") as file:
+            for line in file:
+                parts = line.split()
+                if len(parts) == 2 and parts[0] in result:
+                    # example: usage_usec 4000000
+                    result[parts[0]] = int(parts[1])
+    except (OSError, ValueError):
+        pass
+
+    return result
+
+
+def _sum_over_dirs(dirs, filename, reader, *args):
+    return sum(reader(os.path.join(d, filename), *args) for d in dirs)
+
+
+def _multi_delta_over_dirs(dirs, filename, reader, state, fields):
+    # sum across dirs how much each of `fields` increased since the last
+    # time each individual directory was read
+    totals = dict.fromkeys(fields, 0)
+    for d in dirs:
+        current = reader(os.path.join(d, filename), fields)
+        for field in fields:
+            key = (filename, field, d)
+            previous = state.get(key, current[field])
+            totals[field] += max(current[field] - previous, 0)
+            state[key] = current[field]
+
+    return totals
+
+
+def _active_dirs(dirs):
+    # Keep the first dir unconditionally (the caller's own cgroup), and any
+    # further dirs only while they currently exist.
+    #
+    # cgroup v2 aggregates cumulative values recursively across the whole
+    # subtree, even after a descendant is gone, so summing just these
+    # top-level dirs is enough. A further dir (e.g. a named nspawn slice) can
+    # appear and disappear during the build, so this is re-evaluated every
+    # tick rather than cached.
+    if not dirs:
+        return []
+
+    return [dirs[0]] + [d for d in dirs[1:] if os.path.isdir(d)]
+
+
+def _take_sample(dirs, state):
+    now = time.time()
+    active_dirs = _active_dirs(dirs)
+
+    cpu = _multi_delta_over_dirs(active_dirs, "cpu.stat", _read_stat_fields, state,
+                                  ["usage_usec", "user_usec", "system_usec"])
+
+    return {
+        "t": now,
+        "rss_bytes": _sum_over_dirs(active_dirs, "memory.current", _read_int),
+        "swap_bytes": _sum_over_dirs(active_dirs, "memory.swap.current", _read_int),
+        "cpu_usage_delta_usec": cpu["usage_usec"],
+        "cpu_user_delta_usec": cpu["user_usec"],
+        "cpu_system_delta_usec": cpu["system_usec"],
+        "pids": _sum_over_dirs(active_dirs, "pids.current", _read_int),
+    }
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Periodically sample cgroup v2 resource usage and print "
+                     "one JSONL sample per line to STDOUT.",
+    )
+    parser.add_argument("--interval", type=float, required=True,
+                         help="seconds to sleep between samples")
+    parser.add_argument("--cgroup", dest="cgroups", metavar="PATH",
+                         action="append", required=True,
+                         help="cgroup directory to sample; may be given more than once")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """ Entry point: parse args, then sample forever until killed or the pipe closes. """
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    state = {}
+
+    while True:
+        try:
+            sample = _take_sample(args.cgroups, state)
+            print(json.dumps(sample), flush=True)
+        except BrokenPipeError:
+            # the parent went away without terminating us - nothing left to do
+            break
+        except (OSError, ValueError):
+            # a bad tick shouldn't stop the whole collector
+            pass
+
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/mock/py/mockbuild/backend.py
+++ b/mock/py/mockbuild/backend.py
@@ -751,7 +751,14 @@ class Commands(object):
         if not calculatedeps:
             checkdeps = dynamic_buildrequires and self.bootstrap_buildroot is not None
             rpmbuild.run_build(mode, checkdeps=checkdeps)
-            rpmbuild.run_separate_check()
+            if rpmbuild.use_separate_check:
+                # these hooks let system_monitor tell %check apart from %build/%install;
+                # only fired when %check actually runs as its own separate phase
+                try:
+                    self.plugins.call_hooks('precheck')
+                    rpmbuild.run_separate_check()
+                finally:
+                    self.plugins.call_hooks('postcheck')
 
         results = glob.glob(bd_out + '/RPMS/*.rpm')
         results += glob.glob(bd_out + '/SRPMS/*.rpm')

--- a/mock/py/mockbuild/plugins/system_monitor.py
+++ b/mock/py/mockbuild/plugins/system_monitor.py
@@ -1,190 +1,176 @@
 # License: GPL2 or later see COPYING
 """
-Track various system statistics during the build phase.
-- Report maximum allocated memory in total and for the "biggest" process
-- Report maximum swap usage
+Sample resource usage continuously throughout the whole build,
+tagging each sample with the build phase active at the time, and
+stream the raw samples into the result dir.
 
-The plugin requires systemd-nspawn as build container runner
+The actual sampling happens in a separate `mock-system-monitor-collector`
+process (see mock-system-monitor-collector.py). This plugin only figures out
+which cgroups to monitor plus is creating named nspawn slice.
 """
 
-import threading
-import os
 import json
-import backoff
+import os
+import subprocess
+import threading
 
+from mockbuild import util
 from mockbuild.trace_decorator import getLog
-from mockbuild.util import get_machinectl_uuid, _safe_check_output, USE_NSPAWN
 
 requires_api_version = "1.1"
+# TODO: would be nice to have monitoring for bootstrap as well
 run_in_bootstrap = False
+
+_COLLECTOR_ARGV = ["mock-system-monitor-collector"]
+
 
 def init(plugins, conf, buildroot):
     """ Plugin entry point """
     SystemMonitor(plugins, conf, buildroot)
 
-class SystemMonitor:
-    """ Main plugin class """
 
-    def get_top_process_info(self, scope_path):
-        """Finds the process in the cgroup with the highest RSS.
+def _own_cgroup_path():
+    # return the cgroupfs path of the current process cgroup as
+    # absolute path (no self-reference). This is where mock itself
+    # is running: builddeps, chroot init, ...
+    try:
+        with open("/proc/self/cgroup", 'r', encoding="utf-8") as file:
+            for line in file:
+                # example line: 0::/some/path
+                if line.startswith("0::"):
+                    relative = line.strip().split(":", 2)[2]
+                    return "/sys/fs/cgroup" + relative
+    except OSError as e:
+        getLog().debug("SYSMON: could not read own cgroup: %s", e)
 
-        Args:
-            scope_path (str): Path to the cgroup scope directory.
+    return None
 
-        Returns:
-            tuple[int, str]: A tuple containing the RSS of the top process in bytes
-                and its command line.
-        """
-        procs_path = os.path.join(scope_path, "cgroup.procs")
-        max_rss = 0
-        max_cmdline = ""
 
-        try:
-            if not os.path.exists(procs_path):
-                return (0, "unknown")
-            with open(procs_path, 'r', encoding="utf-8") as f:
-                pids = f.read().split()
+def _setup_cgroup():
+    cgroup_path = _own_cgroup_path()
+    if not cgroup_path or not os.path.isdir(cgroup_path):
+        return None
 
-            for pid in pids:
-                try:
-                    with open(f"/proc/{pid}/statm", 'r', encoding="utf-8") as sm:
-                        data = sm.read().split()
-                        if not data:
-                            continue
-                        # RSS in pages * PAGE_SIZE bytes
-                        rss_bytes = int(data[1]) * os.sysconf('SC_PAGE_SIZE')
+    return cgroup_path
 
-                    if rss_bytes > max_rss:
-                        max_rss = rss_bytes
-                        with open(f"/proc/{pid}/cmdline", 'r', encoding="utf-8") as cmd:
-                            max_cmdline = cmd.read().replace('\0', ' ').strip()
-                        if not max_cmdline:
-                            max_cmdline = f"{pid}"
 
-                except (FileNotFoundError, ProcessLookupError, IndexError):
-                    continue
-        except OSError as e:
-            getLog().error("SYSMON: Error: %s", e)
+def _inject_nspawn_slice(config, slice_name):
+    # without a dedicated slice, the actual build (running inside
+    # the nspawn container) would be invisible to us - monitoring
+    # only mock's own cgroup would be misleading, not useful.
+    # This is where the building happens.
+    if '--slice' not in util.systemd_nspawn_help_output():
+        return False
 
-        return (max_rss, max_cmdline)
+    nspawn_args = config.get('nspawn_args', [])
+    slice_arg = f'--slice={slice_name}'
+    if slice_arg not in nspawn_args:
+        nspawn_args.append(slice_arg)
+        config['nspawn_args'] = nspawn_args
 
-    @backoff.on_predicate(backoff.constant, jitter=None, interval=2, max_time=120)
-    def get_machine_id(self, buildroot):
-        """ Retry getting machine id until nspawn starts """
-        return get_machinectl_uuid(buildroot.make_chroot_path())
+    return True
 
-    def sysmon_thread(self, buildroot, interval):
-        """ Main monitoring thread """
-        current_memory_peak = 0
-        current_swap_peak = 0
 
-        machine_id = self.get_machine_id(buildroot)
-        if machine_id is None:
-            getLog().error("SYSMON: Failed to get nspawn container machine_id")
-            return
+def _parse_sample_line(line):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        getLog().debug("SYSMON: could not parse collector output line: %r", line)
+        return None
 
-        getLog().debug("SYSMON: Collecting data from machine_id: %s", machine_id)
 
-        # The unit name depends on systemd version
-        ustr = _safe_check_output(["/bin/machinectl", "show", "--property=Unit", f"{machine_id}"])
-        if isinstance(ustr, bytes):
-            ustr = ustr.decode("utf-8")
-        machine_id_unit = ustr.rstrip().split('=')[1]
-        scope_dir = f"/sys/fs/cgroup/machine.slice/{machine_id_unit}"
-        memory_peak_file = os.path.join(scope_dir, "memory.peak")
-        swap_peak_file = os.path.join(scope_dir, "memory.swap.peak")
-
-        while not self.sysmon_stop_event.is_set():
-            max_status = "Current"
-            pid_status = "Current"
-            swap_status = "Current"
-
-            try:
-                if os.path.exists(memory_peak_file):
-                    with open(memory_peak_file, 'r', encoding="utf-8") as f:
-                        current_memory_peak = int(f.read().strip())
-
-                if current_memory_peak > self.max_memory_peak:
-                    max_status = "NEW"
-                    self.max_memory_peak = current_memory_peak
-
-                if os.path.exists(swap_peak_file):
-                    with open(swap_peak_file, 'r', encoding="utf-8") as f:
-                        current_swap_peak = int(f.read().strip())
-
-                if current_swap_peak > self.max_swap_peak:
-                    swap_status = "NEW"
-                    self.max_swap_peak = current_swap_peak
-
-                top = self.get_top_process_info(f"{scope_dir}/payload")
-                if top[0] > self.top_rss[0]:
-                    pid_status = "NEW"
-                    self.top_rss = top
-
-                if f"{max_status}{swap_status}{pid_status}" != "CurrentCurrentCurrent":
-                    getLog().debug("SYSMON: "
-                        "%s MEMORY PEAK %.2f MiB | "
-                        "%s SWAP PEAK %.2f MiB | "
-                        "%s Top Process: RSS:%.2f MiB [%s]",
-                        max_status, self.max_memory_peak / 1048576,
-                        swap_status, self.max_swap_peak / 1048576,
-                        pid_status, self.top_rss[0] / 1048576, self.top_rss[1]
-                    )
-            except (IOError, ValueError):
-                getLog().debug("SYSMON: memory.peak missing %s", scope_dir)
-
-            if self.sysmon_stop_event.wait(timeout=interval):
-                break
-
-    def _on_postdeps(self):
-        # Inject nspawn args
-        nspawn_args = self.config.get('nspawn_args', [])
-        prop = '--property=MemoryAccounting=on'
-        if prop not in nspawn_args:
-            nspawn_args.append(prop)
-            self.config['nspawn_args'] = nspawn_args
-
-        # Start thread
-        interval = self.system_monitor_opts.get('interval', 2)
-        self.sysmon_stop_event.clear()
-        self.sysmon_timer_thread = threading.Thread(target=self.sysmon_thread,
-                                                    args=(self.buildroot, interval),
-                                                    daemon=True)
-        self.sysmon_timer_thread.start()
-
-        getLog().debug("SYSMON: Monitoring thread started via callback.")
-
-    def _on_postbuild(self):
-        self.sysmon_stop_event.set()
-        self.sysmon_timer_thread.join()
-        getLog().info("SYSMON: "
-            "Total Memory Peak %.2f MiB | Total Swap Peak %.2f MiB | "
-            "Top process: RSS:%.2f MiB [%s]",
-            self.max_memory_peak / 1048576, self.max_swap_peak / 1048576,
-            self.top_rss[0] / 1048576, self.top_rss[1]
-        )
-        out_file = os.path.join(self.buildroot.resultdir, 'system_monior.json')
-        with open(out_file, 'w', encoding="utf-8") as f:
-            json.dump({"total_max_memory" : self.max_memory_peak,
-                       "total_max_swap" : self.max_swap_peak,
-                       "top_process_memory" : self.top_rss[0],
-                       "top_process_cmdline" : self.top_rss[1]},
-                       f)
+class SystemMonitor:  # pylint: disable=too-few-public-methods
+    """ Main plugin class. """
 
     def __init__(self, plugins, conf, buildroot):
-        self.max_memory_peak = 0
-        self.max_swap_peak = 0
-        self.top_rss = (0, "")
-        self.sysmon_timer_thread = None
-        self.sysmon_stop_event = threading.Event()
         self.buildroot = buildroot
-        self.system_monitor_opts = conf
-        self.config = buildroot.config
+        self.opts = conf
+        self.interval = self.opts.get('interval', 5)
+        self._proc = None
+        self._thread = None
+        self._samples_path = None
+        self._current_phase = "startup"
 
-        if not USE_NSPAWN:
-            getLog().warning("SYSMON: build is not using nspawn. Statistics will not be available")
+        cgroup_path = _setup_cgroup()
+        if not cgroup_path:
+            getLog().warning("SYSMON: could not determine own cgroup, "
+                              "resource monitoring disabled")
             return
 
-        getLog().info("SYSMON: Starting system monitor")
-        plugins.add_hook("postdeps", self._on_postdeps)
-        plugins.add_hook("postbuild", self._on_postbuild)
+        slice_name = f"mocksysmon{os.getpid()}.slice"
+        if not _inject_nspawn_slice(buildroot.config, slice_name):
+            getLog().warning("SYSMON: systemd-nspawn does not support --slice, "
+                              "resource monitoring disabled")
+            return
+
+        if not self._prepare_samples_file(buildroot.resultdir):
+            return
+
+        cgroup_dirs = [cgroup_path, os.path.join("/sys/fs/cgroup", slice_name)]
+        self._start_collector(cgroup_dirs, self.interval)
+
+        # needed for phase tagging in samples
+        plugins.add_hook("preinit", lambda: self._set_phase("chroot_init"))
+        plugins.add_hook("earlyprebuild", lambda: self._set_phase("resolving_deps"))
+        plugins.add_hook("postdeps", lambda: self._set_phase("build"))
+        # only produces check phase when `separate_check` is enabled
+        # otherwise %check run inside the run_build() so we get
+        # everything under build phase
+        plugins.add_hook("precheck", lambda: self._set_phase("check"))
+
+        plugins.add_hook("postbuild", self._finalize)
+        plugins.add_hook("initfailed", self._finalize)
+
+        getLog().info("SYSMON: monitoring cgroups ready at %s", cgroup_dirs)
+
+    def _prepare_samples_file(self, resultdir):
+        try:
+            self._samples_path = os.path.join(resultdir, "system_monitor_samples.jsonl")
+            # start each build with a fresh, empty file - later samples are
+            # appended to it one by one as they arrive
+            with open(self._samples_path, 'w', encoding="utf-8"):
+                pass
+
+            return True
+        except OSError:
+            getLog().warning("SYSMON: failed to create results file", exc_info=True)
+            return False
+
+    def _start_collector(self, cgroup_dirs, interval):
+        cmd = list(_COLLECTOR_ARGV) + ["--interval", str(interval)]
+        for cgroup_dir in cgroup_dirs:
+            cmd += ["--cgroup", cgroup_dir]
+
+        self._proc = subprocess.Popen(  # pylint: disable=consider-using-with
+            cmd, stdout=subprocess.PIPE, universal_newlines=True)
+        self._thread = threading.Thread(target=self._read_samples, daemon=True)
+        self._thread.start()
+
+    def _read_samples(self):
+        # runs in the background reader thread; ends naturally once the
+        # collector process exits and its stdout hits EOF
+        for line in self._proc.stdout:
+            sample = _parse_sample_line(line)
+            if sample is None:
+                continue
+
+            sample["phase"] = self._current_phase
+            try:
+                with open(self._samples_path, 'a', encoding="utf-8") as f:
+                    f.write(json.dumps(sample) + "\n")
+            except OSError:
+                getLog().warning("SYSMON: failed to write sample", exc_info=True)
+
+    def _set_phase(self, name):
+        getLog().debug("SYSMON: switching to phase '%s'", name)
+        self._current_phase = name
+
+    def _finalize(self):
+        if self._proc is None:
+            return
+
+        proc = self._proc
+        self._proc = None
+        proc.terminate()
+        self._thread.join(timeout=5)
+        proc.wait()

--- a/mock/tests/plugins/test_system_monitor.py
+++ b/mock/tests/plugins/test_system_monitor.py
@@ -1,0 +1,96 @@
+"""Test the system_monitor plugin."""
+
+import json
+import os
+import sys
+import time
+from unittest import mock
+
+from mockbuild.plugins import system_monitor as sysmon
+
+GiB = 1024 ** 3
+
+COLLECTOR_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "..", "..", "py", "mock-system-monitor-collector.py")
+
+
+def _write(directory, filename, content):
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path
+
+
+def _populate_cgroup(cgroup_dir):
+    _write(cgroup_dir, "memory.current", str(1 * GiB))
+    _write(cgroup_dir, "memory.swap.current", "0")
+    _write(cgroup_dir, "cpu.stat", "usage_usec 1000000\nuser_usec 900000\nsystem_usec 100000\n")
+    _write(cgroup_dir, "pids.current", "5")
+
+
+def _make_buildroot(tmp_path):
+    buildroot = mock.Mock()
+    buildroot.resultdir = str(tmp_path)
+    buildroot.config = {"nspawn_args": []}
+    return buildroot
+
+
+def _wait_for_phase_sample(samples_path, phase, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if samples_path.exists():
+            with open(samples_path, encoding="utf-8") as f:
+                if any(json.loads(line)["phase"] == phase for line in f if line.strip()):
+                    return
+        time.sleep(0.01)
+    raise AssertionError(f"no sample collected for phase {phase!r} within {timeout}s")
+
+
+def test_plugin_enabled_writes_results(tmp_path):
+    """ Test that the plugin writes results when enabled. """
+    cgroup_dir = tmp_path / "cg"
+    cgroup_dir.mkdir()
+    _populate_cgroup(str(cgroup_dir))
+
+    plugins = mock.Mock()
+    buildroot = _make_buildroot(tmp_path)
+
+    with mock.patch.object(sysmon, "_setup_cgroup", return_value=str(cgroup_dir)), \
+            mock.patch.object(sysmon.util, "systemd_nspawn_help_output", return_value="--slice"), \
+            mock.patch.object(sysmon, "_COLLECTOR_ARGV", [sys.executable, COLLECTOR_SCRIPT]):
+        sysmon.SystemMonitor(plugins, {"interval": 0.01}, buildroot)
+
+    # a dedicated --slice=... is injected so containers from other,
+    # concurrent nspawn/mock instances on the same host aren't summed in
+    assert any(arg.startswith("--slice=") for arg in buildroot.config["nspawn_args"])
+
+    hooks = dict((call[0][0], call[0][1]) for call in plugins.add_hook.call_args_list)
+    assert set(hooks) == {
+        "preinit", "earlyprebuild", "postdeps", "precheck", "postbuild", "initfailed",
+    }
+
+    samples_path = tmp_path / "system_monitor_samples.jsonl"
+
+    hooks["preinit"]()
+    hooks["earlyprebuild"]()
+    hooks["postdeps"]()
+    # wait for at least one real sample in each phase instead of a fixed
+    # sleep, so this isn't flaky under a loaded/throttled CPU. Each sample
+    # is streamed straight to samples.jsonl as it is collected, so we can
+    # poll the file directly even before the build finishes.
+    _wait_for_phase_sample(samples_path, "build")
+    hooks["precheck"]()
+    _wait_for_phase_sample(samples_path, "check")
+    hooks["postbuild"]()
+    # finalize must be idempotent - initfailed firing afterwards must not raise
+    hooks["initfailed"]()
+
+    assert samples_path.exists()
+
+    with open(samples_path, encoding="utf-8") as f:
+        samples = [json.loads(line) for line in f]
+
+    assert samples
+    phases = {s["phase"] for s in samples}
+    assert {"build", "check"} <= phases
+    assert all(s["rss_bytes"] == 1 * GiB for s in samples)

--- a/mock/tests/test_system_monitor_collector.py
+++ b/mock/tests/test_system_monitor_collector.py
@@ -1,0 +1,88 @@
+"""Test the standalone mock-system-monitor-collector script."""
+
+# _write()/_populate_cgroup() below are intentionally duplicated from
+# tests/plugins/test_system_monitor.py, not worth sharing via
+# conftest.py.
+# pylint: disable=duplicate-code
+
+import importlib.util
+import os
+
+_SPEC = importlib.util.spec_from_file_location(
+    "mock_system_monitor_collector",
+    os.path.join(os.path.dirname(__file__), "..", "py", "mock-system-monitor-collector.py"),
+)
+collector = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(collector)
+
+GiB = 1024 ** 3
+
+
+def _write(directory, filename, content):
+    path = os.path.join(directory, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return path
+
+
+def _populate_cgroup(cgroup_dir):
+    _write(cgroup_dir, "memory.current", str(1 * GiB))
+    _write(cgroup_dir, "memory.swap.current", "0")
+    _write(cgroup_dir, "cpu.stat", "usage_usec 1000000\nuser_usec 900000\nsystem_usec 100000\n")
+    _write(cgroup_dir, "pids.current", "5")
+
+
+def test_multi_delta_since_last_read(tmp_path):
+    """ Test that cpu.stat deltas are computed since the last read, not absolute values. """
+    # pylint: disable=protected-access
+    cgroup_dir = tmp_path / "cg"
+    cgroup_dir.mkdir()
+    _write(str(cgroup_dir), "cpu.stat", "usage_usec 1000000\nuser_usec 900000\nsystem_usec 100000\n")
+
+    state = {}
+    fields = ["usage_usec", "user_usec", "system_usec"]
+    # the first read has no prior value to diff against, so it seeds `state`
+    # and reports a zero delta
+    first = collector._multi_delta_over_dirs(
+        [str(cgroup_dir)], "cpu.stat", collector._read_stat_fields, state, fields)
+    assert first == {"usage_usec": 0, "user_usec": 0, "system_usec": 0}
+
+    _write(str(cgroup_dir), "cpu.stat", "usage_usec 1500000\nuser_usec 1350000\nsystem_usec 150000\n")
+    second = collector._multi_delta_over_dirs(
+        [str(cgroup_dir)], "cpu.stat", collector._read_stat_fields, state, fields)
+    assert second == {"usage_usec": 500000, "user_usec": 450000, "system_usec": 50000}
+
+
+def test_active_dirs_filters_missing_extra_dirs(tmp_path):
+    """ Test that only the first dir is kept unconditionally; extras only while they exist. """
+    cgroup_dir = tmp_path / "cg"
+    cgroup_dir.mkdir()
+    slice_dir = tmp_path / "slice"
+
+    assert collector._active_dirs([str(cgroup_dir), str(slice_dir)]) == [str(cgroup_dir)]  # pylint: disable=protected-access
+
+    slice_dir.mkdir()
+    assert collector._active_dirs([str(cgroup_dir), str(slice_dir)]) == [  # pylint: disable=protected-access
+        str(cgroup_dir), str(slice_dir)]
+
+
+def test_take_sample_schema(tmp_path):
+    """ Test that _take_sample() wires the helpers together into the expected sample shape. """
+    cgroup_dir = tmp_path / "cg"
+    cgroup_dir.mkdir()
+    _populate_cgroup(str(cgroup_dir))
+
+    state = {}
+    # first tick has no prior state to diff cpu.stat against, so its delta is 0
+    collector._take_sample([str(cgroup_dir)], state)  # pylint: disable=protected-access
+
+    _write(str(cgroup_dir), "cpu.stat", "usage_usec 1500000\nuser_usec 1350000\nsystem_usec 150000\n")
+    sample = collector._take_sample([str(cgroup_dir)], state)  # pylint: disable=protected-access
+
+    assert sample["rss_bytes"] == 1 * GiB
+    assert sample["swap_bytes"] == 0
+    assert sample["cpu_usage_delta_usec"] == 500000
+    assert sample["cpu_user_delta_usec"] == 450000
+    assert sample["cpu_system_delta_usec"] == 50000
+    assert sample["pids"] == 5
+    assert "t" in sample

--- a/releng/release-notes-next/system-monitor-phase-metrics.feature.md
+++ b/releng/release-notes-next/system-monitor-phase-metrics.feature.md
@@ -1,0 +1,4 @@
+The `system_monitor` plugin now samples resource usage for the whole build
+instead of only reporting a single peak snapshot, and tags every sample
+with the active build phase. Extended statistics: CPU, memory. Logged into
+`<resultdir>/system_monitor_samples.jsonl`.


### PR DESCRIPTION
Old implementation looked up a single nspawn scope, collecting mainly
rpmbuild -bb part. Now it injects a dedicated --slice for the nspawn
container (plus IO accounting anchor to monitor IO), and samples the
whole build (including bootstrap, chroot init, dep resoluition, build
and check).

Also the sampler was extended to collect a lot more data.

Relates #1243