### PR TITLE
Alma Kitten + EPEL 10s adjustments

### DIFF
--- a/mock-core-configs/etc/mock/alma-kitten+epel-10-aarch64.cfg
+++ b/mock-core-configs/etc/mock/alma-kitten+epel-10-aarch64.cfg
@@ -1,6 +1,6 @@
 config_opts["koji_primary_repo"] = "epel"
 include('templates/almalinux-kitten-10.tpl')
-include('templates/epel-10.tpl')
+include('templates/epel-10s.tpl')
 
 config_opts['root'] = 'alma-kitten+epel-10-aarch64'
 config_opts['description'] = 'AlmaLinux Kitten 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma-kitten+epel-10-ppc64le.cfg
+++ b/mock-core-configs/etc/mock/alma-kitten+epel-10-ppc64le.cfg
@@ -1,6 +1,6 @@
 config_opts["koji_primary_repo"] = "epel"
 include('templates/almalinux-kitten-10.tpl')
-include('templates/epel-10.tpl')
+include('templates/epel-10s.tpl')
 
 config_opts['root'] = 'alma-kitten+epel-10-ppc64le'
 config_opts['description'] = 'AlmaLinux Kitten 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma-kitten+epel-10-s390x.cfg
+++ b/mock-core-configs/etc/mock/alma-kitten+epel-10-s390x.cfg
@@ -1,6 +1,6 @@
 config_opts["koji_primary_repo"] = "epel"
 include('templates/almalinux-kitten-10.tpl')
-include('templates/epel-10.tpl')
+include('templates/epel-10s.tpl')
 
 config_opts['root'] = 'alma-kitten+epel-10-s390x'
 config_opts['description'] = 'AlmaLinux Kitten 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma-kitten+epel-10-x86_64.cfg
+++ b/mock-core-configs/etc/mock/alma-kitten+epel-10-x86_64.cfg
@@ -1,6 +1,6 @@
 config_opts["koji_primary_repo"] = "epel"
 include('templates/almalinux-kitten-10.tpl')
-include('templates/epel-10.tpl')
+include('templates/epel-10s.tpl')
 
 config_opts['root'] = 'alma-kitten+epel-10-x86_64'
 config_opts['description'] = 'AlmaLinux Kitten 10 + EPEL'

--- a/mock-core-configs/etc/mock/alma-kitten+epel-10-x86_64_v2.cfg
+++ b/mock-core-configs/etc/mock/alma-kitten+epel-10-x86_64_v2.cfg
@@ -1,5 +1,5 @@
 include('almalinux-kitten-10-x86_64_v2.cfg')
-include('templates/almalinux-epel-10.tpl')
+include('templates/almalinux-epel-10s.tpl')
 
 config_opts['root'] = "alma-kitten+epel-10-{{ target_arch }}"
 config_opts['description'] = 'AlmaLinux Kitten 10 + EPEL'

--- a/mock-core-configs/etc/mock/templates/almalinux-epel-10s.tpl
+++ b/mock-core-configs/etc/mock/templates/almalinux-epel-10s.tpl
@@ -1,0 +1,12 @@
+config_opts['chroot_setup_cmd'] += " epel-rpm-macros"
+
+config_opts['dnf.conf'] += """
+
+[epel]
+name=Extra Packages for Enterprise Linux $releasever from AlmaLinux - x86_64_v2
+# mirrorlist=https://epel.mirrors.almalinux.org/mirrorlist/{{ releasever_major }}s/epel?arch=x86_64_v2
+baseurl=https://epel.repo.almalinux.org/{{ releasever_major }}s/x86_64_v2/
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-$releasever-EPEL-AltArch
+gpgcheck=1
+countme=1
+"""

--- a/releng/release-notes-next/alma-epel-10s-template.config
+++ b/releng/release-notes-next/alma-epel-10s-template.config
@@ -1,0 +1,5 @@
+The AlmaLinux Kitten + EPEL 10 configs have been updated to use a new 10s
+pattern.  This is related to a minor reconfiguration of EPEL 10 minor version
+repo redirects.  See [this discussion
+thread](https://discussion.fedoraproject.org/t/looking-back-at-epel-10-and-forward-to-epel-11/197373)
+for more details.


### PR DESCRIPTION
Alma chroots also need to be adjusted similar to #1811.  For standard architectures this only needs a switch from the epel-10 template to the epel-10s template, but on x86_64_v2 we also need to create an equivalent almalinux-epel-10s template.